### PR TITLE
fix: revert to camelCase sellerMetadata for linkable property

### DIFF
--- a/backend/src/links/seller-metadata.ts
+++ b/backend/src/links/seller-metadata.ts
@@ -28,7 +28,7 @@ const sellerMetadataLink = SellerModule
         isList: false,
       },
       {
-        linkable: SellerExtensionModule.linkable.seller_metadata,
+        linkable: SellerExtensionModule.linkable.sellerMetadata,
         isList: false,
       }
     )


### PR DESCRIPTION
TypeScript error showed that Module() automatically converts snake_case model names to camelCase for the linkable property.

Error: Property 'seller_metadata' does not exist. Did you mean 'sellerMetadata'?