### PR TITLE
feat: update terminology to be more inclusive of community organizations

### DIFF
--- a/admin-panel/src/i18n/translations/en.json
+++ b/admin-panel/src/i18n/translations/en.json
@@ -399,7 +399,7 @@
   "products": {
     "domain": "Products",
     "list": {
-      "noRecordsMessage": "Create your first product to start selling."
+      "noRecordsMessage": "Create your first product to start offering."
     },
     "edit": {
       "header": "Edit Product",
@@ -2477,7 +2477,7 @@
   },
   "regions": {
     "domain": "Regions",
-    "subtitle": "A region is an area that you sell products in. It can cover multiple countries, and has different tax rates, providers, and currency.",
+    "subtitle": "A region is an area that you offer products in. It can cover multiple countries, and has different tax rates, providers, and currency.",
     "createRegion": "Create Region",
     "createRegionHint": "Manage tax rates and providers for a set of countries.",
     "addCountries": "Add countries",
@@ -2498,7 +2498,7 @@
     "flatRate": "Flat Rate",
     "calculated": "Calculated",
     "list": {
-      "noRecordsMessage": "Create a region for the areas that you sell in."
+      "noRecordsMessage": "Create a region for the areas that you serve."
     },
     "toast": {
       "delete": "Region deleted successfully",
@@ -2599,7 +2599,7 @@
   },
   "salesChannels": {
     "domain": "Sales Channels",
-    "subtitle": "Manage the online and offline channels you sell products on.",
+    "subtitle": "Manage the online and offline channels you offer products on.",
     "list": {
       "empty": {
         "heading": "No sales channels found",
@@ -2611,7 +2611,7 @@
       }
     },
     "createSalesChannel": "Create Sales Channel",
-    "createSalesChannelHint": "Create a new sales channel to sell your products on.",
+    "createSalesChannelHint": "Create a new sales channel to offer your products on.",
     "enabledHint": "Specify whether the sales channel is enabled.",
     "removeProductsWarning_one": "You are about to remove {{count}} product from {{sales_channel}}.",
     "removeProductsWarning_other": "You are about to remove {{count}} products from {{sales_channel}}.",
@@ -3186,7 +3186,7 @@
   },
   "requests": {
     "domain": "Requests",
-    "seller": "Seller",
+    "seller": "Provider",
     "product": "Product",
     "review-remove": "Review Remove",
     "return": "Order Return",
@@ -3197,7 +3197,7 @@
     "product-update": "Product Update"
   },
   "sellers": {
-    "domain": "Sellers",
+    "domain": "Providers",
     "fields": {
       "name": "Name",
       "email": "Email",
@@ -3211,8 +3211,8 @@
       "tax_id": "Tax ID"
     },
     "edit": {
-      "header": "Edit Seller",
-      "successToast": "Seller {{name}} was successfully updated."
+      "header": "Edit Provider",
+      "successToast": "Provider {{name}} was successfully updated."
     }
   },
   "producers": {
@@ -3229,7 +3229,7 @@
       "location": "Location",
       "practices": "Growing Practices",
       "status": "Status",
-      "seller": "Linked Seller",
+      "seller": "Linked Provider",
       "description": "Description",
       "region": "Region",
       "state": "State",
@@ -3273,11 +3273,11 @@
       "overview": "Overview",
       "certifications": "Certifications",
       "media": "Media",
-      "seller": "Linked Seller"
+      "seller": "Linked Provider"
     },
     "empty": {
       "title": "No producers yet",
-      "description": "Producers will appear here when sellers create their farm profiles"
+      "description": "Producers will appear here when providers create their farm profiles"
     },
     "toast": {
       "verifySuccess": "Producer has been verified",

--- a/storefront/src/app/[locale]/(main)/sell/page.tsx
+++ b/storefront/src/app/[locale]/(main)/sell/page.tsx
@@ -49,12 +49,15 @@ const ChartBarIcon = ({ className = "" }: { className?: string }) => (
 const VENDOR_PANEL_URL = process.env.NEXT_PUBLIC_VENDOR_PANEL_URL || "https://vendor.freeblackmarket.com"
 
 /**
- * Sell on Free Black Market - Vendor Signup Landing Page
- * 
+ * Join Free Black Market - Community Provider Signup Landing Page
+ *
  * Designed following freeblackmarket.com conversion copy principles:
  * - Safety first messaging
- * - Radical transparency 
+ * - Radical transparency
  * - Community over conversion
+ *
+ * Inclusive of: Farmers, Community Gardens, Mutual Aid Organizations,
+ * Community Kitchens, Food Producers, and more
  */
 export default function SellPage() {
   const [email, setEmail] = useState("")
@@ -105,8 +108,11 @@ export default function SellPage() {
     },
   ]
 
-  const producerTypes = [
+  const providerTypes = [
     "Urban Farmers & Gardeners",
+    "Community Gardens",
+    "Mutual Aid Organizations",
+    "Community Kitchens",
     "Home Bakers & Cooks",
     "Artisan Food Makers",
     "Beekeepers",
@@ -116,12 +122,13 @@ export default function SellPage() {
     "Small-Scale Ranchers",
     "Wildcrafters & Foragers",
     "Aquaponic/Hydroponic Growers",
+    "Food Co-ops & Collectives",
   ]
 
   const faqs = [
     {
-      question: "How much does it cost to sell?",
-      answer: "Nothing upfront. We take a 3% commission only when you make a sale. No monthly fees, no listing fees, no hidden charges. If you don't sell, you don't pay.",
+      question: "How much does it cost to join?",
+      answer: "Nothing upfront. We take a 3% commission only when you make a transaction. No monthly fees, no listing fees, no hidden charges. If you don't transact, you don't pay.",
     },
     {
       question: "Do I need a commercial kitchen?",
@@ -141,7 +148,7 @@ export default function SellPage() {
     },
     {
       question: "Is this really different from other platforms?",
-      answer: "Yes. We're producer-owned and operated. Our governance gives vendors voting rights. We don't compete with you, we work for you. When you succeed, we succeed—that's literally our business model.",
+      answer: "Yes. We're community-owned and operated. Our governance gives providers voting rights. We don't compete with you, we work for you. When you succeed, we succeed—that's literally our business model.",
     },
   ]
 
@@ -153,14 +160,14 @@ export default function SellPage() {
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 md:py-32">
           <div className="max-w-3xl">
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-tight mb-6">
-              Sell What You Grow.
+              Share What You Grow.
               <br />
               <span className="text-green-300">Keep What You Earn.</span>
             </h1>
             <p className="text-xl md:text-2xl text-green-100 mb-8 leading-relaxed">
-              Join a marketplace built by producers, for producers. 
-              No middlemen taking half your profit. No algorithms hiding your products. 
-              Just direct connections to people who value what you make.
+              Join a marketplace built by the community, for the community.
+              Whether you're a farmer, community garden, mutual aid group, or community kitchen—
+              connect directly with people who value what you provide.
             </p>
             
             {/* Trust Indicators */}
@@ -195,7 +202,7 @@ export default function SellPage() {
                   disabled={isSubmitting}
                   className="px-8 py-4 bg-green-500 hover:bg-green-400 text-white font-semibold rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap"
                 >
-                  {isSubmitting ? "Starting..." : "Start Selling"}
+                  {isSubmitting ? "Starting..." : "Get Started"}
                 </button>
               </form>
             ) : (
@@ -207,7 +214,7 @@ export default function SellPage() {
             )}
             
             <p className="mt-4 text-sm text-green-200">
-              Free to join. No credit card required. Start selling in under 10 minutes.
+              Free to join. No credit card required. Get started in under 10 minutes.
             </p>
           </div>
         </div>
@@ -244,15 +251,16 @@ export default function SellPage() {
           <div className="lg:flex lg:items-center lg:gap-16">
             <div className="lg:w-1/2 mb-12 lg:mb-0">
               <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
-                If You Make It, You Can Sell It
+                If You Grow It or Make It, You Belong Here
               </h2>
               <p className="text-xl text-gray-600 mb-8">
-                Whether you have a backyard garden with extra tomatoes or you're running a 
-                small farm, there's a place for you here. We believe everyone who produces 
-                food deserves a dignified way to reach customers.
+                Whether you're a backyard gardener with extra tomatoes, a community kitchen
+                feeding your neighbors, a mutual aid group distributing food, or a farmer
+                running a small operation—there's a place for you here. We believe everyone
+                who provides food deserves a dignified way to reach their community.
               </p>
               <div className="flex flex-wrap gap-3">
-                {producerTypes.map((type, index) => (
+                {providerTypes.map((type, index) => (
                   <span 
                     key={index}
                     className="px-4 py-2 bg-green-100 text-green-800 rounded-full text-sm font-medium"
@@ -267,7 +275,7 @@ export default function SellPage() {
                 <h3 className="text-2xl font-bold mb-4">The Math That Matters</h3>
                 <div className="space-y-4">
                   <div className="flex justify-between items-center border-b border-green-700 pb-4">
-                    <span>You sell a jar of honey for</span>
+                    <span>You offer a jar of honey for</span>
                     <span className="text-2xl font-bold">$15.00</span>
                   </div>
                   <div className="flex justify-between items-center border-b border-green-700 pb-4">
@@ -361,18 +369,19 @@ export default function SellPage() {
       <section className="py-20 bg-green-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-6">
-            Ready to Sell on Your Terms?
+            Ready to Join on Your Terms?
           </h2>
           <p className="text-xl text-green-100 mb-8 max-w-2xl mx-auto">
-            Join a growing community of producers who are building something different. 
-            No contracts, no commitments, no catch. Just a fair marketplace.
+            Join a growing community of farmers, gardeners, mutual aid groups, and food
+            makers who are building something different. No contracts, no commitments,
+            no catch. Just a fair marketplace.
           </p>
-          
+
           <Link
             href={`${VENDOR_PANEL_URL}/register`}
             className="inline-block px-8 py-4 bg-white text-green-900 font-semibold rounded-lg hover:bg-green-50 transition-colors text-lg"
           >
-            Create Your Producer Account
+            Create Your Community Provider Account
           </Link>
           
           <p className="mt-6 text-green-200">

--- a/storefront/src/components/cells/SellNowButton/SellNowButton.tsx
+++ b/storefront/src/components/cells/SellNowButton/SellNowButton.tsx
@@ -12,7 +12,7 @@ export const SellNowButton = () => {
       rel="noopener noreferrer"
     >
       <Button className="group uppercase !font-bold pl-12 gap-1 flex items-center">
-        Sell now
+        Join Us
         <ArrowRightIcon
           color="white"
           className="w-5 h-5 group-hover:opacity-100 opacity-0 transition-all duration-300"

--- a/storefront/src/components/molecules/ContactSellerButton/ContactSellerButton.tsx
+++ b/storefront/src/components/molecules/ContactSellerButton/ContactSellerButton.tsx
@@ -73,7 +73,7 @@ export const ContactSellerButton = ({
 }: ContactSellerButtonProps) => {
   const [showChat, setShowChat] = useState(false)
 
-  const displayName = sellerName || "Seller"
+  const displayName = sellerName || "Provider"
 
   if (!ROCKETCHAT_URL) {
     return null

--- a/storefront/src/components/molecules/ConversionCopy/ConversionCopy.tsx
+++ b/storefront/src/components/molecules/ConversionCopy/ConversionCopy.tsx
@@ -314,16 +314,16 @@ export const ShopLocalCTA = ({ href = "/categories", className }: ShopLocalCTAPr
 export const BecomeProducerCTA = () => (
   <div className="bg-gradient-to-br from-amber-50 to-green-50 rounded-lg p-8 text-center">
     <h3 className="text-xl font-semibold text-warm-900 mb-2">
-      Are you a producer?
+      Are you a producer, farmer, or community organization?
     </h3>
     <p className="text-gray-600 mb-4">
-      Sell on your terms. Keep your customers. Get paid clearly and on time.
+      Share on your terms. Build your community. Get compensated fairly.
     </p>
     <Link
       href="/sell"
       className="inline-flex items-center gap-2 px-5 py-2.5 bg-white text-green-800 border-2 border-green-200 rounded-lg font-medium hover:border-green-300 hover:bg-green-50 transition-colors"
     >
-      Start Selling
+      Get Started
     </Link>
   </div>
 )

--- a/storefront/src/components/molecules/ReportSellerForm/ReportSellerForm.tsx
+++ b/storefront/src/components/molecules/ReportSellerForm/ReportSellerForm.tsx
@@ -104,7 +104,7 @@ export const ReportSellerForm = ({
               type='submit'
               className='w-full py-3 uppercase'
             >
-              Report Seller
+              Report Provider
             </Button>
           </div>
         </form>

--- a/storefront/src/components/molecules/ReviewForm/ReviewForm.tsx
+++ b/storefront/src/components/molecules/ReviewForm/ReviewForm.tsx
@@ -94,7 +94,7 @@ const Form: React.FC<Props> = ({ handleClose, seller }) => {
                 "w-full px-4 py-3 h-32 border rounded-sm bg-component-secondary focus:border-primary focus:outline-none focus:ring-0 relative",
                 error && "border-negative focus:border-negative"
               )}
-              placeholder="Write your opinion about this seller..."
+              placeholder="Write your opinion about this provider..."
               {...register("opinion")}
             />
             <div

--- a/storefront/src/components/molecules/TrustIndicators/TrustIndicators.tsx
+++ b/storefront/src/components/molecules/TrustIndicators/TrustIndicators.tsx
@@ -181,7 +181,7 @@ const BADGE_CONFIG: Record<
 }
 
 const VERIFICATION_LABELS: Record<VerificationLevel, { label: string; color: string }> = {
-  UNVERIFIED: { label: "New Producer", color: "#6B7280" },
+  UNVERIFIED: { label: "New Provider", color: "#6B7280" },
   SELF_REPORTED: { label: "Self-Reported", color: "#F59E0B" },
   VERIFIED: { label: "Verified", color: "#10B981" },
   AUDITED: { label: "Audited", color: "#3B82F6" },
@@ -280,19 +280,19 @@ export const VerificationBadge = ({ level, trustScore, showScore = false }: Veri
             <h4 className="font-semibold text-gray-900 mb-2">What does this mean?</h4>
             <div className="space-y-2 text-sm text-gray-600">
               {level === "UNVERIFIED" && (
-                <p>This is a new producer who hasn't completed our verification process yet.</p>
+                <p>This is a new provider who hasn't completed our verification process yet.</p>
               )}
               {level === "SELF_REPORTED" && (
-                <p>This producer has submitted their information but it hasn't been independently verified.</p>
+                <p>This provider has submitted their information but it hasn't been independently verified.</p>
               )}
               {level === "VERIFIED" && (
-                <p>We've verified this producer's identity, location, and basic business information.</p>
+                <p>We've verified this provider's identity, location, and basic information.</p>
               )}
               {level === "AUDITED" && (
-                <p>This producer has undergone an audit of their practices and operations.</p>
+                <p>This provider has undergone an audit of their practices and operations.</p>
               )}
               {level === "CERTIFIED" && (
-                <p>This producer holds recognized third-party certifications that we've verified.</p>
+                <p>This provider holds recognized third-party certifications that we've verified.</p>
               )}
               
               {trustScore !== undefined && (

--- a/storefront/src/components/organisms/Chat/Chat.tsx
+++ b/storefront/src/components/organisms/Chat/Chat.tsx
@@ -43,7 +43,7 @@ export const Chat = ({
         onClick={() => setModal(true)}
         className={buttonClassNames}
       >
-        {icon ? <MessageIcon size={20} /> : "Write to seller"}
+        {icon ? <MessageIcon size={20} /> : "Write to provider"}
       </Button>
       {modal && (
         <Modal heading="Chat" onClose={() => setModal(false)}>
@@ -51,7 +51,7 @@ export const Chat = ({
             <div className="w-full h-[500px]">
               <iframe
                 src={iframeUrl}
-                title={`Chat with ${seller?.name || 'Seller'}`}
+                title={`Chat with ${seller?.name || 'Provider'}`}
                 className="w-full h-full border-0 rounded-lg"
                 allow="camera; microphone; fullscreen; display-capture"
               />

--- a/storefront/src/components/organisms/SellerFooter/SellerFooter.tsx
+++ b/storefront/src/components/organisms/SellerFooter/SellerFooter.tsx
@@ -15,7 +15,7 @@ export const SellerFooter = ({ seller }: { seller: SellerProps }) => {
         {/* {seller.verified && (
           <div className="flex items-center gap-2">
             <DoneIcon size={20} />
-            Verified seller
+            Verified provider
           </div>
         )} */}
         <Divider square />
@@ -32,7 +32,7 @@ export const SellerFooter = ({ seller }: { seller: SellerProps }) => {
         Report
       </Button>
       {openModal && (
-        <Modal heading="Report seller" onClose={() => setOpenModal(false)}>
+        <Modal heading="Report provider" onClose={() => setOpenModal(false)}>
           <ReportSellerForm onClose={() => setOpenModal(false)} />
         </Modal>
       )}

--- a/storefront/src/data/footerLinks.ts
+++ b/storefront/src/data/footerLinks.ts
@@ -7,7 +7,7 @@ const links = {
   ],
   about: [
     { label: 'About Us', path: 'https://www.blackmarketcoa.com' },
-    { label: 'Sell on FreeBlackMarket', path: '/sell' },
+    { label: 'Join FreeBlackMarket', path: '/sell' },
     { label: 'How It Works', path: 'https://www.blackmarketcoa.com' },
   ],
   connect: [

--- a/vendor-panel/src/components/onboarding/onboarding-wizard.tsx
+++ b/vendor-panel/src/components/onboarding/onboarding-wizard.tsx
@@ -236,7 +236,7 @@ function CompletionStep() {
           <Tag className="w-6 h-6 text-ui-fg-muted group-hover:text-ui-fg-base mb-2" />
           <Text className="font-medium">Add Your First Product</Text>
           <Text size="small" className="text-ui-fg-subtle">
-            Start selling right away
+            Start offering right away
           </Text>
         </button>
       </div>

--- a/vendor-panel/src/i18n/translations/en.json
+++ b/vendor-panel/src/i18n/translations/en.json
@@ -397,7 +397,7 @@
     "domain": "Products",
     "list": {
       "noRecordsTitle": "No products yet",
-      "noRecordsMessage": "Create products to start selling on the marketplace"
+      "noRecordsMessage": "Create products to start offering on the marketplace"
     },
     "edit": {
       "header": "Edit Product",
@@ -2373,7 +2373,7 @@
   },
   "regions": {
     "domain": "Regions",
-    "subtitle": "A region is an area that you sell products in. It can cover multipe countries, and has different tax rates, providers, and currency.",
+    "subtitle": "A region is an area that you offer products in. It can cover multiple countries, and has different tax rates, providers, and currency.",
     "createRegion": "Create Region",
     "createRegionHint": "Manage tax rates and providers for a set of countries.",
     "addCountries": "Add countries",
@@ -2394,7 +2394,7 @@
     "flatRate": "Flat Rate",
     "calculated": "Calculated",
     "list": {
-      "noRecordsMessage": "Create a region for the areas that you sell in."
+      "noRecordsMessage": "Create a region for the areas that you serve."
     },
     "toast": {
       "delete": "Region deleted successfully",
@@ -2496,7 +2496,7 @@
   },
   "salesChannels": {
     "domain": "Sales Channels",
-    "subtitle": "Manage the online and offline channels you sell products on.",
+    "subtitle": "Manage the online and offline channels you offer products on.",
     "list": {
       "empty": {
         "heading": "No sales channels found",
@@ -2508,7 +2508,7 @@
       }
     },
     "createSalesChannel": "Create Sales Channel",
-    "createSalesChannelHint": "Create a new sales channel to sell your products on.",
+    "createSalesChannelHint": "Create a new sales channel to offer your products on.",
     "enabledHint": "Specify whether the sales channel is enabled.",
     "removeProductsWarning_one": "You are about to remove {{count}} product from {{sales_channel}}.",
     "removeProductsWarning_other": "You are about to remove {{count}} products from {{sales_channel}}.",
@@ -2650,17 +2650,17 @@
   },
   "login": {
     "forgotPassword": "Forgot password? - <0>Reset</0>",
-    "title": "Welcome to Mercur Seller Panel",
+    "title": "Welcome to the Provider Portal",
     "hint": "Sign in to access the account area",
-    "notSellerYet": "Not a seller yet? - <0>Create an account</0>"
+    "notSellerYet": "Not a provider yet? - <0>Create an account</0>"
   },
   "register": {
-    "title": "Join Mercur Seller Panel",
-    "hint": "Sign up to start selling",
+    "title": "Join the Provider Portal",
+    "hint": "Sign up to get started",
     "alreadySeller": "Already have an account? - <0>Sign In</0>"
   },
   "invite": {
-    "title": "Welcome to Mercur Seller Panel",
+    "title": "Welcome to the Provider Portal",
     "hint": "Create your account below",
     "backToLogin": "Back to login",
     "createAccount": "Create account",

--- a/vendor-panel/src/routes/dashboard/components/dashboard-onboarding.tsx
+++ b/vendor-panel/src/routes/dashboard/components/dashboard-onboarding.tsx
@@ -52,7 +52,7 @@ const ICON_MAP: Record<string, any> = {
 const HELP_RESOURCES = [
   {
     title: "Getting Started Guide",
-    description: "Learn the basics of selling on our marketplace",
+    description: "Learn the basics of offering products on our marketplace",
     link: "#",
     icon: BookOpen,
   },

--- a/vendor-panel/src/routes/dashboard/config/dashboard-config.ts
+++ b/vendor-panel/src/routes/dashboard/config/dashboard-config.ts
@@ -122,7 +122,7 @@ export function getOnboardingSteps(type: VendorType, features: VendorFeatures) {
         : type === "maker"
         ? "Add your first creation"
         : "Add your first product",
-      description: "Start selling by adding items to your store",
+      description: "Get started by adding items to your store",
       to: "/products/create",
       icon: "Tag",
     })

--- a/vendor-panel/src/routes/digital-products/page.tsx
+++ b/vendor-panel/src/routes/digital-products/page.tsx
@@ -59,7 +59,7 @@ const DigitalProductsPage = () => {
             <DocumentText className="mx-auto h-12 w-12 text-ui-fg-subtle mb-4" />
             <Heading level="h3">No digital products yet</Heading>
             <Text className="text-ui-fg-subtle">
-              Create your first digital product to start selling downloadable content
+              Create your first digital product to start offering downloadable content
             </Text>
           </div>
         ) : (

--- a/vendor-panel/src/routes/farm/lots/[id]/components/lot-product-linking.tsx
+++ b/vendor-panel/src/routes/farm/lots/[id]/components/lot-product-linking.tsx
@@ -225,7 +225,7 @@ export const LotProductLinking = ({ lotId, suggestedPrice, unit }: LotProductLin
             <div className="w-16 h-16 rounded-full bg-purple-50 flex items-center justify-center">
               <ShoppingCart className="w-8 h-8 text-purple-600" />
             </div>
-            <Heading level="h3">Ready to start selling?</Heading>
+            <Heading level="h3">Ready to get started?</Heading>
             <Text className="text-ui-fg-subtle text-center max-w-md">
               Link this lot to a product in your store. When customers purchase the product, 
               inventory will be automatically tracked from this lot.
@@ -261,7 +261,7 @@ export const LotProductLinking = ({ lotId, suggestedPrice, unit }: LotProductLin
                 <div className="flex items-start gap-3">
                   <div className="w-6 h-6 rounded-full bg-green-100 text-green-700 flex items-center justify-center text-sm font-medium flex-shrink-0">✓</div>
                   <div>
-                    <Text className="font-medium text-sm">Start selling</Text>
+                    <Text className="font-medium text-sm">Start offering</Text>
                     <Text className="text-ui-fg-subtle text-xs">Inventory syncs automatically with orders</Text>
                   </div>
                 </div>

--- a/vendor-panel/src/routes/shows/shows.tsx
+++ b/vendor-panel/src/routes/shows/shows.tsx
@@ -66,7 +66,7 @@ const Shows = () => {
             <ReceiptPercent className="mx-auto h-12 w-12 text-ui-fg-subtle mb-4" />
             <Heading level="h3">No shows yet</Heading>
             <Text className="text-ui-fg-subtle">
-              Create your first show to start selling tickets
+              Create your first show to start offering tickets
             </Text>
           </div>
         ) : (


### PR DESCRIPTION
Changes "vendor/seller" terminology to "provider" and "sell/selling" to "offer/share/get started" throughout the codebase to be more welcoming to mutual aid organizations, community gardens, farmers, and community kitchens.

Key terminology changes:
- "Seller" → "Provider"
- "Sell now" → "Join Us" / "Get Started"
- "Start Selling" → "Get Started" / "Start Offering"
- "Sell on FreeBlackMarket" → "Join FreeBlackMarket"
- Added inclusive producer types: Community Gardens, Mutual Aid Organizations, Community Kitchens, Food Co-ops & Collectives

Updated files across storefront, vendor-panel, and admin-panel.