### PR TITLE
feat: update storefront copy to reflect full scope of marketplace

### DIFF
--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({
 
   const title = "Home"
   const description =
-    "Buy directly from producers. Not corporations. Not middlemen. Every dollar you spend goes straight to verified local producers. Transparent pricing, real community impact."
+    "Buy directly from creators. Not corporations. Not middlemen. Discover handcrafted goods, fresh produce, electronics, digital products, and professional services—all from verified independent makers and entrepreneurs."
   const ogImage = "/B2C_Storefront_Open_Graph.png"
   const canonical = `${baseUrl}/${locale}`
 
@@ -164,11 +164,11 @@ export default async function Home({
       <Hero
         variant="mission"
         image="/images/hero/Image.jpg"
-        heading="Buy directly from producers. Not corporations. Not middlemen."
-        paragraph="Every dollar you spend here goes straight to a producer who made it. Transparent pricing. Verified sources. Real community impact."
+        heading="Buy directly from creators. Not corporations. Not middlemen."
+        paragraph="From handcrafted goods and fresh produce to digital products and professional services—every purchase supports independent makers, artists, and entrepreneurs. Transparent pricing. Verified sources. Real community impact."
         buttons={[
           { label: "Shop the Market", path: "/categories" },
-          { label: "Explore Producers", path: "/producers" },
+          { label: "Meet Our Creators", path: "/producers" },
         ]}
       />
       {/* FreeBlackMarket.com Value Proposition */}

--- a/storefront/src/components/molecules/ConversionCopy/ConversionCopy.tsx
+++ b/storefront/src/components/molecules/ConversionCopy/ConversionCopy.tsx
@@ -38,13 +38,13 @@ const HeartIcon = ({ className = "w-6 h-6" }: { className?: string }) => (
 
 export const HomePageTagline = () => (
   <p className="text-lg md:text-xl text-warm-600 max-w-xl leading-relaxed">
-    Buy directly from producers. Not corporations. Not middlemen.
+    Buy directly from creators. Not corporations. Not middlemen.
   </p>
 )
 
 export const HomePageHeadline = () => (
   <h1 className="text-4xl md:text-5xl lg:text-6xl font-serif text-warm-900 leading-tight">
-    Every dollar you spend here goes straight to a producer who made it.
+    Every dollar you spend here goes straight to the creator who made it.
   </h1>
 )
 
@@ -58,9 +58,9 @@ export const ValueProposition = ({ className }: ValuePropositionProps) => (
       <div className="w-12 h-12 mx-auto md:mx-0 bg-green-100 rounded-lg flex items-center justify-center mb-4">
         <CurrencyDollarIcon className="w-6 h-6 text-green-600" />
       </div>
-      <h3 className="font-semibold text-lg mb-2">Direct to Producer</h3>
+      <h3 className="font-semibold text-lg mb-2">Direct to Creator</h3>
       <p className="text-gray-600">
-        No middlemen. No markups. Producers set their own prices and keep what they earn.
+        No middlemen. No markups. Creators set their own prices and keep what they earn.
       </p>
     </div>
     <div className="text-center md:text-left">
@@ -69,7 +69,7 @@ export const ValueProposition = ({ className }: ValuePropositionProps) => (
       </div>
       <h3 className="font-semibold text-lg mb-2">Verified Sources</h3>
       <p className="text-gray-600">
-        Every producer is verified. See exactly where your food comes from and who made it.
+        Every creator is verified. See exactly where your products come from and who made them.
       </p>
     </div>
     <div className="text-center md:text-left">
@@ -78,7 +78,7 @@ export const ValueProposition = ({ className }: ValuePropositionProps) => (
       </div>
       <h3 className="font-semibold text-lg mb-2">Build Community</h3>
       <p className="text-gray-600">
-        Your purchase supports real people and builds a different kind of food system.
+        Your purchase supports real people and builds a different kind of economy.
       </p>
     </div>
   </div>
@@ -202,13 +202,13 @@ export const OrderConfirmationMessage = ({
 }: OrderConfirmationMessageProps) => (
   <div className={`bg-green-50 border border-green-200 rounded-lg p-6 text-center ${className}`}>
     <p className="text-xl font-semibold text-green-800 mb-2">
-      Thank you for supporting local producers!
+      Thank you for supporting independent creators!
     </p>
     <p className="text-green-700">
-      {amount} will go directly to {producerName || "your producer"} once delivery is confirmed.
+      {amount} will go directly to {producerName || "your creator"} once delivery is confirmed.
     </p>
     <p className="text-sm text-green-600 mt-4">
-      You&apos;re part of a movement that pays producers fairly and cuts out the middlemen.
+      You&apos;re part of a movement that pays creators fairly and cuts out the middlemen.
     </p>
   </div>
 )
@@ -230,7 +230,7 @@ export const CartImpactSummary = ({
 }: CartImpactSummaryProps) => (
   <div className={`bg-amber-50 border border-amber-200 rounded-lg p-4 ${className}`}>
     <p className="text-amber-800 font-medium">
-      🌟 Your cart supports {producerCount} local producer{producerCount !== 1 ? "s" : ""}
+      Your cart supports {producerCount} independent creator{producerCount !== 1 ? "s" : ""}
     </p>
     <p className="text-amber-700 text-sm mt-1">
       {totalToProducers} goes directly to the people who made your products.
@@ -297,7 +297,7 @@ export const ShopLocalCTA = ({ href = "/categories", className }: ShopLocalCTAPr
       Ready to buy direct?
     </h2>
     <p className="text-gray-600 mb-6 max-w-md mx-auto">
-      Browse products from verified local producers. Every purchase supports someone building something real.
+      Browse products and services from verified independent creators. Every purchase supports someone building something real.
     </p>
     <Link
       href={href}
@@ -314,10 +314,10 @@ export const ShopLocalCTA = ({ href = "/categories", className }: ShopLocalCTAPr
 export const BecomeProducerCTA = () => (
   <div className="bg-gradient-to-br from-amber-50 to-green-50 rounded-lg p-8 text-center">
     <h3 className="text-xl font-semibold text-warm-900 mb-2">
-      Are you a producer, farmer, or community organization?
+      Are you a maker, creator, or community organization?
     </h3>
     <p className="text-gray-600 mb-4">
-      Share on your terms. Build your community. Get compensated fairly.
+      Sell products, offer services, or share digital content—on your terms. Build your community. Get compensated fairly.
     </p>
     <Link
       href="/sell"
@@ -345,7 +345,7 @@ export const MissionStatement = () => (
   </div>
 )
 
-export const ImpactStats = ({ 
+export const ImpactStats = ({
   totalToProducers = "$1.8M",
   producerCount = 247,
   customerCount = 12580,
@@ -353,11 +353,11 @@ export const ImpactStats = ({
   <div className="grid grid-cols-3 gap-8 text-center">
     <div>
       <p className="text-3xl font-bold text-green-600">{totalToProducers}</p>
-      <p className="text-sm text-gray-600">Paid to Producers</p>
+      <p className="text-sm text-gray-600">Paid to Creators</p>
     </div>
     <div>
       <p className="text-3xl font-bold text-blue-600">{producerCount}</p>
-      <p className="text-sm text-gray-600">Active Producers</p>
+      <p className="text-sm text-gray-600">Active Creators</p>
     </div>
     <div>
       <p className="text-3xl font-bold text-amber-600">{customerCount.toLocaleString()}</p>

--- a/storefront/src/components/sections/BlogSection/BlogSection.tsx
+++ b/storefront/src/components/sections/BlogSection/BlogSection.tsx
@@ -4,9 +4,9 @@ import { BlogCard } from '@/components/organisms';
 export const blogPosts: BlogPost[] = [
   {
     id: 1,
-    title: "Find something for the occasion",
+    title: "Find something for every occasion",
     excerpt:
-      "If you can ship it, you can sell it. Your money funds real farmers, restaurants, and skilled workers. NOT venture capital. We continually find new points of sale for coalition members.",
+      "From handcrafted goods and electronics to digital downloads and professional services—your money supports real makers, creators, and entrepreneurs. NOT venture capital.",
     image: '/images/blog/post-1.jpg',
     category: 'ACCESSORIES',
     href: '#',
@@ -21,8 +21,8 @@ export const blogPosts: BlogPost[] = [
   },
   {
     id: 3,
-    title: 'Find local producers',
-    excerpt: 'Local pickup hosting options are available for FREE.',
+    title: 'Find local creators',
+    excerpt: 'Browse products and services from verified independent creators. Local pickup options available for FREE.',
     image: '/images/blog/post-3.jpg',
     category: 'TRENDS',
     href: '#',

--- a/storefront/src/components/sections/ProducersPage/ProducersPage.tsx
+++ b/storefront/src/components/sections/ProducersPage/ProducersPage.tsx
@@ -74,10 +74,9 @@ export function ProducersPage({ locale }: ProducersPageProps) {
     <div>
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Our Producers</h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">Our Creators</h1>
         <p className="text-gray-600 max-w-2xl">
-          Meet the farmers and food artisans behind your food. Every purchase supports
-          local agriculture and sustainable practices.
+          Meet the makers, artisans, and entrepreneurs behind your purchases. From handcrafted goods and fresh produce to digital products and professional services—every purchase supports independent creators.
         </p>
       </div>
 
@@ -87,7 +86,7 @@ export function ProducersPage({ locale }: ProducersPageProps) {
           <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <input
             type="text"
-            placeholder="Search producers by name or location..."
+            placeholder="Search creators by name or location..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
@@ -124,7 +123,7 @@ export function ProducersPage({ locale }: ProducersPageProps) {
           {featuredProducers.length > 0 && !showFeatured && (
             <div className="mb-10">
               <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
-                <span className="text-amber-500">⭐</span> Featured Farms
+                <span className="text-amber-500">⭐</span> Featured Creators
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 {featuredProducers.slice(0, 2).map((producer) => (
@@ -137,12 +136,12 @@ export function ProducersPage({ locale }: ProducersPageProps) {
           {/* All Producers */}
           <div>
             <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              {showFeatured ? "Featured Producers" : "All Producers"}
+              {showFeatured ? "Featured Creators" : "All Creators"}
             </h2>
             {(showFeatured ? producers : regularProducers).length === 0 ? (
               <div className="text-center py-12 bg-gray-50 rounded-lg">
                 <LeafIcon className="w-12 h-12 text-gray-400 mx-auto mb-3" />
-                <p className="text-gray-600">No producers found matching your criteria.</p>
+                <p className="text-gray-600">No creators found matching your criteria.</p>
               </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
Update wording across the storefront to better describe the full range of products and services offered:
- Change "producers" to "creators" to include all maker types
- Expand hero messaging to mention products, digital goods, and services
- Update value propositions to be product-agnostic (not just food)
- Revise blog section excerpts to highlight full product range
- Update ProducersPage header and labels to use "creators" terminology