### PR TITLE
fix: create missing /vendor/sellers endpoint to handle vendor_type field

### DIFF
--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -1,0 +1,78 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
+import { createSellerMetadataWorkflow } from "../../../workflows/create-seller-metadata"
+import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
+
+/**
+ * POST /vendor/sellers
+ *
+ * Create a new seller during vendor registration.
+ * This endpoint is called after the auth registration to create the seller entity
+ * and associated metadata including vendor_type.
+ */
+export const POST = async (
+  req: MedusaRequest,
+  res: MedusaResponse
+) => {
+  const body = req.body as {
+    name: string
+    member: {
+      name: string
+      email: string
+    }
+    vendor_type?: VendorType
+    website_url?: string
+    social_links?: {
+      instagram?: string
+      facebook?: string
+      twitter?: string
+      tiktok?: string
+      youtube?: string
+      linkedin?: string
+      pinterest?: string
+    }
+  }
+
+  try {
+    // Create the seller using MercurJS workflow
+    const { result: seller } = await createSellerWorkflow.run({
+      container: req.scope,
+      input: {
+        member: {
+          name: body.member.name,
+          email: body.member.email,
+        },
+        seller: {
+          name: body.name,
+        },
+      },
+    })
+
+    // Create seller metadata with vendor_type and other extended fields
+    await createSellerMetadataWorkflow.run({
+      container: req.scope,
+      input: {
+        seller_id: seller.id,
+        vendor_type: body.vendor_type || VendorType.PRODUCER,
+        website_url: body.website_url || null,
+        social_links: body.social_links || null,
+      } as any,
+    })
+
+    return res.status(201).json({
+      seller: {
+        id: seller.id,
+        name: seller.name,
+        member: seller.member,
+      },
+    })
+  } catch (error: any) {
+    console.error("Failed to create seller:", error)
+
+    // Return proper error response
+    return res.status(400).json({
+      type: "invalid_data",
+      message: error.message || "Failed to create seller",
+    })
+  }
+}

--- a/backend/src/workflows/create-seller-metadata.ts
+++ b/backend/src/workflows/create-seller-metadata.ts
@@ -13,6 +13,9 @@ type CreateSellerMetadataInput = {
   vendor_type?: VendorType
   business_registration_number?: string
   tax_classification?: string
+  website_url?: string | null
+  social_links?: Record<string, any> | null
+  storefront_links?: Record<string, any> | null
   farm_practices?: Record<string, any>
   certifications?: Record<string, any>[]
   growing_region?: string
@@ -40,6 +43,9 @@ const createSellerMetadataStep = createStep(
       vendor_type: input.vendor_type || VendorType.PRODUCER,
       business_registration_number: input.business_registration_number || null,
       tax_classification: input.tax_classification || null,
+      website_url: input.website_url || null,
+      social_links: input.social_links || null,
+      storefront_links: input.storefront_links || null,
       farm_practices: input.farm_practices || null,
       certifications: input.certifications || null,
       growing_region: input.growing_region || null,


### PR DESCRIPTION
- Add POST /vendor/sellers route to handle seller registration
- Route creates seller via createSellerWorkflow and seller_metadata with vendor_type
- Update createSellerMetadataWorkflow to accept website_url and social_links
- Fixes "Unrecognized fields: 'vendor_type'" error during vendor registration

The issue was that the frontend was POSTing to /vendor/sellers with vendor_type, but this endpoint didn't exist. The endpoint now properly creates the seller and associated metadata including vendor_type, website_url, and social_links.