### PR TITLE
fix: rename wishlist models to avoid naming conflict

### DIFF
--- a/backend/src/api/store/wishlist/[id]/product/[productId]/route.ts
+++ b/backend/src/api/store/wishlist/[id]/product/[productId]/route.ts
@@ -18,7 +18,7 @@ export async function DELETE(req: AuthenticatedMedusaRequest, res: MedusaRespons
     const wishlistService = req.scope.resolve<WishlistModuleService>(WISHLIST_MODULE)
 
     // Verify the wishlist belongs to this customer
-    const wishlists = await wishlistService.listWishlists({
+    const wishlists = await wishlistService.listCustomerWishlists({
       id: wishlistId,
       customer_id: customerId,
     })

--- a/backend/src/api/store/wishlist/route.ts
+++ b/backend/src/api/store/wishlist/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
 
     // Query wishlists with items and linked products
     const { data: wishlists } = await query.graph({
-      entity: "wishlist",
+      entity: "customer_wishlist",
       fields: ["id", "customer_id", "items.*", "items.product.*"],
       filters: {
         customer_id: customerId,

--- a/backend/src/links/wishlist-customer.ts
+++ b/backend/src/links/wishlist-customer.ts
@@ -3,14 +3,14 @@ import WishlistModule from "../modules/wishlist"
 import CustomerModule from "@medusajs/medusa/customer"
 
 /**
- * Link Wishlist to Customer
+ * Link CustomerWishlist to Customer
  *
- * Creates a read-only link between wishlist and customer
+ * Creates a read-only link between customer wishlist and customer
  * for querying purposes.
  */
 export default defineLink(
   {
-    linkable: WishlistModule.linkable.wishlist,
+    linkable: WishlistModule.linkable.customerWishlist,
     field: "customer_id",
   },
   CustomerModule.linkable.customer,

--- a/backend/src/links/wishlist-product.ts
+++ b/backend/src/links/wishlist-product.ts
@@ -3,14 +3,14 @@ import WishlistModule from "../modules/wishlist"
 import ProductModule from "@medusajs/medusa/product"
 
 /**
- * Link WishlistItem to Product
+ * Link CustomerWishlistItem to Product
  *
- * Creates a read-only link between wishlist items and products
+ * Creates a read-only link between customer wishlist items and products
  * for querying purposes.
  */
 export default defineLink(
   {
-    linkable: WishlistModule.linkable.wishlistItem,
+    linkable: WishlistModule.linkable.customerWishlistItem,
     field: "product_id",
   },
   ProductModule.linkable.product,

--- a/backend/src/modules/wishlist/models/index.ts
+++ b/backend/src/modules/wishlist/models/index.ts
@@ -1,2 +1,2 @@
-export { default as Wishlist } from "./wishlist"
-export { default as WishlistItem } from "./wishlist-item"
+export { default as CustomerWishlist } from "./wishlist"
+export { default as CustomerWishlistItem } from "./wishlist-item"

--- a/backend/src/modules/wishlist/models/wishlist-item.ts
+++ b/backend/src/modules/wishlist/models/wishlist-item.ts
@@ -1,24 +1,26 @@
 import { model } from "@medusajs/framework/utils"
-import Wishlist from "./wishlist"
+import CustomerWishlist from "./wishlist"
 
 /**
- * WishlistItem Model
+ * CustomerWishlistItem Model
  *
  * Represents a product in a customer's wishlist.
  * Uses product_id (not variant_id) to match storefront expectations.
+ *
+ * Named "customer_wishlist_item" to avoid conflict with existing wishlist services.
  */
-const WishlistItem = model.define("wishlist_item", {
+const CustomerWishlistItem = model.define("customer_wishlist_item", {
   id: model.id().primaryKey(),
   product_id: model.text(),
-  wishlist: model.belongsTo(() => Wishlist, {
+  wishlist: model.belongsTo(() => CustomerWishlist, {
     mappedBy: "items",
   }),
 })
 .indexes([
   {
-    on: ["product_id", "wishlist_id"],
+    on: ["product_id", "customer_wishlist_id"],
     unique: true,
   },
 ])
 
-export default WishlistItem
+export default CustomerWishlistItem

--- a/backend/src/modules/wishlist/models/wishlist.ts
+++ b/backend/src/modules/wishlist/models/wishlist.ts
@@ -1,16 +1,18 @@
 import { model } from "@medusajs/framework/utils"
-import WishlistItem from "./wishlist-item"
+import CustomerWishlistItem from "./wishlist-item"
 
 /**
- * Wishlist Model
+ * CustomerWishlist Model
  *
  * Represents a customer's wishlist. Each customer can have one wishlist
  * containing multiple products.
+ *
+ * Named "customer_wishlist" to avoid conflict with existing wishlist services.
  */
-const Wishlist = model.define("wishlist", {
+const CustomerWishlist = model.define("customer_wishlist", {
   id: model.id().primaryKey(),
   customer_id: model.text(),
-  items: model.hasMany(() => WishlistItem, {
+  items: model.hasMany(() => CustomerWishlistItem, {
     mappedBy: "wishlist",
   }),
 })
@@ -21,4 +23,4 @@ const Wishlist = model.define("wishlist", {
   },
 ])
 
-export default Wishlist
+export default CustomerWishlist

--- a/backend/src/modules/wishlist/service.ts
+++ b/backend/src/modules/wishlist/service.ts
@@ -1,5 +1,5 @@
 import { MedusaService } from "@medusajs/framework/utils"
-import { Wishlist, WishlistItem } from "./models"
+import { CustomerWishlist, CustomerWishlistItem } from "./models"
 
 /**
  * Wishlist Module Service
@@ -8,14 +8,14 @@ import { Wishlist, WishlistItem } from "./models"
  * Supports the storefront wishlist feature where customers can save products.
  */
 class WishlistModuleService extends MedusaService({
-  Wishlist,
-  WishlistItem,
+  CustomerWishlist,
+  CustomerWishlistItem,
 }) {
   /**
    * Get or create a wishlist for a customer
    */
   async getOrCreateWishlist(customerId: string) {
-    const existing = await this.listWishlists({
+    const existing = await this.listCustomerWishlists({
       customer_id: customerId,
     })
 
@@ -23,7 +23,7 @@ class WishlistModuleService extends MedusaService({
       return existing[0]
     }
 
-    return this.createWishlists({
+    return this.createCustomerWishlists({
       customer_id: customerId,
     })
   }
@@ -35,8 +35,8 @@ class WishlistModuleService extends MedusaService({
     const wishlist = await this.getOrCreateWishlist(customerId)
 
     // Check if product already exists in wishlist
-    const existingItems = await this.listWishlistItems({
-      wishlist_id: wishlist.id,
+    const existingItems = await this.listCustomerWishlistItems({
+      customer_wishlist_id: wishlist.id,
       product_id: productId,
     })
 
@@ -44,8 +44,8 @@ class WishlistModuleService extends MedusaService({
       return wishlist
     }
 
-    await this.createWishlistItems({
-      wishlist_id: wishlist.id,
+    await this.createCustomerWishlistItems({
+      customer_wishlist_id: wishlist.id,
       product_id: productId,
     })
 
@@ -56,13 +56,13 @@ class WishlistModuleService extends MedusaService({
    * Remove a product from a customer's wishlist
    */
   async removeProductFromWishlist(wishlistId: string, productId: string) {
-    const items = await this.listWishlistItems({
-      wishlist_id: wishlistId,
+    const items = await this.listCustomerWishlistItems({
+      customer_wishlist_id: wishlistId,
       product_id: productId,
     })
 
     if (items.length > 0) {
-      await this.deleteWishlistItems(items[0].id)
+      await this.deleteCustomerWishlistItems(items[0].id)
     }
 
     return { success: true }
@@ -72,7 +72,7 @@ class WishlistModuleService extends MedusaService({
    * Get wishlists for a customer with items
    */
   async getCustomerWishlists(customerId: string) {
-    return this.listWishlists(
+    return this.listCustomerWishlists(
       { customer_id: customerId },
       { relations: ["items"] }
     )


### PR DESCRIPTION
Rename models from "wishlist" to "customer_wishlist" to avoid conflict with existing wishlist service from MercurJS plugins.

Changes:
- Rename Wishlist model to CustomerWishlist
- Rename WishlistItem model to CustomerWishlistItem
- Update service methods (listCustomerWishlists, etc.)
- Update links to use new linkable names
- Update API routes to use new entity names