### PR TITLE
fix: add validateAndTransformBody middleware for vendor_type field

### DIFF
--- a/backend/src/api/vendor/sellers/middlewares.ts
+++ b/backend/src/api/vendor/sellers/middlewares.ts
@@ -1,0 +1,20 @@
+import { defineMiddlewares, validateAndTransformBody } from "@medusajs/framework/http"
+import { createSellerSchema } from "./validators"
+
+/**
+ * Middleware for /vendor/sellers endpoint
+ *
+ * Explicitly validates the request body to accept vendor_type and other
+ * extended fields that are not part of the core createSellerWorkflow schema.
+ */
+export default defineMiddlewares({
+  routes: [
+    {
+      matcher: "/vendor/sellers",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(createSellerSchema),
+      ],
+    },
+  ],
+})

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -12,20 +12,11 @@ import { createSellerSchema, CreateSellerInput } from "./validators"
  * and associated metadata including vendor_type.
  */
 export const POST = async (
-  req: MedusaRequest,
+  req: MedusaRequest<CreateSellerInput>,
   res: MedusaResponse
 ) => {
-  // Validate request body with explicit schema
-  let body: CreateSellerInput
-  try {
-    body = createSellerSchema.parse(req.body)
-  } catch (error: any) {
-    return res.status(400).json({
-      type: "invalid_data",
-      message: error.errors?.[0]?.message || "Invalid request data",
-      errors: error.errors,
-    })
-  }
+  // Body is already validated and transformed by middleware
+  const body = req.body as CreateSellerInput
 
   try {
     // Create the seller using MercurJS workflow


### PR DESCRIPTION
The vendor_type field was still being rejected because Medusa V2 was applying automatic validation at the framework level before the route handler could process it.

Solution:
- Created middlewares.ts with validateAndTransformBody using our custom schema
- This explicitly tells Medusa to validate against createSellerSchema
- Updated route handler to use the pre-validated body from middleware
- Removes duplicate validation logic from the route handler

This ensures the validation happens at the correct layer and accepts all extended fields (vendor_type, website_url, social_links).