### PR TITLE
fix: add debug logging and reorder middleware to run before validation

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -107,29 +107,46 @@ async function normalizeEmailMiddleware(
  * Extracts vendor_type and other extended fields from the request body
  * before Medusa's automatic validation sees them, then restores them
  * for the route handler to use.
+ *
+ * CRITICAL: This must run BEFORE any body parsing/validation middleware
  */
 async function handleVendorTypeField(
   req: MedusaRequest,
   res: MedusaResponse,
   next: MedusaNextFunction
 ) {
-  if (req.body && typeof req.body === "object") {
-    const body = req.body as Record<string, any>;
+  console.log('[handleVendorTypeField] Middleware called for:', req.method, req.path);
 
-    // Extract extended fields that aren't part of the core seller workflow
-    const extendedFields: Record<string, any> = {
-      vendor_type: body.vendor_type,
-      website_url: body.website_url,
-      social_links: body.social_links,
-    };
+  // Only process for POST requests to /vendor/sellers
+  if (req.method === 'POST' && req.path === '/vendor/sellers') {
+    console.log('[handleVendorTypeField] Processing vendor/sellers POST request');
+    console.log('[handleVendorTypeField] Original body keys:', Object.keys(req.body || {}));
 
-    // Store extended fields in request for route handler to access
-    (req as any).extendedFields = extendedFields;
+    // Access raw body before it's parsed and validated
+    const rawBody = req.body;
 
-    // Remove from body to prevent auto-validation errors
-    delete body.vendor_type;
-    delete body.website_url;
-    delete body.social_links;
+    if (rawBody && typeof rawBody === "object") {
+      const body = rawBody as Record<string, any>;
+
+      // Extract extended fields that aren't part of the core seller workflow
+      const extendedFields: Record<string, any> = {
+        vendor_type: body.vendor_type,
+        website_url: body.website_url,
+        social_links: body.social_links,
+      };
+
+      console.log('[handleVendorTypeField] Extracted fields:', extendedFields);
+
+      // Store extended fields in request for route handler to access
+      (req as any).extendedFields = extendedFields;
+
+      // Remove from body to prevent auto-validation errors
+      delete body.vendor_type;
+      delete body.website_url;
+      delete body.social_links;
+
+      console.log('[handleVendorTypeField] Modified body keys:', Object.keys(body));
+    }
   }
 
   next();
@@ -137,6 +154,13 @@ async function handleVendorTypeField(
 
 export default defineMiddlewares({
   routes: [
+    // CRITICAL: This MUST be first to run before any validation
+    // Handle vendor_type field extraction for /vendor/sellers
+    {
+      matcher: "/vendor/sellers",
+      method: "POST",
+      middlewares: [handleVendorTypeField],
+    },
     // Auth routes - register and login for all actor types (rate limited)
     {
       matcher: "/auth/*",
@@ -153,11 +177,10 @@ export default defineMiddlewares({
       matcher: "/store/customers",
       middlewares: [authRateLimiter, normalizeEmailMiddleware],
     },
-    // Vendor seller routes - extract extended fields before auto-validation
+    // Vendor seller routes - normalize email (vendor_type handled above)
     {
       matcher: "/vendor/sellers",
-      method: "POST",
-      middlewares: [handleVendorTypeField, normalizeEmailMiddleware],
+      middlewares: [normalizeEmailMiddleware],
     },
     // Admin user routes
     {


### PR DESCRIPTION
The validation error persists, suggesting the middleware may not be running before Medusa's automatic validation layer. Added detailed debug logging to confirm execution order and field extraction.

Changes:
- Moved handleVendorTypeField to FIRST position in middleware routes
- Added console.log statements to track middleware execution
- Added path/method checking within middleware for safety
- Removed duplicate middleware registration

If logs don't appear, it confirms validation happens before middleware runs and we'll need a different approach (e.g., Medusa config changes or separate endpoint).