### PR TITLE
fix: rename module from cms-blueprint to cms_blueprint (hyphens not a…

### DIFF
--- a/backend/src/modules/cms-blueprint/index.ts
+++ b/backend/src/modules/cms-blueprint/index.ts
@@ -1,7 +1,7 @@
 import { Module } from "@medusajs/framework/utils"
 import CmsBlueprintService from "./service"
 
-export const CMS_BLUEPRINT_MODULE = "cms-blueprint"
+export const CMS_BLUEPRINT_MODULE = "cms_blueprint"
 
 export type CmsBlueprintServiceType = InstanceType<typeof CmsBlueprintService>
 


### PR DESCRIPTION
…llowed)