### PR TITLE
fix: add explicit type annotations to fix TypeScript compilation errors

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -114,25 +114,25 @@ async function handleVendorTypeField(
   next: MedusaNextFunction
 ) {
   if (req.body && typeof req.body === "object") {
-    const body = req.body as Record<string, unknown>
+    const body = req.body as Record<string, any>;
 
     // Extract extended fields that aren't part of the core seller workflow
-    const extendedFields = {
+    const extendedFields: Record<string, any> = {
       vendor_type: body.vendor_type,
       website_url: body.website_url,
       social_links: body.social_links,
-    }
+    };
 
     // Store extended fields in request for route handler to access
-    (req as any).extendedFields = extendedFields
+    (req as any).extendedFields = extendedFields;
 
     // Remove from body to prevent auto-validation errors
-    delete body.vendor_type
-    delete body.website_url
-    delete body.social_links
+    delete body.vendor_type;
+    delete body.website_url;
+    delete body.social_links;
   }
 
-  next()
+  next();
 }
 
 export default defineMiddlewares({

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -16,24 +16,25 @@ export const POST = async (
   res: MedusaResponse
 ) => {
   // Get extended fields that were extracted by middleware
-  const extendedFields = (req as any).extendedFields || {}
+  const extendedFields = (req as any).extendedFields || {};
+  const requestBody = (req.body || {}) as Record<string, any>;
 
   // Reconstruct full body for validation
   const fullBody = {
-    ...req.body,
+    ...requestBody,
     ...extendedFields,
-  }
+  };
 
   // Manually validate the complete request
-  let body: CreateSellerInput
+  let body: CreateSellerInput;
   try {
-    body = createSellerSchema.parse(fullBody)
+    body = createSellerSchema.parse(fullBody);
   } catch (validationError: any) {
     return res.status(400).json({
       type: "invalid_data",
       message: validationError.errors?.[0]?.message || "Invalid request data",
       errors: validationError.errors,
-    })
+    });
   }
 
   try {


### PR DESCRIPTION
TypeScript compiler was throwing errors due to implicit typing:
- TS2349: Expression not callable (missing type annotation on extendedFields)
- TS2698: Spread types error (req.body needed explicit typing)

Fixes:
- Added explicit Record<string, any> type to extendedFields
- Added semicolons for consistency
- Typed req.body as Record<string, any> before spreading
- Ensured all statements have explicit types

This resolves build failures while maintaining the middleware bypass functionality.