### PR TITLE
fix: align RegisterForm password validation with PasswordValidator UI

### DIFF
--- a/storefront/src/components/molecules/RegisterForm/schema.ts
+++ b/storefront/src/components/molecules/RegisterForm/schema.ts
@@ -8,9 +8,14 @@ export const registerFormSchema = z.object({
     .string()
     .nonempty("Please enter password")
     .min(8, "Password must be at least 8 characters long")
-    .regex(/^(?=.*[A-Z])(?=.*[!@#$%^&*])/, {
-      message:
-        "Password must contain at least one uppercase letter and one special character",
+    .regex(/[a-z]/, {
+      message: "Password must contain at least one lowercase letter",
+    })
+    .regex(/[A-Z]/, {
+      message: "Password must contain at least one uppercase letter",
+    })
+    .regex(/[0-9!@#$%^&*(),.?":{}|<>_\-+=\[\]\\\/~`]/, {
+      message: "Password must contain at least one number or symbol",
     }),
   phone: z
     .string()


### PR DESCRIPTION
The form schema was requiring a special character (!@#$%^&*) while the PasswordValidator UI indicated "One number or symbol" would satisfy the requirement. This caused passwords with numbers but no symbols (like "TeBLcb6BSu9VGG2") to show all green checkmarks but fail validation.

Changes:
- Add lowercase letter validation (was missing from schema)
- Accept number OR symbol for the digit/symbol requirement
- Use same character set as PasswordValidator component