### PR TITLE
fix: bypass validateAndTransformBody middleware and use manual valida…

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -1,10 +1,9 @@
-import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
+import { defineMiddlewares, authenticate } from "@medusajs/framework/http"
 import type {
   MedusaRequest,
   MedusaResponse,
   MedusaNextFunction,
 } from "@medusajs/framework/http"
-import { createSellerSchema } from "./vendor/sellers/validators"
 
 // Basic email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -104,11 +103,11 @@ async function normalizeEmailMiddleware(
 
 export default defineMiddlewares({
   routes: [
-    // Vendor seller routes - normalize email and validate body
+    // Vendor seller routes - normalize email only, validation done in route handler
     {
       matcher: "/vendor/sellers",
       method: "POST",
-      middlewares: [normalizeEmailMiddleware, validateAndTransformBody(createSellerSchema)],
+      middlewares: [normalizeEmailMiddleware],
     },
     // Auth routes - register and login for all actor types (rate limited)
     {

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -15,11 +15,21 @@ export const AUTHENTICATE = false
  * and associated metadata including vendor_type.
  */
 export const POST = async (
-  req: MedusaRequest<CreateSellerInput>,
+  req: MedusaRequest,
   res: MedusaResponse
 ) => {
-  // Body is already validated by middleware and available in validatedBody
-  const body = req.validatedBody
+  // Manually validate request body using Zod schema
+  let body: CreateSellerInput
+  try {
+    body = createSellerSchema.parse(req.body)
+  } catch (validationError: any) {
+    console.error("[POST /vendor/sellers] Validation error:", validationError)
+    return res.status(400).json({
+      type: "invalid_data",
+      message: validationError.errors?.[0]?.message || "Invalid request data",
+      errors: validationError.errors,
+    })
+  }
 
   console.log("[POST /vendor/sellers] Validated body:", {
     name: body.name,

--- a/backend/src/api/vendor/sellers/validators.ts
+++ b/backend/src/api/vendor/sellers/validators.ts
@@ -31,7 +31,7 @@ export const createSellerSchema = z.object({
   }),
 
   // Extended metadata fields
-  vendor_type: z.nativeEnum(VendorType).optional(),
+  vendor_type: z.enum(["producer", "garden", "maker", "restaurant", "mutual_aid"]).optional(),
   website_url: z.string().url().optional().nullable(),
   social_links: socialLinksSchema,
 })


### PR DESCRIPTION
…tion

The validateAndTransformBody middleware was rejecting the vendor_type field even though it was explicitly defined in the schema. This appears to be an incompatibility between Medusa's validateAndTransformBody and z.nativeEnum().

Changes:
- Remove validateAndTransformBody from /vendor/sellers middleware
- Change from z.nativeEnum(VendorType) to z.enum([...]) with explicit values
- Implement manual validation in route handler using createSellerSchema.parse()
- Update route handler to parse req.body instead of using req.validatedBody

This approach bypasses the middleware issue and ensures vendor_type, website_url, and social_links are properly validated.

Fixes: "Invalid request: Unrecognized fields: 'vendor_type'" error