### PR TITLE
feat: add type-based navigation to storefront header

### DIFF
--- a/storefront/src/components/cells/MobileNavbar/MobileNavbar.tsx
+++ b/storefront/src/components/cells/MobileNavbar/MobileNavbar.tsx
@@ -5,24 +5,30 @@ import {
   CategoryNavbar,
   HeaderCategoryNavbar,
 } from '@/components/molecules';
-import { CloseIcon, HamburgerMenuIcon, SearchIcon } from '@/icons';
+import { CloseIcon, HamburgerMenuIcon, SearchIcon, CollapseIcon } from '@/icons';
 import { useState } from 'react';
 import LocalizedClientLink from '@/components/molecules/LocalizedLink/LocalizedLink';
 import { useRouter } from 'next/navigation';
+import { CmsType, CmsCategory } from '@/lib/data/cms-taxonomy';
+import { cn } from '@/lib/utils';
 
 export const MobileNavbar = ({
   childrenCategories,
   parentCategories,
+  cmsTypes,
 }: {
   childrenCategories: HttpTypes.StoreProductCategory[];
   parentCategories: HttpTypes.StoreProductCategory[];
+  cmsTypes?: CmsType[];
 }) => {
   const [openMenu, setOpenMenu] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [expandedType, setExpandedType] = useState<string | null>(null);
   const router = useRouter();
 
   const closeMenuHandler = () => {
     setOpenMenu(false);
+    setExpandedType(null);
   };
 
   const handleSearch = (e: React.FormEvent) => {
@@ -33,9 +39,15 @@ export const MobileNavbar = ({
     }
   };
 
+  const toggleType = (typeId: string) => {
+    setExpandedType(expandedType === typeId ? null : typeId);
+  };
+
+  const hasCmsTypes = cmsTypes && cmsTypes.length > 0;
+
   return (
     <div className='lg:hidden'>
-      <button 
+      <button
         onClick={() => setOpenMenu(true)}
         aria-label="Open navigation menu"
         className="p-1"
@@ -46,7 +58,7 @@ export const MobileNavbar = ({
         <div className='fixed w-full h-full bg-primary p-4 top-0 left-0 z-50 overflow-y-auto'>
           <div className='flex justify-between items-center mb-4'>
             <span className="font-semibold text-lg">Menu</span>
-            <button 
+            <button
               onClick={() => closeMenuHandler()}
               aria-label="Close navigation menu"
               className="p-1"
@@ -68,50 +80,117 @@ export const MobileNavbar = ({
               />
             </div>
           </form>
-          
+
           {/* Quick Links */}
-          <div className='border rounded-sm mb-4 p-4'>
+          <div className='border rounded-lg mb-4 p-4'>
             <div className='flex flex-col gap-3'>
-              <LocalizedClientLink 
-                href="/categories" 
+              <LocalizedClientLink
+                href="/categories"
                 onClick={closeMenuHandler}
-                className="font-medium text-primary hover:text-green-700"
+                className="font-medium text-primary hover:text-green-700 flex items-center gap-2"
               >
-                🛒 Shop All Products
+                <span className="text-lg">🛒</span> Shop All Products
               </LocalizedClientLink>
-              <LocalizedClientLink 
-                href="/producers" 
+              <LocalizedClientLink
+                href="/producers"
                 onClick={closeMenuHandler}
-                className="font-medium text-primary hover:text-green-700"
+                className="font-medium text-primary hover:text-green-700 flex items-center gap-2"
               >
-                👨‍🌾 Our Producers
+                <span className="text-lg">👨‍🌾</span> Our Producers
               </LocalizedClientLink>
-              <LocalizedClientLink 
-                href="/sell" 
+              <LocalizedClientLink
+                href="/sell"
                 onClick={closeMenuHandler}
-                className="font-medium text-green-700 hover:text-green-800"
+                className="font-medium text-green-700 hover:text-green-800 flex items-center gap-2"
               >
-                ✨ Sell on FreeBlackMarket
+                <span className="text-lg">✨</span> Sell on FreeBlackMarket
               </LocalizedClientLink>
             </div>
           </div>
 
-          {/* Categories */}
-          <div className='border rounded-sm'>
-            <div className='p-3 border-b'>
-              <span className='text-sm font-medium text-gray-500 uppercase'>Categories</span>
+          {/* CMS Type-Based Navigation */}
+          {hasCmsTypes ? (
+            <div className='border rounded-lg'>
+              <div className='p-3 border-b bg-gray-50'>
+                <span className='text-sm font-medium text-gray-600 uppercase tracking-wide'>Browse by Category</span>
+              </div>
+              <div className='divide-y'>
+                {cmsTypes
+                  .filter(type => type.is_active)
+                  .sort((a, b) => a.display_order - b.display_order)
+                  .map((type) => (
+                    <div key={type.id} className=''>
+                      {/* Type Header */}
+                      <button
+                        onClick={() => toggleType(type.id)}
+                        className='w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors'
+                      >
+                        <span className='flex items-center gap-3'>
+                          {type.icon && <span className='text-xl'>{type.icon}</span>}
+                          <span className='font-medium'>{type.name}</span>
+                        </span>
+                        <CollapseIcon
+                          size={18}
+                          className={cn(
+                            'transition-transform text-gray-400',
+                            expandedType === type.id ? 'rotate-180' : ''
+                          )}
+                        />
+                      </button>
+
+                      {/* Expanded Categories */}
+                      {expandedType === type.id && type.categories && (
+                        <div className='bg-gray-50 border-t'>
+                          {/* View All Link */}
+                          <LocalizedClientLink
+                            href={`/type/${type.handle}`}
+                            onClick={closeMenuHandler}
+                            className='block px-4 py-3 text-sm font-medium text-green-700 hover:bg-gray-100 border-b border-gray-200'
+                          >
+                            View All {type.name} →
+                          </LocalizedClientLink>
+
+                          {/* Category Links */}
+                          {type.categories
+                            .filter((cat: CmsCategory) => cat.is_active)
+                            .sort((a: CmsCategory, b: CmsCategory) => a.display_order - b.display_order)
+                            .map((category: CmsCategory) => (
+                              <LocalizedClientLink
+                                key={category.id}
+                                href={`/category/${category.handle}`}
+                                onClick={closeMenuHandler}
+                                className='block px-4 py-3 text-sm hover:bg-gray-100 transition-colors'
+                              >
+                                <span className='flex items-center gap-2 pl-4'>
+                                  {category.icon && <span className='text-base'>{category.icon}</span>}
+                                  {category.name}
+                                </span>
+                              </LocalizedClientLink>
+                            ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+              </div>
             </div>
-            <HeaderCategoryNavbar
-              onClose={closeMenuHandler}
-              categories={parentCategories}
-            />
-            <div className='border-t pt-2'>
-              <CategoryNavbar
+          ) : (
+            // Fallback to legacy categories
+            <div className='border rounded-sm'>
+              <div className='p-3 border-b'>
+                <span className='text-sm font-medium text-gray-500 uppercase'>Categories</span>
+              </div>
+              <HeaderCategoryNavbar
                 onClose={closeMenuHandler}
-                categories={childrenCategories}
+                categories={parentCategories}
               />
+              <div className='border-t pt-2'>
+                <CategoryNavbar
+                  onClose={closeMenuHandler}
+                  categories={childrenCategories}
+                />
+              </div>
             </div>
-          </div>
+          )}
         </div>
       )}
     </div>

--- a/storefront/src/components/cells/Navbar/Navbar.tsx
+++ b/storefront/src/components/cells/Navbar/Navbar.tsx
@@ -1,15 +1,23 @@
 import { HttpTypes } from "@medusajs/types"
-import { CategoryNavbar, NavbarSearch } from "@/components/molecules"
+import { CategoryNavbar, NavbarSearch, TypeNavbar } from "@/components/molecules"
+import { CmsType } from "@/lib/data/cms-taxonomy"
 
 export const Navbar = ({
   categories,
+  cmsTypes,
 }: {
   categories: HttpTypes.StoreProductCategory[]
+  cmsTypes: CmsType[]
 }) => {
   return (
     <div className="flex border py-4 justify-between px-6">
       <div className="hidden md:flex items-center">
-        <CategoryNavbar categories={categories} />
+        {/* Use TypeNavbar if CMS types are available, otherwise fall back to CategoryNavbar */}
+        {cmsTypes && cmsTypes.length > 0 ? (
+          <TypeNavbar types={cmsTypes} />
+        ) : (
+          <CategoryNavbar categories={categories} />
+        )}
       </div>
 
       <NavbarSearch />

--- a/storefront/src/components/molecules/TypeNavbar/TypeNavbar.tsx
+++ b/storefront/src/components/molecules/TypeNavbar/TypeNavbar.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { useParams, usePathname } from "next/navigation"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { cn } from "@/lib/utils"
+import { CollapseIcon } from "@/icons"
+import { CmsType, CmsCategory } from "@/lib/data/cms-taxonomy"
+
+export const TypeNavbar = ({
+  types,
+  onClose,
+}: {
+  types: CmsType[]
+  onClose?: (state: boolean) => void
+}) => {
+  const pathname = usePathname()
+  const [openDropdown, setOpenDropdown] = useState<string | null>(null)
+  const dropdownRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      let clickedInside = false
+      dropdownRefs.current.forEach((ref) => {
+        if (ref && ref.contains(event.target as Node)) {
+          clickedInside = true
+        }
+      })
+      if (!clickedInside) {
+        setOpenDropdown(null)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  const isTypeActive = (typeHandle: string) => {
+    return pathname?.includes(`/type/${typeHandle}`)
+  }
+
+  const isCategoryActive = (categoryHandle: string) => {
+    return pathname?.includes(`/category/${categoryHandle}`)
+  }
+
+  return (
+    <nav className="flex md:items-center flex-col md:flex-row gap-1">
+      {/* Shop All Products */}
+      <LocalizedClientLink
+        href="/categories"
+        onClick={() => onClose?.(false)}
+        className={cn(
+          "label-md uppercase px-3 py-2 flex items-center justify-between hover:bg-secondary rounded transition-colors"
+        )}
+      >
+        All Products
+      </LocalizedClientLink>
+
+      {/* Type Dropdowns */}
+      {types?.filter(t => t.is_active).map((type) => (
+        <div
+          key={type.id}
+          className="relative"
+          ref={(el) => {
+            if (el) dropdownRefs.current.set(type.id, el)
+          }}
+        >
+          <button
+            onClick={() => setOpenDropdown(openDropdown === type.id ? null : type.id)}
+            onMouseEnter={() => setOpenDropdown(type.id)}
+            className={cn(
+              "label-md uppercase px-3 py-2 flex items-center gap-1 hover:bg-secondary rounded transition-colors whitespace-nowrap",
+              isTypeActive(type.handle) && "bg-secondary font-semibold"
+            )}
+          >
+            {type.icon && <span className="text-base mr-1">{type.icon}</span>}
+            <span className="hidden xl:inline">{type.name}</span>
+            <span className="xl:hidden">{type.icon ? "" : type.name.split(" ")[0]}</span>
+            <CollapseIcon
+              size={14}
+              className={cn(
+                "transition-transform ml-1",
+                openDropdown === type.id ? "rotate-180" : ""
+              )}
+            />
+          </button>
+
+          {openDropdown === type.id && type.categories && type.categories.length > 0 && (
+            <div
+              className="absolute left-0 top-full mt-1 bg-primary border border-gray-200 rounded-lg shadow-lg z-30 min-w-[220px] py-2"
+              onMouseLeave={() => setOpenDropdown(null)}
+            >
+              {/* Type Header */}
+              <div className="px-4 py-2 border-b border-gray-100">
+                <LocalizedClientLink
+                  href={`/type/${type.handle}`}
+                  onClick={() => {
+                    setOpenDropdown(null)
+                    onClose?.(false)
+                  }}
+                  className="text-sm font-semibold text-gray-700 hover:text-green-700 flex items-center gap-2"
+                >
+                  {type.icon && <span>{type.icon}</span>}
+                  View All {type.name}
+                </LocalizedClientLink>
+              </div>
+
+              {/* Categories */}
+              <div className="max-h-[300px] overflow-y-auto">
+                {type.categories
+                  .filter((cat: CmsCategory) => cat.is_active)
+                  .sort((a: CmsCategory, b: CmsCategory) => a.display_order - b.display_order)
+                  .map((category: CmsCategory) => (
+                    <LocalizedClientLink
+                      key={category.id}
+                      href={`/category/${category.handle}`}
+                      onClick={() => {
+                        setOpenDropdown(null)
+                        onClose?.(false)
+                      }}
+                      className={cn(
+                        "block px-4 py-2 text-sm hover:bg-secondary transition-colors",
+                        isCategoryActive(category.handle) && "bg-secondary font-medium"
+                      )}
+                    >
+                      <span className="flex items-center gap-2">
+                        {category.icon && <span className="text-base">{category.icon}</span>}
+                        {category.name}
+                      </span>
+                    </LocalizedClientLink>
+                  ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Our Producers */}
+      <LocalizedClientLink
+        href="/producers"
+        onClick={() => onClose?.(false)}
+        className={cn(
+          "label-md uppercase px-3 py-2 flex items-center justify-between hover:bg-secondary rounded transition-colors",
+          pathname?.includes("/producers") && "bg-secondary font-semibold"
+        )}
+      >
+        Producers
+      </LocalizedClientLink>
+    </nav>
+  )
+}
+
+export default TypeNavbar

--- a/storefront/src/components/molecules/TypeNavbar/index.ts
+++ b/storefront/src/components/molecules/TypeNavbar/index.ts
@@ -1,0 +1,1 @@
+export { TypeNavbar } from "./TypeNavbar"

--- a/storefront/src/components/molecules/index.ts
+++ b/storefront/src/components/molecules/index.ts
@@ -1,5 +1,6 @@
 import { CategoryNavbar } from "./CategoryNavbar/CategoryNavbar"
 import { PrimeCategoryNavbar } from "./PrimeCategoryNavbar/PrimeCategoryNavbar"
+import { TypeNavbar } from "./TypeNavbar/TypeNavbar"
 import { SelectField } from "./SelectField/SelectField"
 import { Accordion } from "./Accordion/Accordion"
 import { FilterCheckboxOption } from "./FilterCheckboxOption/FilterCheckboxOption"
@@ -47,6 +48,7 @@ export * from "./ImpactDashboard"
 export {
   PrimeCategoryNavbar,
   CategoryNavbar,
+  TypeNavbar,
   SelectField,
   Accordion,
   FilterCheckboxOption,

--- a/storefront/src/components/organisms/Header/Header.tsx
+++ b/storefront/src/components/organisms/Header/Header.tsx
@@ -15,6 +15,7 @@ import { listRegions } from "@/lib/data/regions"
 import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 import { MessageButton } from "@/components/molecules/MessageButton/MessageButton"
 import { SellNowButton } from "@/components/cells/SellNowButton/SellNowButton"
+import { getCmsTaxonomy, FALLBACK_TYPES } from "@/lib/data/cms-taxonomy"
 
 export const Header = async () => {
   const user = await retrieveCustomer()
@@ -35,6 +36,10 @@ export const Header = async () => {
     parentCategories: HttpTypes.StoreProductCategory[]
   }
 
+  // Fetch CMS taxonomy for type-based navigation
+  const cmsTaxonomy = await getCmsTaxonomy()
+  const cmsTypes = cmsTaxonomy.taxonomy.length > 0 ? cmsTaxonomy.taxonomy : FALLBACK_TYPES
+
   return (
     <header>
       <div className="flex py-2 lg:px-8 px-4">
@@ -42,6 +47,7 @@ export const Header = async () => {
           <MobileNavbar
             parentCategories={parentCategories}
             childrenCategories={categories}
+            cmsTypes={cmsTypes}
           />
           <div className="hidden lg:block">
             <SellNowButton />
@@ -76,7 +82,7 @@ export const Header = async () => {
           <CartDropdown />
         </div>
       </div>
-      <Navbar categories={categories} />
+      <Navbar categories={categories} cmsTypes={cmsTypes} />
     </header>
   )
 }

--- a/storefront/src/lib/data/cms-taxonomy.ts
+++ b/storefront/src/lib/data/cms-taxonomy.ts
@@ -1,0 +1,235 @@
+import { sdk } from "@/lib/config"
+
+export interface CmsType {
+  id: string
+  handle: string
+  name: string
+  description: string | null
+  icon: string | null
+  display_order: number
+  is_active: boolean
+  categories?: CmsCategory[]
+}
+
+export interface CmsCategory {
+  id: string
+  type_id: string
+  handle: string
+  name: string
+  description: string | null
+  icon: string | null
+  image_url: string | null
+  display_order: number
+  is_active: boolean
+  tags?: CmsTag[]
+  attributes?: CmsAttribute[]
+}
+
+export interface CmsTag {
+  id: string
+  handle: string
+  name: string
+  tag_type: string
+  icon: string | null
+  color: string | null
+  is_active: boolean
+}
+
+export interface CmsAttribute {
+  id: string
+  handle: string
+  name: string
+  description: string | null
+  input_type: string
+  display_type: string
+  unit: string | null
+  is_filterable: boolean
+  is_required: boolean
+}
+
+export interface CmsTaxonomy {
+  taxonomy: CmsType[]
+  total_types: number
+  total_categories: number
+}
+
+/**
+ * Fetch the complete CMS taxonomy for navigation
+ * Returns all types with their categories
+ */
+export async function getCmsTaxonomy(): Promise<CmsTaxonomy> {
+  try {
+    const response = await sdk.client.fetch<CmsTaxonomy>(
+      "/store/cms-taxonomy",
+      {
+        cache: "force-cache",
+        next: { revalidate: 3600 }, // Cache for 1 hour
+      }
+    )
+    return response
+  } catch (error) {
+    console.error("Failed to fetch CMS taxonomy:", error)
+    // Return empty taxonomy on error
+    return {
+      taxonomy: [],
+      total_types: 0,
+      total_categories: 0,
+    }
+  }
+}
+
+/**
+ * Fetch all CMS types
+ */
+export async function getCmsTypes(): Promise<CmsType[]> {
+  try {
+    const response = await sdk.client.fetch<{ types: CmsType[] }>(
+      "/store/cms-types",
+      {
+        cache: "force-cache",
+        next: { revalidate: 3600 },
+      }
+    )
+    return response.types || []
+  } catch (error) {
+    console.error("Failed to fetch CMS types:", error)
+    return []
+  }
+}
+
+/**
+ * Fetch a single type with its categories
+ */
+export async function getCmsTypeByHandle(handle: string): Promise<CmsType | null> {
+  try {
+    const response = await sdk.client.fetch<{ type: CmsType }>(
+      `/store/cms-types/${handle}`,
+      {
+        cache: "force-cache",
+        next: { revalidate: 300 }, // 5 minute cache
+      }
+    )
+    return response.type || null
+  } catch (error) {
+    console.error(`Failed to fetch CMS type ${handle}:`, error)
+    return null
+  }
+}
+
+/**
+ * Fetch a category with its tags and attributes
+ */
+export async function getCmsCategoryByHandle(handle: string): Promise<CmsCategory | null> {
+  try {
+    const response = await sdk.client.fetch<{ category: CmsCategory }>(
+      `/store/cms-categories/${handle}`,
+      {
+        cache: "force-cache",
+        next: { revalidate: 300 },
+      }
+    )
+    return response.category || null
+  } catch (error) {
+    console.error(`Failed to fetch CMS category ${handle}:`, error)
+    return null
+  }
+}
+
+/**
+ * Fetch tags, optionally filtered by type or category
+ */
+export async function getCmsTags(options?: {
+  tag_type?: string
+  category_id?: string
+}): Promise<CmsTag[]> {
+  try {
+    const queryParams = new URLSearchParams()
+    if (options?.tag_type) queryParams.set("tag_type", options.tag_type)
+    if (options?.category_id) queryParams.set("category_id", options.category_id)
+
+    const url = `/store/cms-tags${queryParams.toString() ? `?${queryParams.toString()}` : ""}`
+
+    const response = await sdk.client.fetch<{ tags: CmsTag[] }>(url, {
+      cache: "force-cache",
+      next: { revalidate: 3600 },
+    })
+    return response.tags || []
+  } catch (error) {
+    console.error("Failed to fetch CMS tags:", error)
+    return []
+  }
+}
+
+// Icon mapping for CMS types (emoji to Lucide icon name mapping)
+export const TYPE_ICONS: Record<string, string> = {
+  "food-produce": "🥬",
+  "prepared-foods-meals": "🍽️",
+  "supplies-goods": "📦",
+  "services-delivery": "🚚",
+  "organizations-partnerships": "🤝",
+  "equipment-tools": "🔧",
+}
+
+// Fallback categories for when CMS is not available
+export const FALLBACK_TYPES: CmsType[] = [
+  {
+    id: "type_food_produce",
+    handle: "food-produce",
+    name: "Food & Produce",
+    description: "Fresh fruits, vegetables, grains, meat, dairy, and beverages",
+    icon: "🥬",
+    display_order: 1,
+    is_active: true,
+    categories: [],
+  },
+  {
+    id: "type_prepared_foods",
+    handle: "prepared-foods-meals",
+    name: "Prepared Foods",
+    description: "Ready-to-eat meals, snacks, and beverages",
+    icon: "🍽️",
+    display_order: 2,
+    is_active: true,
+    categories: [],
+  },
+  {
+    id: "type_supplies_goods",
+    handle: "supplies-goods",
+    name: "Supplies & Goods",
+    description: "Household items, personal care, and pantry staples",
+    icon: "📦",
+    display_order: 3,
+    is_active: true,
+    categories: [],
+  },
+  {
+    id: "type_services_delivery",
+    handle: "services-delivery",
+    name: "Services",
+    description: "Delivery, catering, and logistics",
+    icon: "🚚",
+    display_order: 4,
+    is_active: true,
+    categories: [],
+  },
+  {
+    id: "type_organizations",
+    handle: "organizations-partnerships",
+    name: "Organizations",
+    description: "Food banks, mutual aid, community gardens, and kitchens",
+    icon: "🤝",
+    display_order: 5,
+    is_active: true,
+    categories: [],
+  },
+  {
+    id: "type_equipment_tools",
+    handle: "equipment-tools",
+    name: "Equipment",
+    description: "Kitchen equipment, gardening tools, and machinery",
+    icon: "🔧",
+    display_order: 6,
+    is_active: true,
+    categories: [],
+  },
+]


### PR DESCRIPTION
- Create CMS taxonomy data fetching service with types, categories, tags
- Add TypeNavbar component with dropdown menus for each type
- Update Header to fetch CMS taxonomy and pass to navigation components
- Update Navbar to use TypeNavbar when CMS types are available
- Update MobileNavbar with accordion-style type navigation
- Add fallback types for when CMS is unavailable