### PR TITLE
fix: rename wishlist models from customer_wishlist to shopper_wishlist

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -322,7 +322,7 @@ module.exports = defineConfig({
     {
       resolve: './src/links/seller-metadata',
     },
-    // Note: wishlist-customer link removed to avoid alias conflict
-    // The customer_id field in CustomerWishlist model handles the relationship
+    // Note: Wishlist model renamed from customer_wishlist to shopper_wishlist
+    // to avoid alias collision with the Customer module
   ],
 })

--- a/backend/src/api/store/wishlist/[id]/product/[productId]/route.ts
+++ b/backend/src/api/store/wishlist/[id]/product/[productId]/route.ts
@@ -18,7 +18,7 @@ export async function DELETE(req: AuthenticatedMedusaRequest, res: MedusaRespons
     const wishlistService = req.scope.resolve<WishlistModuleService>(WISHLIST_MODULE)
 
     // Verify the wishlist belongs to this customer
-    const wishlists = await wishlistService.listCustomerWishlists({
+    const wishlists = await wishlistService.listShopperWishlists({
       id: wishlistId,
       customer_id: customerId,
     })

--- a/backend/src/api/store/wishlist/route.ts
+++ b/backend/src/api/store/wishlist/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     const query = req.scope.resolve("query")
 
     // Get wishlists with items using the module service
-    const wishlists = await wishlistService.listCustomerWishlists(
+    const wishlists = await wishlistService.listShopperWishlists(
       { customer_id: customerId },
       { relations: ["items"] }
     )

--- a/backend/src/modules/wishlist/models/index.ts
+++ b/backend/src/modules/wishlist/models/index.ts
@@ -1,2 +1,2 @@
-export { default as CustomerWishlist } from "./wishlist"
-export { default as CustomerWishlistItem } from "./wishlist-item"
+export { default as ShopperWishlist } from "./wishlist"
+export { default as ShopperWishlistItem } from "./wishlist-item"

--- a/backend/src/modules/wishlist/models/wishlist-item.ts
+++ b/backend/src/modules/wishlist/models/wishlist-item.ts
@@ -1,18 +1,18 @@
 import { model } from "@medusajs/framework/utils"
-import CustomerWishlist from "./wishlist"
+import ShopperWishlist from "./wishlist"
 
 /**
- * CustomerWishlistItem Model
+ * ShopperWishlistItem Model
  *
  * Represents a product in a customer's wishlist.
  * Uses product_id (not variant_id) to match storefront expectations.
  *
- * Named "customer_wishlist_item" to avoid conflict with existing wishlist services.
+ * Named "shopper_wishlist_item" to avoid naming conflict with Customer module.
  */
-const CustomerWishlistItem = model.define("customer_wishlist_item", {
+const ShopperWishlistItem = model.define("shopper_wishlist_item", {
   id: model.id().primaryKey(),
   product_id: model.text(),
-  wishlist: model.belongsTo(() => CustomerWishlist, {
+  wishlist: model.belongsTo(() => ShopperWishlist, {
     mappedBy: "items",
   }),
 })
@@ -23,4 +23,4 @@ const CustomerWishlistItem = model.define("customer_wishlist_item", {
   },
 ])
 
-export default CustomerWishlistItem
+export default ShopperWishlistItem

--- a/backend/src/modules/wishlist/models/wishlist.ts
+++ b/backend/src/modules/wishlist/models/wishlist.ts
@@ -1,18 +1,19 @@
 import { model } from "@medusajs/framework/utils"
-import CustomerWishlistItem from "./wishlist-item"
+import ShopperWishlistItem from "./wishlist-item"
 
 /**
- * CustomerWishlist Model
+ * ShopperWishlist Model
  *
  * Represents a customer's wishlist. Each customer can have one wishlist
  * containing multiple products.
  *
- * Named "customer_wishlist" to avoid conflict with existing wishlist services.
+ * Named "shopper_wishlist" to avoid naming conflict with Customer module
+ * which was causing alias collision errors.
  */
-const CustomerWishlist = model.define("customer_wishlist", {
+const ShopperWishlist = model.define("shopper_wishlist", {
   id: model.id().primaryKey(),
   customer_id: model.text(),
-  items: model.hasMany(() => CustomerWishlistItem, {
+  items: model.hasMany(() => ShopperWishlistItem, {
     mappedBy: "wishlist",
   }),
 })
@@ -23,4 +24,4 @@ const CustomerWishlist = model.define("customer_wishlist", {
   },
 ])
 
-export default CustomerWishlist
+export default ShopperWishlist

--- a/backend/src/modules/wishlist/service.ts
+++ b/backend/src/modules/wishlist/service.ts
@@ -1,5 +1,5 @@
 import { MedusaService } from "@medusajs/framework/utils"
-import { CustomerWishlist, CustomerWishlistItem } from "./models"
+import { ShopperWishlist, ShopperWishlistItem } from "./models"
 
 /**
  * Wishlist Module Service
@@ -8,14 +8,14 @@ import { CustomerWishlist, CustomerWishlistItem } from "./models"
  * Supports the storefront wishlist feature where customers can save products.
  */
 class WishlistModuleService extends MedusaService({
-  CustomerWishlist,
-  CustomerWishlistItem,
+  ShopperWishlist,
+  ShopperWishlistItem,
 }) {
   /**
    * Get or create a wishlist for a customer
    */
   async getOrCreateWishlist(customerId: string) {
-    const existing = await this.listCustomerWishlists({
+    const existing = await this.listShopperWishlists({
       customer_id: customerId,
     })
 
@@ -23,7 +23,7 @@ class WishlistModuleService extends MedusaService({
       return existing[0]
     }
 
-    return this.createCustomerWishlists({
+    return this.createShopperWishlists({
       customer_id: customerId,
     })
   }
@@ -35,7 +35,7 @@ class WishlistModuleService extends MedusaService({
     const wishlist = await this.getOrCreateWishlist(customerId)
 
     // Check if product already exists in wishlist
-    const existingItems = await this.listCustomerWishlistItems({
+    const existingItems = await this.listShopperWishlistItems({
       wishlist_id: wishlist.id,
       product_id: productId,
     })
@@ -44,7 +44,7 @@ class WishlistModuleService extends MedusaService({
       return wishlist
     }
 
-    await this.createCustomerWishlistItems({
+    await this.createShopperWishlistItems({
       wishlist_id: wishlist.id,
       product_id: productId,
     })
@@ -56,13 +56,13 @@ class WishlistModuleService extends MedusaService({
    * Remove a product from a customer's wishlist
    */
   async removeProductFromWishlist(wishlistId: string, productId: string) {
-    const items = await this.listCustomerWishlistItems({
+    const items = await this.listShopperWishlistItems({
       wishlist_id: wishlistId,
       product_id: productId,
     })
 
     if (items.length > 0) {
-      await this.deleteCustomerWishlistItems(items[0].id)
+      await this.deleteShopperWishlistItems(items[0].id)
     }
 
     return { success: true }
@@ -72,7 +72,7 @@ class WishlistModuleService extends MedusaService({
    * Get wishlists for a customer with items
    */
   async getCustomerWishlists(customerId: string) {
-    return this.listCustomerWishlists(
+    return this.listShopperWishlists(
       { customer_id: customerId },
       { relations: ["items"] }
     )


### PR DESCRIPTION
The model name "customer_wishlist" was causing a service alias collision with the Medusa Customer module. When registering models with names starting with "customer_", the framework incorrectly parsed the entity name, creating conflicts during link entity generation.

Renamed models:
- customer_wishlist → shopper_wishlist
- customer_wishlist_item → shopper_wishlist_item

Updated all service methods and API routes to use the new naming.