### PR TITLE
fix: use pnpm instead of npm in start script to eliminate deprecation…

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "build": "medusa build",
     "ib": "init-backend",
     "init-algolia": "node .medusa/server/src/scripts/init-algolia.js",
-    "start": "npm run seed && medusa db:migrate --execute-safe-links && init-backend && pnpm run init-algolia && cd .medusa/server && medusa start",
+    "start": "pnpm seed && medusa db:migrate --execute-safe-links && init-backend && pnpm init-algolia && cd .medusa/server && medusa start",
     "dev": "medusa develop",
     "seed": "medusa exec ./src/scripts/seed.ts",
     "test:integration:http": "TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",


### PR DESCRIPTION
… warning

Replace `npm run seed` with `pnpm seed` and `pnpm run init-algolia` with `pnpm init-algolia` in the start script. This fixes the deprecation warning "npm warn config production Use --omit=dev instead" that appears during Railway deployments.