### PR TITLE
feat: implement wishlist module for customer product wishlists

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -111,7 +111,11 @@ module.exports = defineConfig({
     {
       resolve: './src/modules/subscription',
     },
-    
+    // Wishlist module (customer product wishlists)
+    {
+      resolve: './src/modules/wishlist',
+    },
+
     // === FreeBlackMarket.com Feature Modules ===
     // Vendor Verification module (trust badges, verification levels)
     {
@@ -317,6 +321,13 @@ module.exports = defineConfig({
     // Link seller to seller metadata for vendor_type and extended fields
     {
       resolve: './src/links/seller-metadata',
+    },
+    // Wishlist links for customer and product relationships
+    {
+      resolve: './src/links/wishlist-customer',
+    },
+    {
+      resolve: './src/links/wishlist-product',
     },
   ],
 })

--- a/backend/src/api/store/wishlist/[id]/product/[productId]/route.ts
+++ b/backend/src/api/store/wishlist/[id]/product/[productId]/route.ts
@@ -1,0 +1,40 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { WISHLIST_MODULE } from "../../../../../../modules/wishlist"
+import WishlistModuleService from "../../../../../../modules/wishlist/service"
+import { requireCustomerId, notFound, forbidden } from "../../../../../../shared"
+
+// ===========================================
+// DELETE /store/wishlist/:id/product/:productId
+// Remove a product from customer's wishlist
+// ===========================================
+
+export async function DELETE(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  try {
+    const customerId = requireCustomerId(req, res)
+    if (!customerId) return
+
+    const { id: wishlistId, productId } = req.params
+
+    const wishlistService = req.scope.resolve<WishlistModuleService>(WISHLIST_MODULE)
+
+    // Verify the wishlist belongs to this customer
+    const wishlists = await wishlistService.listWishlists({
+      id: wishlistId,
+      customer_id: customerId,
+    })
+
+    if (wishlists.length === 0) {
+      return notFound(res, "Wishlist not found")
+    }
+
+    // Remove the product from wishlist
+    await wishlistService.removeProductFromWishlist(wishlistId, productId)
+
+    res.json({
+      message: "Product removed from wishlist",
+      success: true,
+    })
+  } catch (error) {
+    throw error
+  }
+}

--- a/backend/src/api/store/wishlist/route.ts
+++ b/backend/src/api/store/wishlist/route.ts
@@ -1,0 +1,87 @@
+import { z } from "zod"
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { WISHLIST_MODULE } from "../../../modules/wishlist"
+import WishlistModuleService from "../../../modules/wishlist/service"
+import { requireCustomerId } from "../../../shared"
+
+// ===========================================
+// VALIDATION SCHEMAS
+// ===========================================
+
+const addWishlistItemSchema = z.object({
+  reference: z.literal("product"),
+  reference_id: z.string().min(1, "Product ID is required"),
+})
+
+// ===========================================
+// GET /store/wishlist
+// Get customer's wishlists with products
+// ===========================================
+
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  try {
+    const customerId = requireCustomerId(req, res)
+    if (!customerId) return
+
+    const query = req.scope.resolve("query")
+
+    // Query wishlists with items and linked products
+    const { data: wishlists } = await query.graph({
+      entity: "wishlist",
+      fields: ["id", "customer_id", "items.*", "items.product.*"],
+      filters: {
+        customer_id: customerId,
+      },
+    })
+
+    // Transform data to match storefront expectations
+    const transformedWishlists = wishlists.map((wishlist: any) => ({
+      id: wishlist.id,
+      products: (wishlist.items || [])
+        .map((item: any) => item.product)
+        .filter(Boolean),
+    }))
+
+    res.json({
+      wishlists: transformedWishlists,
+      count: transformedWishlists.length,
+    })
+  } catch (error) {
+    throw error
+  }
+}
+
+// ===========================================
+// POST /store/wishlist
+// Add a product to customer's wishlist
+// ===========================================
+
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  try {
+    const customerId = requireCustomerId(req, res)
+    if (!customerId) return
+
+    const data = addWishlistItemSchema.parse(req.body)
+
+    const wishlistService = req.scope.resolve<WishlistModuleService>(WISHLIST_MODULE)
+
+    // Add product to wishlist (will create wishlist if it doesn't exist)
+    const wishlist = await wishlistService.addProductToWishlist(
+      customerId,
+      data.reference_id
+    )
+
+    res.status(201).json({
+      wishlist: {
+        id: wishlist.id,
+      },
+      message: "Product added to wishlist",
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Validation failed", errors: error.errors })
+      return
+    }
+    throw error
+  }
+}

--- a/backend/src/links/wishlist-customer.ts
+++ b/backend/src/links/wishlist-customer.ts
@@ -1,0 +1,20 @@
+import { defineLink } from "@medusajs/framework/utils"
+import WishlistModule from "../modules/wishlist"
+import CustomerModule from "@medusajs/medusa/customer"
+
+/**
+ * Link Wishlist to Customer
+ *
+ * Creates a read-only link between wishlist and customer
+ * for querying purposes.
+ */
+export default defineLink(
+  {
+    linkable: WishlistModule.linkable.wishlist,
+    field: "customer_id",
+  },
+  CustomerModule.linkable.customer,
+  {
+    readOnly: true,
+  }
+)

--- a/backend/src/links/wishlist-product.ts
+++ b/backend/src/links/wishlist-product.ts
@@ -1,0 +1,20 @@
+import { defineLink } from "@medusajs/framework/utils"
+import WishlistModule from "../modules/wishlist"
+import ProductModule from "@medusajs/medusa/product"
+
+/**
+ * Link WishlistItem to Product
+ *
+ * Creates a read-only link between wishlist items and products
+ * for querying purposes.
+ */
+export default defineLink(
+  {
+    linkable: WishlistModule.linkable.wishlistItem,
+    field: "product_id",
+  },
+  ProductModule.linkable.product,
+  {
+    readOnly: true,
+  }
+)

--- a/backend/src/modules/wishlist/index.ts
+++ b/backend/src/modules/wishlist/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import WishlistModuleService from "./service"
+
+export const WISHLIST_MODULE = "wishlistModuleService"
+
+export default Module(WISHLIST_MODULE, {
+  service: WishlistModuleService,
+})

--- a/backend/src/modules/wishlist/models/index.ts
+++ b/backend/src/modules/wishlist/models/index.ts
@@ -1,0 +1,2 @@
+export { default as Wishlist } from "./wishlist"
+export { default as WishlistItem } from "./wishlist-item"

--- a/backend/src/modules/wishlist/models/wishlist-item.ts
+++ b/backend/src/modules/wishlist/models/wishlist-item.ts
@@ -1,0 +1,24 @@
+import { model } from "@medusajs/framework/utils"
+import Wishlist from "./wishlist"
+
+/**
+ * WishlistItem Model
+ *
+ * Represents a product in a customer's wishlist.
+ * Uses product_id (not variant_id) to match storefront expectations.
+ */
+const WishlistItem = model.define("wishlist_item", {
+  id: model.id().primaryKey(),
+  product_id: model.text(),
+  wishlist: model.belongsTo(() => Wishlist, {
+    mappedBy: "items",
+  }),
+})
+.indexes([
+  {
+    on: ["product_id", "wishlist_id"],
+    unique: true,
+  },
+])
+
+export default WishlistItem

--- a/backend/src/modules/wishlist/models/wishlist.ts
+++ b/backend/src/modules/wishlist/models/wishlist.ts
@@ -1,0 +1,24 @@
+import { model } from "@medusajs/framework/utils"
+import WishlistItem from "./wishlist-item"
+
+/**
+ * Wishlist Model
+ *
+ * Represents a customer's wishlist. Each customer can have one wishlist
+ * containing multiple products.
+ */
+const Wishlist = model.define("wishlist", {
+  id: model.id().primaryKey(),
+  customer_id: model.text(),
+  items: model.hasMany(() => WishlistItem, {
+    mappedBy: "wishlist",
+  }),
+})
+.indexes([
+  {
+    on: ["customer_id"],
+    unique: true,
+  },
+])
+
+export default Wishlist

--- a/backend/src/modules/wishlist/service.ts
+++ b/backend/src/modules/wishlist/service.ts
@@ -1,0 +1,82 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { Wishlist, WishlistItem } from "./models"
+
+/**
+ * Wishlist Module Service
+ *
+ * Provides CRUD operations for wishlists and wishlist items.
+ * Supports the storefront wishlist feature where customers can save products.
+ */
+class WishlistModuleService extends MedusaService({
+  Wishlist,
+  WishlistItem,
+}) {
+  /**
+   * Get or create a wishlist for a customer
+   */
+  async getOrCreateWishlist(customerId: string) {
+    const existing = await this.listWishlists({
+      customer_id: customerId,
+    })
+
+    if (existing.length > 0) {
+      return existing[0]
+    }
+
+    return this.createWishlists({
+      customer_id: customerId,
+    })
+  }
+
+  /**
+   * Add a product to a customer's wishlist
+   */
+  async addProductToWishlist(customerId: string, productId: string) {
+    const wishlist = await this.getOrCreateWishlist(customerId)
+
+    // Check if product already exists in wishlist
+    const existingItems = await this.listWishlistItems({
+      wishlist_id: wishlist.id,
+      product_id: productId,
+    })
+
+    if (existingItems.length > 0) {
+      return wishlist
+    }
+
+    await this.createWishlistItems({
+      wishlist_id: wishlist.id,
+      product_id: productId,
+    })
+
+    return wishlist
+  }
+
+  /**
+   * Remove a product from a customer's wishlist
+   */
+  async removeProductFromWishlist(wishlistId: string, productId: string) {
+    const items = await this.listWishlistItems({
+      wishlist_id: wishlistId,
+      product_id: productId,
+    })
+
+    if (items.length > 0) {
+      await this.deleteWishlistItems(items[0].id)
+    }
+
+    return { success: true }
+  }
+
+  /**
+   * Get wishlists for a customer with items
+   */
+  async getCustomerWishlists(customerId: string) {
+    return this.listWishlists(
+      { customer_id: customerId },
+      { relations: ["items"] }
+    )
+  }
+}
+
+export default WishlistModuleService


### PR DESCRIPTION
Add complete wishlist feature based on MedusaJS examples:
- Wishlist and WishlistItem models with proper indexes
- WishlistModuleService with CRUD operations
- Module links for customer and product relationships
- Store API routes matching storefront expectations:
  - GET /store/wishlist - Get customer wishlists with products
  - POST /store/wishlist - Add product to wishlist
  - DELETE /store/wishlist/:id/product/:productId - Remove product
- Register module and links in medusa-config.ts