### PR TITLE
fix: correct foreign key field name in wishlist models

### DIFF
--- a/backend/src/modules/wishlist/models/wishlist-item.ts
+++ b/backend/src/modules/wishlist/models/wishlist-item.ts
@@ -18,7 +18,7 @@ const CustomerWishlistItem = model.define("customer_wishlist_item", {
 })
 .indexes([
   {
-    on: ["product_id", "customer_wishlist_id"],
+    on: ["product_id", "wishlist_id"],
     unique: true,
   },
 ])

--- a/backend/src/modules/wishlist/service.ts
+++ b/backend/src/modules/wishlist/service.ts
@@ -36,7 +36,7 @@ class WishlistModuleService extends MedusaService({
 
     // Check if product already exists in wishlist
     const existingItems = await this.listCustomerWishlistItems({
-      customer_wishlist_id: wishlist.id,
+      wishlist_id: wishlist.id,
       product_id: productId,
     })
 
@@ -45,7 +45,7 @@ class WishlistModuleService extends MedusaService({
     }
 
     await this.createCustomerWishlistItems({
-      customer_wishlist_id: wishlist.id,
+      wishlist_id: wishlist.id,
       product_id: productId,
     })
 
@@ -57,7 +57,7 @@ class WishlistModuleService extends MedusaService({
    */
   async removeProductFromWishlist(wishlistId: string, productId: string) {
     const items = await this.listCustomerWishlistItems({
-      customer_wishlist_id: wishlistId,
+      wishlist_id: wishlistId,
       product_id: productId,
     })
 


### PR DESCRIPTION
The belongsTo relationship creates a foreign key named after the relationship (wishlist_id), not after the model name. Fixed:
- Index in CustomerWishlistItem to use wishlist_id
- Service methods to use wishlist_id for filtering and creation