### PR TITLE
fix: resolve remaining TypeScript errors for CMS Blueprint

### DIFF
--- a/backend/src/api/admin/cms-attributes/[id]/route.ts
+++ b/backend/src/api/admin/cms-attributes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { CMS_BLUEPRINT_MODULE, CmsBlueprintServiceType } from "../../../../modules/cms-blueprint"
+import { AttributeInputType, AttributeDisplayType } from "../../../../modules/cms-blueprint/models/cms-attribute"
 
 /**
  * GET /admin/cms-attributes/:id
@@ -81,22 +82,24 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
     metadata?: Record<string, unknown>
   }
 
-  const attribute = await cmsBlueprintService.updateCmsAttributes({
-    id,
-    handle,
-    name,
-    description,
-    input_type,
-    display_type,
-    unit,
-    options,
-    validation,
-    is_filterable,
-    is_required,
-    display_order,
-    is_active,
-    metadata,
-  })
+  const attribute = await cmsBlueprintService.updateCmsAttributes(
+    { id },
+    {
+      handle,
+      name,
+      description,
+      input_type: input_type ? (input_type as AttributeInputType) : undefined,
+      display_type: display_type ? (display_type as AttributeDisplayType) : undefined,
+      unit,
+      options: options as Record<string, unknown> | null | undefined,
+      validation: validation as Record<string, unknown> | null | undefined,
+      is_filterable,
+      is_required,
+      display_order,
+      is_active,
+      metadata,
+    }
+  )
 
   return res.json({ attribute })
 }

--- a/backend/src/api/admin/cms-attributes/route.ts
+++ b/backend/src/api/admin/cms-attributes/route.ts
@@ -1,6 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, generateEntityId } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { CMS_BLUEPRINT_MODULE, CmsBlueprintServiceType } from "../../../modules/cms-blueprint"
+import { AttributeInputType, AttributeDisplayType } from "../../../modules/cms-blueprint/models/cms-attribute"
 
 /**
  * GET /admin/cms-attributes
@@ -145,15 +146,14 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const attribute = await cmsBlueprintService.createCmsAttributes({
-    id: generateEntityId("", "cms_attr"),
     handle,
     name,
     description,
-    input_type: input_type || "text",
-    display_type: display_type || "text_input",
+    input_type: (input_type as AttributeInputType) || AttributeInputType.TEXT,
+    display_type: (display_type as AttributeDisplayType) || AttributeDisplayType.TEXT_INPUT,
     unit,
-    options,
-    validation,
+    options: options as Record<string, unknown> | null,
+    validation: validation as Record<string, unknown> | null,
     is_filterable: is_filterable ?? true,
     is_required: is_required ?? false,
     display_order: display_order ?? 0,

--- a/backend/src/api/admin/cms-tags/[id]/route.ts
+++ b/backend/src/api/admin/cms-tags/[id]/route.ts
@@ -1,6 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { CMS_BLUEPRINT_MODULE, CmsBlueprintServiceType } from "../../../../modules/cms-blueprint"
+import { TagType } from "../../../../modules/cms-blueprint/models/cms-tag"
 
 /**
  * GET /admin/cms-tags/:id
@@ -57,17 +58,19 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
     metadata?: Record<string, unknown>
   }
 
-  const tag = await cmsBlueprintService.updateCmsTags({
-    id,
-    handle,
-    name,
-    description,
-    tag_type,
-    icon,
-    color,
-    is_active,
-    metadata,
-  })
+  const tag = await cmsBlueprintService.updateCmsTags(
+    { id },
+    {
+      handle,
+      name,
+      description,
+      tag_type: tag_type ? (tag_type as TagType) : undefined,
+      icon,
+      color,
+      is_active,
+      metadata,
+    }
+  )
 
   return res.json({ tag })
 }

--- a/backend/src/api/admin/cms-tags/route.ts
+++ b/backend/src/api/admin/cms-tags/route.ts
@@ -1,6 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, generateEntityId } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { CMS_BLUEPRINT_MODULE, CmsBlueprintServiceType } from "../../../modules/cms-blueprint"
+import { TagType } from "../../../modules/cms-blueprint/models/cms-tag"
 
 /**
  * GET /admin/cms-tags
@@ -85,11 +86,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const tag = await cmsBlueprintService.createCmsTags({
-    id: generateEntityId("", "cms_tag"),
     handle,
     name,
     description,
-    tag_type: tag_type || "availability",
+    tag_type: (tag_type as TagType) || TagType.AVAILABILITY,
     icon,
     color,
     is_active: is_active ?? true,


### PR DESCRIPTION
- Remove id from create methods (Medusa auto-generates IDs)
- Use selector pattern for update methods: updateX({ id }, { data })
- Import and properly cast TagType enum for tag_type field
- Import and cast AttributeInputType/AttributeDisplayType enums
- Update seed script to map handle-based IDs to database-generated IDs
- Add error handling for table existence check in seed