### PR TITLE
fix: add proper validation middleware for vendor_type field

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -1,9 +1,10 @@
-import { defineMiddlewares, authenticate } from "@medusajs/framework/http"
+import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
 import type {
   MedusaRequest,
   MedusaResponse,
   MedusaNextFunction,
 } from "@medusajs/framework/http"
+import { createSellerSchema } from "./vendor/sellers/validators"
 
 // Basic email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -103,11 +104,11 @@ async function normalizeEmailMiddleware(
 
 export default defineMiddlewares({
   routes: [
-    // Vendor seller routes - normalize email
+    // Vendor seller routes - normalize email and validate body
     {
       matcher: "/vendor/sellers",
       method: "POST",
-      middlewares: [normalizeEmailMiddleware],
+      middlewares: [normalizeEmailMiddleware, validateAndTransformBody(createSellerSchema)],
     },
     // Auth routes - register and login for all actor types (rate limited)
     {

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -2,7 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
 import { createSellerMetadataWorkflow } from "../../../workflows/create-seller-metadata"
 import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
-import { createSellerSchema, CreateSellerInput } from "./validators"
+import { CreateSellerInput } from "./validators"
 
 // Disable automatic authentication to allow public registration
 export const AUTHENTICATE = false
@@ -15,21 +15,11 @@ export const AUTHENTICATE = false
  * and associated metadata including vendor_type.
  */
 export const POST = async (
-  req: MedusaRequest,
+  req: MedusaRequest<CreateSellerInput>,
   res: MedusaResponse
 ) => {
-  // Validate request body directly (no middleware extraction needed)
-  let body: CreateSellerInput;
-  try {
-    body = createSellerSchema.parse(req.body);
-  } catch (validationError: any) {
-    console.error("[POST /vendor/sellers] Validation error:", validationError);
-    return res.status(400).json({
-      type: "invalid_data",
-      message: validationError.errors?.[0]?.message || "Invalid request data",
-      errors: validationError.errors,
-    });
-  }
+  // Body is already validated by middleware and available in validatedBody
+  const body = req.validatedBody
 
   console.log("[POST /vendor/sellers] Validated body:", {
     name: body.name,


### PR DESCRIPTION
- Add validateAndTransformBody middleware to /vendor/sellers POST route
- Use createSellerSchema to validate vendor_type, website_url, and social_links
- Update route handler to use req.validatedBody instead of manual validation
- Fix "Invalid request: Unrecognized fields: 'vendor_type'" error

The issue was that Medusa v2 requires request validation to be configured in middlewares.ts using validateAndTransformBody. Without this, the framework was rejecting the vendor_type field before it reached the route handler.