### PR TITLE
fix: remove vendor_type from frontend registration

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -2,8 +2,6 @@ import { FetchError } from "@medusajs/js-sdk"
 import { HttpTypes } from "@medusajs/types"
 import { UseMutationOptions, useMutation } from "@tanstack/react-query"
 import { fetchQuery, sdk } from "../../lib/client"
-import { SocialLinks } from "../../types/user"
-import { VendorType } from "../../providers/vendor-type-provider"
 
 export const useSignInWithEmailPass = (
   options?: UseMutationOptions<
@@ -34,32 +32,25 @@ export const useSignUpWithEmailPass = (
     HttpTypes.AdminSignInWithEmailPassword & {
       confirmPassword: string
       name: string
-      vendor_type?: VendorType
-      website_url?: string
-      social_links?: SocialLinks
     }
   >
 ) => {
   return useMutation({
     mutationFn: (payload) => {
-      // Only pass fields that the auth.register endpoint accepts
-      const { vendor_type, website_url, social_links, ...authPayload } = payload
       return sdk.auth.register("seller", "emailpass", {
-        ...authPayload,
+        ...payload,
         email: payload.email.toLowerCase().trim(),
       })
     },
     onSuccess: async (_, variables) => {
       const normalizedEmail = variables.email.toLowerCase().trim()
+      // Only send core seller fields - metadata is created by subscriber
       const seller = {
         name: variables.name,
         member: {
           name: variables.name,
           email: normalizedEmail,
         },
-        vendor_type: variables.vendor_type,
-        website_url: variables.website_url,
-        social_links: variables.social_links,
       }
       await fetchQuery("/vendor/sellers", {
         method: "POST",

--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -97,7 +97,7 @@ export const Register = () => {
   }
 
   const handleSubmit = form.handleSubmit(
-    async ({ name, email, password, confirmPassword, website_url, instagram, facebook }) => {
+    async ({ name, email, password, confirmPassword }) => {
       if (password !== confirmPassword) {
         form.setError("password", {
           type: "manual",
@@ -111,21 +111,13 @@ export const Register = () => {
         return null
       }
 
-      // Build social links object if any are provided
-      const social_links = (instagram || facebook) ? {
-        instagram: instagram || undefined,
-        facebook: facebook || undefined,
-      } : undefined
-
+      // Only send core registration fields - vendor_type is set by admin later
       await mutateAsync(
         {
           name,
           email,
           password,
           confirmPassword,
-          vendor_type: selectedType || undefined,
-          website_url: website_url || undefined,
-          social_links,
         },
         {
           onError: (error) => {


### PR DESCRIPTION
- Update auth hook to not send vendor_type, website_url, social_links
- Update register form to only submit core fields
- Vendor type can be set by admin after registration