### PR TITLE
fix: remove duplicate mappedBy in wishlist-item belongsTo relationship

### DIFF
--- a/backend/src/modules/wishlist/models/wishlist-item.ts
+++ b/backend/src/modules/wishlist/models/wishlist-item.ts
@@ -12,9 +12,7 @@ import ShopperWishlist from "./wishlist"
 const ShopperWishlistItem = model.define("shopper_wishlist_item", {
   id: model.id().primaryKey(),
   product_id: model.text(),
-  wishlist: model.belongsTo(() => ShopperWishlist, {
-    mappedBy: "items",
-  }),
+  wishlist: model.belongsTo(() => ShopperWishlist),
 })
 .indexes([
   {


### PR DESCRIPTION
The belongsTo relationship was configured with mappedBy pointing to the parent's hasMany field, but since the hasMany already has mappedBy configured pointing back, this caused MikroORM to register the wishlist_id column twice in SQL queries. Removing the mappedBy from the belongsTo side fixes the duplicate column selection issue.