### PR TITLE
fix: remove vendor_type from registration flow

### DIFF
--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -1,9 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
-import { createSellerMetadataWorkflow } from "../../../workflows/create-seller-metadata"
-import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
-import { SELLER_EXTENSION_MODULE } from "../../../modules/seller-extension"
-import SellerExtensionService from "../../../modules/seller-extension/service"
 import { createSellerSchema, CreateSellerInput } from "./validators"
 
 // Disable automatic authentication to allow public registration
@@ -13,12 +9,8 @@ export const AUTHENTICATE = false
  * POST /vendor/sellers
  *
  * Create a new seller during vendor registration.
- * This endpoint is called after the auth registration to create the seller entity
- * and associated metadata including vendor_type.
- *
- * NOTE: Handles race condition with seller-created subscriber by using upsert logic.
- * If the subscriber creates metadata first (with default PRODUCER type), this route
- * will update it with the user's actual vendor_type selection.
+ * This endpoint is called after the auth registration to create the seller entity.
+ * Seller metadata (including vendor_type) is created by the seller-created subscriber.
  */
 export const POST = async (
   req: MedusaRequest,
@@ -37,15 +29,11 @@ export const POST = async (
     })
   }
 
-  console.log("[POST /vendor/sellers] Validated body:", {
-    name: body.name,
-    vendor_type: body.vendor_type,
-    hasWebsiteUrl: !!body.website_url,
-    hasSocialLinks: !!body.social_links,
-  });
+  console.log("[POST /vendor/sellers] Creating seller:", body.name)
 
   try {
     // Create the seller using MercurJS workflow
+    // The seller-created subscriber will automatically create metadata with default vendor_type
     const { result: seller } = await createSellerWorkflow.run({
       container: req.scope,
       input: {
@@ -58,46 +46,6 @@ export const POST = async (
         },
       },
     })
-
-    // Get seller extension service for upsert logic
-    const sellerExtensionService: SellerExtensionService = req.scope.resolve(
-      SELLER_EXTENSION_MODULE
-    )
-
-    // Check if metadata was already created by the subscriber (race condition)
-    const existingMetadata = await sellerExtensionService.listSellerMetadatas({
-      seller_id: seller.id,
-    })
-
-    // Cast vendor_type string to VendorType enum (values are identical)
-    const vendorType = (body.vendor_type || VendorType.PRODUCER) as VendorType
-
-    const metadataInput = {
-      vendor_type: vendorType,
-      website_url: body.website_url || null,
-      social_links: body.social_links || null,
-    }
-
-    if (existingMetadata && existingMetadata.length > 0) {
-      // Metadata already exists (created by subscriber) - update it with user's values
-      console.log(`[POST /vendor/sellers] Updating existing metadata for seller ${seller.id}`)
-      await sellerExtensionService.updateSellerMetadatas({
-        id: existingMetadata[0].id,
-        vendor_type: vendorType,
-        website_url: metadataInput.website_url,
-        social_links: metadataInput.social_links,
-      })
-    } else {
-      // No metadata exists - create it
-      console.log(`[POST /vendor/sellers] Creating metadata for seller ${seller.id}`)
-      await createSellerMetadataWorkflow.run({
-        container: req.scope,
-        input: {
-          seller_id: seller.id,
-          ...metadataInput,
-        } as any,
-      })
-    }
 
     return res.status(201).json({
       seller: {

--- a/backend/src/api/vendor/sellers/validators.ts
+++ b/backend/src/api/vendor/sellers/validators.ts
@@ -1,24 +1,11 @@
 import { z } from "zod"
-import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
-
-/**
- * Social Links Schema
- */
-const socialLinksSchema = z.object({
-  instagram: z.string().url().optional(),
-  facebook: z.string().url().optional(),
-  twitter: z.string().url().optional(),
-  tiktok: z.string().url().optional(),
-  youtube: z.string().url().optional(),
-  linkedin: z.string().url().optional(),
-  pinterest: z.string().url().optional(),
-}).optional()
 
 /**
  * Create Seller Request Schema
  *
  * Validates the request body for POST /vendor/sellers
- * Accepts all fields needed for seller creation + metadata
+ * Accepts core fields needed for seller creation.
+ * Metadata (including vendor_type) is created by the seller-created subscriber.
  */
 export const createSellerSchema = z.object({
   // Core seller fields
@@ -29,11 +16,6 @@ export const createSellerSchema = z.object({
     name: z.string().min(1, "Member name is required"),
     email: z.string().email("Valid email is required"),
   }),
-
-  // Extended metadata fields
-  vendor_type: z.enum(["producer", "garden", "maker", "restaurant", "mutual_aid"]).optional(),
-  website_url: z.string().url().optional().nullable(),
-  social_links: socialLinksSchema,
 })
 
 export type CreateSellerInput = z.infer<typeof createSellerSchema>

--- a/backend/src/subscribers/seller-created.ts
+++ b/backend/src/subscribers/seller-created.ts
@@ -1,18 +1,12 @@
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { createSellerMetadataWorkflow } from "../workflows/create-seller-metadata"
 import { VendorType } from "../modules/seller-extension/models/seller-metadata"
-import { SELLER_EXTENSION_MODULE } from "../modules/seller-extension"
-import SellerExtensionService from "../modules/seller-extension/service"
 
 /**
  * Subscriber: Seller Created
  *
  * Automatically creates seller_metadata when a new seller is created.
  * This ensures every seller has a vendor_type (defaults to PRODUCER).
- *
- * IMPORTANT: This subscriber checks if metadata already exists before creating.
- * This prevents race conditions when sellers are created via /vendor/sellers route
- * which creates metadata with the user's chosen vendor_type.
  */
 export default async function sellerCreatedHandler({
   event,
@@ -25,45 +19,19 @@ export default async function sellerCreatedHandler({
     return
   }
 
-  console.log(`[sellerCreated subscriber] Processing seller ${sellerId}`)
+  console.log(`[sellerCreated subscriber] Creating metadata for seller ${sellerId}`)
 
   try {
-    // Check if metadata already exists BEFORE trying to create
-    // This prevents race condition with /vendor/sellers route
-    const sellerExtensionService: SellerExtensionService = container.resolve(
-      SELLER_EXTENSION_MODULE
-    )
-
-    const existingMetadata = await sellerExtensionService.listSellerMetadatas({
-      seller_id: sellerId,
-    })
-
-    if (existingMetadata && existingMetadata.length > 0) {
-      console.log(`[sellerCreated subscriber] Metadata already exists for seller ${sellerId}, skipping creation`)
-      return
-    }
-
-    // No metadata exists, create with default values
     const { result } = await createSellerMetadataWorkflow.run({
       container,
       input: {
         seller_id: sellerId,
-        vendor_type: VendorType.PRODUCER, // Default type
+        vendor_type: VendorType.PRODUCER,
       },
     })
 
     console.log(`[sellerCreated subscriber] Seller metadata created: ${result.seller_metadata.id}`)
   } catch (error) {
-    // Double-check for unique constraint errors (edge case)
-    if (error instanceof Error && (
-      error.message.includes("unique") ||
-      error.message.includes("duplicate") ||
-      error.message.includes("already exists")
-    )) {
-      console.log(`[sellerCreated subscriber] Metadata already exists for seller ${sellerId} (caught constraint error)`)
-      return
-    }
-
     console.error(`[sellerCreated subscriber] Failed to create seller metadata for ${sellerId}:`, error)
     throw error
   }


### PR DESCRIPTION
Simplify seller registration by removing vendor_type handling:
- Route now only creates seller, no metadata
- Subscriber handles metadata creation with default PRODUCER type
- Removes complexity and race condition issues