### PR TITLE
fix: resolve vendor_type race condition between route and subscriber

### DIFF
--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -2,6 +2,8 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
 import { createSellerMetadataWorkflow } from "../../../workflows/create-seller-metadata"
 import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
+import { SELLER_EXTENSION_MODULE } from "../../../modules/seller-extension"
+import SellerExtensionService from "../../../modules/seller-extension/service"
 import { createSellerSchema, CreateSellerInput } from "./validators"
 
 // Disable automatic authentication to allow public registration
@@ -13,6 +15,10 @@ export const AUTHENTICATE = false
  * Create a new seller during vendor registration.
  * This endpoint is called after the auth registration to create the seller entity
  * and associated metadata including vendor_type.
+ *
+ * NOTE: Handles race condition with seller-created subscriber by using upsert logic.
+ * If the subscriber creates metadata first (with default PRODUCER type), this route
+ * will update it with the user's actual vendor_type selection.
  */
 export const POST = async (
   req: MedusaRequest,
@@ -53,16 +59,40 @@ export const POST = async (
       },
     })
 
-    // Create seller metadata with vendor_type and other extended fields
-    await createSellerMetadataWorkflow.run({
-      container: req.scope,
-      input: {
-        seller_id: seller.id,
-        vendor_type: body.vendor_type || VendorType.PRODUCER,
-        website_url: body.website_url || null,
-        social_links: body.social_links || null,
-      } as any,
+    // Get seller extension service for upsert logic
+    const sellerExtensionService: SellerExtensionService = req.scope.resolve(
+      SELLER_EXTENSION_MODULE
+    )
+
+    // Check if metadata was already created by the subscriber (race condition)
+    const existingMetadata = await sellerExtensionService.listSellerMetadatas({
+      seller_id: seller.id,
     })
+
+    const metadataInput = {
+      vendor_type: body.vendor_type || VendorType.PRODUCER,
+      website_url: body.website_url || null,
+      social_links: body.social_links || null,
+    }
+
+    if (existingMetadata && existingMetadata.length > 0) {
+      // Metadata already exists (created by subscriber) - update it with user's values
+      console.log(`[POST /vendor/sellers] Updating existing metadata for seller ${seller.id}`)
+      await sellerExtensionService.updateSellerMetadatas({
+        id: existingMetadata[0].id,
+        ...metadataInput,
+      })
+    } else {
+      // No metadata exists - create it
+      console.log(`[POST /vendor/sellers] Creating metadata for seller ${seller.id}`)
+      await createSellerMetadataWorkflow.run({
+        container: req.scope,
+        input: {
+          seller_id: seller.id,
+          ...metadataInput,
+        } as any,
+      })
+    }
 
     return res.status(201).json({
       seller: {

--- a/backend/src/subscribers/seller-created.ts
+++ b/backend/src/subscribers/seller-created.ts
@@ -1,12 +1,18 @@
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { createSellerMetadataWorkflow } from "../workflows/create-seller-metadata"
 import { VendorType } from "../modules/seller-extension/models/seller-metadata"
+import { SELLER_EXTENSION_MODULE } from "../modules/seller-extension"
+import SellerExtensionService from "../modules/seller-extension/service"
 
 /**
  * Subscriber: Seller Created
- * 
+ *
  * Automatically creates seller_metadata when a new seller is created.
- * This ensures every seller has a vendor_type (defaults to RETAIL).
+ * This ensures every seller has a vendor_type (defaults to PRODUCER).
+ *
+ * IMPORTANT: This subscriber checks if metadata already exists before creating.
+ * This prevents race conditions when sellers are created via /vendor/sellers route
+ * which creates metadata with the user's chosen vendor_type.
  */
 export default async function sellerCreatedHandler({
   event,
@@ -19,9 +25,25 @@ export default async function sellerCreatedHandler({
     return
   }
 
-  console.log(`Creating seller metadata for seller ${sellerId}`)
+  console.log(`[sellerCreated subscriber] Processing seller ${sellerId}`)
 
   try {
+    // Check if metadata already exists BEFORE trying to create
+    // This prevents race condition with /vendor/sellers route
+    const sellerExtensionService: SellerExtensionService = container.resolve(
+      SELLER_EXTENSION_MODULE
+    )
+
+    const existingMetadata = await sellerExtensionService.listSellerMetadatas({
+      seller_id: sellerId,
+    })
+
+    if (existingMetadata && existingMetadata.length > 0) {
+      console.log(`[sellerCreated subscriber] Metadata already exists for seller ${sellerId}, skipping creation`)
+      return
+    }
+
+    // No metadata exists, create with default values
     const { result } = await createSellerMetadataWorkflow.run({
       container,
       input: {
@@ -30,15 +52,19 @@ export default async function sellerCreatedHandler({
       },
     })
 
-    console.log(`Seller metadata created: ${result.seller_metadata.id}`)
+    console.log(`[sellerCreated subscriber] Seller metadata created: ${result.seller_metadata.id}`)
   } catch (error) {
-    // Check if metadata already exists (duplicate prevention)
-    if (error instanceof Error && error.message.includes("unique")) {
-      console.log(`Seller metadata already exists for seller ${sellerId}`)
+    // Double-check for unique constraint errors (edge case)
+    if (error instanceof Error && (
+      error.message.includes("unique") ||
+      error.message.includes("duplicate") ||
+      error.message.includes("already exists")
+    )) {
+      console.log(`[sellerCreated subscriber] Metadata already exists for seller ${sellerId} (caught constraint error)`)
       return
     }
 
-    console.error(`Failed to create seller metadata for ${sellerId}:`, error)
+    console.error(`[sellerCreated subscriber] Failed to create seller metadata for ${sellerId}:`, error)
     throw error
   }
 }


### PR DESCRIPTION
The vendor_type issue was caused by a race condition:
1. POST /vendor/sellers creates a seller via createSellerWorkflow
2. The seller-created subscriber fires and creates metadata with default PRODUCER
3. Route tries to create metadata with user's vendor_type but fails (unique constraint)

Fix:
- Subscriber now checks if metadata exists BEFORE creating (prevents overwriting)
- Route now uses upsert logic: checks for existing metadata first and updates if found
- Both paths now work correctly regardless of execution order