### PR TITLE
fix: remove .passthrough() from vendor seller schema to fix validation

### DIFF
--- a/backend/src/api/vendor/sellers/validators.ts
+++ b/backend/src/api/vendor/sellers/validators.ts
@@ -19,9 +19,6 @@ const socialLinksSchema = z.object({
  *
  * Validates the request body for POST /vendor/sellers
  * Accepts all fields needed for seller creation + metadata
- *
- * Note: Uses .passthrough() to allow extra fields that may be added
- * in the future without breaking the validation.
  */
 export const createSellerSchema = z.object({
   // Core seller fields
@@ -37,6 +34,6 @@ export const createSellerSchema = z.object({
   vendor_type: z.nativeEnum(VendorType).optional(),
   website_url: z.string().url().optional().nullable(),
   social_links: socialLinksSchema,
-}).passthrough()
+})
 
 export type CreateSellerInput = z.infer<typeof createSellerSchema>


### PR DESCRIPTION
The .passthrough() Zod method was causing Medusa's validateAndTransformBody to reject the vendor_type field as "unrecognized", even though it was explicitly defined in the schema.

This fix removes .passthrough() to align with other schemas in the codebase and ensures vendor_type, website_url, and social_links are properly validated.

Fixes: "Invalid request: Unrecognized fields: 'vendor_type'" error