### PR TITLE
fix: correct linkable property to use snake_case seller_metadata

### DIFF
--- a/backend/src/links/seller-metadata.ts
+++ b/backend/src/links/seller-metadata.ts
@@ -28,7 +28,7 @@ const sellerMetadataLink = SellerModule
         isList: false,
       },
       {
-        linkable: SellerExtensionModule.linkable.sellerMetadata,
+        linkable: SellerExtensionModule.linkable.seller_metadata,
         isList: false,
       }
     )


### PR DESCRIPTION
The model is defined as 'seller_metadata' in snake_case, so the linkable property should also use snake_case, not camelCase.

Changed: SellerExtensionModule.linkable.sellerMetadata
To: SellerExtensionModule.linkable.seller_metadata