### PR TITLE
fix: add explicit validation schema for vendor_type in seller registr…

### DIFF
--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -2,6 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
 import { createSellerMetadataWorkflow } from "../../../workflows/create-seller-metadata"
 import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
+import { createSellerSchema, CreateSellerInput } from "./validators"
 
 /**
  * POST /vendor/sellers
@@ -14,23 +15,16 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
-  const body = req.body as {
-    name: string
-    member: {
-      name: string
-      email: string
-    }
-    vendor_type?: VendorType
-    website_url?: string
-    social_links?: {
-      instagram?: string
-      facebook?: string
-      twitter?: string
-      tiktok?: string
-      youtube?: string
-      linkedin?: string
-      pinterest?: string
-    }
+  // Validate request body with explicit schema
+  let body: CreateSellerInput
+  try {
+    body = createSellerSchema.parse(req.body)
+  } catch (error: any) {
+    return res.status(400).json({
+      type: "invalid_data",
+      message: error.errors?.[0]?.message || "Invalid request data",
+      errors: error.errors,
+    })
   }
 
   try {

--- a/backend/src/api/vendor/sellers/validators.ts
+++ b/backend/src/api/vendor/sellers/validators.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
+
+/**
+ * Social Links Schema
+ */
+const socialLinksSchema = z.object({
+  instagram: z.string().url().optional(),
+  facebook: z.string().url().optional(),
+  twitter: z.string().url().optional(),
+  tiktok: z.string().url().optional(),
+  youtube: z.string().url().optional(),
+  linkedin: z.string().url().optional(),
+  pinterest: z.string().url().optional(),
+}).optional()
+
+/**
+ * Create Seller Request Schema
+ *
+ * Validates the request body for POST /vendor/sellers
+ * Accepts all fields needed for seller creation + metadata
+ */
+export const createSellerSchema = z.object({
+  // Core seller fields
+  name: z.string().min(1, "Seller name is required"),
+
+  // Member information
+  member: z.object({
+    name: z.string().min(1, "Member name is required"),
+    email: z.string().email("Valid email is required"),
+  }),
+
+  // Extended metadata fields
+  vendor_type: z.nativeEnum(VendorType).optional(),
+  website_url: z.string().url().optional().nullable(),
+  social_links: socialLinksSchema,
+})
+
+export type CreateSellerInput = z.infer<typeof createSellerSchema>


### PR DESCRIPTION
…ation

The /vendor/sellers endpoint was rejecting the vendor_type field with "Unrecognized fields" error due to automatic validation from the workflow.

Added explicit Zod validation schema (validators.ts) that accepts:
- vendor_type (VendorType enum)
- website_url (optional)
- social_links (optional)

This overrides any automatic validation and ensures the endpoint properly accepts all extended metadata fields during seller registration.