### PR TITLE
fix: pass auth_identity_id to createSellerWorkflow

### DIFF
--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -1,4 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
 import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
 import { createSellerSchema, CreateSellerInput } from "./validators"
 
@@ -32,11 +33,30 @@ export const POST = async (
   console.log("[POST /vendor/sellers] Creating seller:", body.name)
 
   try {
+    // Look up the auth identity by email (created during auth registration)
+    const authModule = req.scope.resolve(Modules.AUTH)
+    const [authIdentity] = await authModule.listAuthIdentities({
+      provider_identities: {
+        entity_id: body.member.email,
+      },
+    })
+
+    if (!authIdentity) {
+      console.error("[POST /vendor/sellers] Auth identity not found for email:", body.member.email)
+      return res.status(400).json({
+        type: "invalid_data",
+        message: "Please complete authentication registration first",
+      })
+    }
+
+    console.log("[POST /vendor/sellers] Found auth identity:", authIdentity.id)
+
     // Create the seller using MercurJS workflow
     // The seller-created subscriber will automatically create metadata with default vendor_type
     const { result: seller } = await createSellerWorkflow.run({
       container: req.scope,
       input: {
+        auth_identity_id: authIdentity.id,
         member: {
           name: body.member.name,
           email: body.member.email,


### PR DESCRIPTION
The createSellerWorkflow requires auth_identity_id to link the seller to the auth identity via setAuthAppMetadataStep. This was causing the error "authIdentity - id must be defined" during registration.

Now the /vendor/sellers route looks up the auth identity by email (which was created during the preceding auth registration step) and passes its ID to the workflow.