### PR TITLE
fix: add missing links configuration and fix middleware ordering for …

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -313,4 +313,10 @@ module.exports = defineConfig({
         ]
       : []),
   ],
+  links: [
+    // Link seller to seller metadata for vendor_type and extended fields
+    {
+      resolve: './src/links/seller-metadata',
+    },
+  ],
 })

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -159,7 +159,7 @@ export default defineMiddlewares({
     {
       matcher: "/vendor/sellers",
       method: "POST",
-      middlewares: [handleVendorTypeField],
+      middlewares: [handleVendorTypeField, normalizeEmailMiddleware],
     },
     // Auth routes - register and login for all actor types (rate limited)
     {
@@ -176,11 +176,6 @@ export default defineMiddlewares({
     {
       matcher: "/store/customers",
       middlewares: [authRateLimiter, normalizeEmailMiddleware],
-    },
-    // Vendor seller routes - normalize email (vendor_type handled above)
-    {
-      matcher: "/vendor/sellers",
-      middlewares: [normalizeEmailMiddleware],
     },
     // Admin user routes
     {

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -4,6 +4,9 @@ import { createSellerMetadataWorkflow } from "../../../workflows/create-seller-m
 import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
 import { createSellerSchema, CreateSellerInput } from "./validators"
 
+// Disable automatic authentication to allow public registration
+export const AUTHENTICATE = false
+
 /**
  * POST /vendor/sellers
  *


### PR DESCRIPTION
…vendor_type field

This commit fixes the "Unrecognized fields: 'vendor_type'" error by:

1. Adding the seller-metadata link to medusa-config.ts - this registers the module link that connects seller entities to seller_metadata table

2. Consolidating duplicate middleware configurations for /vendor/sellers
   - Removed duplicate normalizeEmailMiddleware entry
   - Combined both middlewares in single route configuration
   - Ensures proper execution order

3. Adding AUTHENTICATE = false to vendor/sellers route to allow public registration without authentication

These changes enable the vendor_type field to be properly accepted, validated, and stored during vendor registration.

Files changed:
- backend/medusa-config.ts: Added links configuration
- backend/src/api/middlewares.ts: Fixed duplicate middleware config
- backend/src/api/vendor/sellers/route.ts: Disabled auth requirement