### PR TITLE
fix: export POST_VALIDATION_SCHEMA from route to override auto-valida…

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -1,10 +1,9 @@
-import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
+import { defineMiddlewares, authenticate } from "@medusajs/framework/http"
 import type {
   MedusaRequest,
   MedusaResponse,
   MedusaNextFunction,
 } from "@medusajs/framework/http"
-import { createSellerSchema } from "./vendor/sellers/validators"
 
 // Basic email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -120,14 +119,10 @@ export default defineMiddlewares({
       matcher: "/store/customers",
       middlewares: [authRateLimiter, normalizeEmailMiddleware],
     },
-    // Vendor seller routes - with validation for vendor_type
+    // Vendor seller routes - validation handled by route-level POST_VALIDATION_SCHEMA export
     {
       matcher: "/vendor/sellers",
-      method: "POST",
-      middlewares: [
-        validateAndTransformBody(createSellerSchema),
-        normalizeEmailMiddleware,
-      ],
+      middlewares: [normalizeEmailMiddleware],
     },
     // Admin user routes
     {

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -5,6 +5,12 @@ import { VendorType } from "../../../modules/seller-extension/models/seller-meta
 import { createSellerSchema, CreateSellerInput } from "./validators"
 
 /**
+ * Export validation schema for Medusa to use
+ * This tells Medusa's automatic validation to use our custom schema
+ */
+export const POST_VALIDATION_SCHEMA = createSellerSchema
+
+/**
  * POST /vendor/sellers
  *
  * Create a new seller during vendor registration.


### PR DESCRIPTION
…tion

Medusa V2's automatic validation was still rejecting vendor_type because it wasn't finding our custom schema. The framework looks for exported validation schemas in route files.

Changes:
- Export POST_VALIDATION_SCHEMA from route.ts (Medusa V2 convention)
- Remove middleware-based validation approach (was being ignored)
- Keep normalizeEmailMiddleware in global middleware
- Let Medusa's framework use our exported schema for automatic validation

This tells Medusa to validate POST requests against createSellerSchema which includes vendor_type and other extended fields.