### PR TITLE
fix: remove duplicate created_at/updated_at fields from Request model

### DIFF
--- a/backend/src/modules/request/models/request.ts
+++ b/backend/src/modules/request/models/request.ts
@@ -28,8 +28,6 @@ const Request = model.define("request", {
   status: model.enum(RequestStatus).default(RequestStatus.PENDING),
   payload: model.json().default({}),
   notes: model.text().nullable(),
-  created_at: model.dateTime().default(() => new Date()),
-  updated_at: model.dateTime().default(() => new Date()),
 })
 .indexes([
   {


### PR DESCRIPTION
MedusaJS automatically defines these fields on every model, so explicitly defining them causes "Cannot define field(s) created_at,updated_at as they are implicitly defined on every model" error at startup.