### PR TITLE
fix: exclude vendor_type from auth.register to prevent validation error

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -41,10 +41,14 @@ export const useSignUpWithEmailPass = (
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.auth.register("seller", "emailpass", {
-      ...payload,
-      email: payload.email.toLowerCase().trim(),
-    }),
+    mutationFn: (payload) => {
+      // Only pass fields that the auth.register endpoint accepts
+      const { vendor_type, website_url, social_links, ...authPayload } = payload
+      return sdk.auth.register("seller", "emailpass", {
+        ...authPayload,
+        email: payload.email.toLowerCase().trim(),
+      })
+    },
     onSuccess: async (_, variables) => {
       const normalizedEmail = variables.email.toLowerCase().trim()
       const seller = {


### PR DESCRIPTION
The auth.register endpoint was rejecting vendor_type, website_url, and social_links fields with "Unrecognized fields" error. These custom fields are now properly filtered out and only sent to the /vendor/sellers endpoint in the onSuccess callback where they belong.