### PR TITLE
fix: replace broken @mercurjs/requests import with custom Request module

### DIFF
--- a/backend/src/api/admin/requests/[id]/approve/route.ts
+++ b/backend/src/api/admin/requests/[id]/approve/route.ts
@@ -1,0 +1,107 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { REQUEST_MODULE } from "../../../../../modules/request"
+import RequestModuleService from "../../../../../modules/request/service"
+import { RequestStatus } from "../../../../../modules/request/models"
+import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
+
+/**
+ * Request type identifier for seller creation requests
+ */
+const SELLER_REQUEST_TYPE = "seller_creation"
+
+/**
+ * POST /admin/requests/:id/approve
+ *
+ * Approve a request. For seller creation requests, this will:
+ * 1. Create the seller using MercurJS workflow
+ * 2. Mark the request as accepted
+ */
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const { id } = req.params
+
+  try {
+    const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
+
+    // Get the request
+    const requests = await requestService.listRequests({ id })
+
+    if (requests.length === 0) {
+      res.status(404).json({ message: "Request not found" })
+      return
+    }
+
+    const request = requests[0]
+
+    // Check if already processed
+    if (request.status !== RequestStatus.PENDING) {
+      res.status(400).json({
+        message: `Request has already been ${request.status}`,
+      })
+      return
+    }
+
+    const payload = request.payload as Record<string, unknown>
+
+    // Handle seller creation requests
+    if (payload?.type === SELLER_REQUEST_TYPE) {
+      const authIdentityId = payload.auth_identity_id as string
+      const member = payload.member as { name: string; email: string }
+      const seller = payload.seller as { name: string }
+
+      if (!authIdentityId || !member || !seller) {
+        res.status(400).json({
+          message: "Invalid seller creation request data",
+        })
+        return
+      }
+
+      console.log(`[Approve] Creating seller "${seller.name}" for ${member.email}`)
+
+      // Create the seller using MercurJS workflow
+      const { result: createdSeller } = await createSellerWorkflow.run({
+        container: req.scope,
+        input: {
+          auth_identity_id: authIdentityId,
+          member: {
+            name: member.name,
+            email: member.email,
+          },
+          seller: {
+            name: seller.name,
+          },
+        },
+      })
+
+      console.log(`[Approve] Seller created:`, createdSeller)
+
+      // Mark request as accepted
+      await requestService.acceptRequest(id)
+
+      res.json({
+        message: "Seller registration approved successfully",
+        seller: createdSeller,
+        request: {
+          id,
+          status: RequestStatus.ACCEPTED,
+        },
+      })
+      return
+    }
+
+    // For other request types, just mark as accepted
+    await requestService.acceptRequest(id)
+
+    res.json({
+      message: "Request approved successfully",
+      request: {
+        id,
+        status: RequestStatus.ACCEPTED,
+      },
+    })
+  } catch (error: any) {
+    console.error("[Approve] Error approving request:", error)
+    res.status(500).json({
+      message: error.message || "Failed to approve request",
+    })
+  }
+}

--- a/backend/src/api/admin/requests/[id]/reject/route.ts
+++ b/backend/src/api/admin/requests/[id]/reject/route.ts
@@ -1,0 +1,73 @@
+import { z } from "zod"
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { REQUEST_MODULE } from "../../../../../modules/request"
+import RequestModuleService from "../../../../../modules/request/service"
+import { RequestStatus } from "../../../../../modules/request/models"
+
+const rejectSchema = z.object({
+  reason: z.string().optional(),
+})
+
+/**
+ * POST /admin/requests/:id/reject
+ *
+ * Reject a request with an optional reason.
+ */
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const { id } = req.params
+
+  try {
+    const { reason } = rejectSchema.parse(req.body || {})
+
+    const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
+
+    // Get the request
+    const requests = await requestService.listRequests({ id })
+
+    if (requests.length === 0) {
+      res.status(404).json({ message: "Request not found" })
+      return
+    }
+
+    const request = requests[0]
+
+    // Check if already processed
+    if (request.status !== RequestStatus.PENDING) {
+      res.status(400).json({
+        message: `Request has already been ${request.status}`,
+      })
+      return
+    }
+
+    // Update notes with rejection reason if provided
+    if (reason) {
+      await requestService.updateRequests(
+        { id },
+        { notes: `${request.notes || ""}\n\nRejection reason: ${reason}`.trim() }
+      )
+    }
+
+    // Mark request as rejected
+    await requestService.rejectRequest(id)
+
+    console.log(`[Reject] Request ${id} rejected${reason ? `: ${reason}` : ""}`)
+
+    res.json({
+      message: "Request rejected",
+      request: {
+        id,
+        status: RequestStatus.REJECTED,
+        reason,
+      },
+    })
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Validation failed", errors: error.errors })
+      return
+    }
+    console.error("[Reject] Error rejecting request:", error)
+    res.status(500).json({
+      message: error.message || "Failed to reject request",
+    })
+  }
+}

--- a/backend/src/api/admin/requests/[id]/route.ts
+++ b/backend/src/api/admin/requests/[id]/route.ts
@@ -58,17 +58,14 @@ export async function PATCH(req: AuthenticatedMedusaRequest, res: MedusaResponse
       return
     }
 
-    const updateData: Record<string, unknown> = {
-      id,
-      updated_at: new Date(),
-    }
+    const updateData: Record<string, unknown> = {}
 
     if (data.status) updateData.status = data.status
     if (data.provider_id !== undefined) updateData.provider_id = data.provider_id
     if (data.payload) updateData.payload = data.payload
     if (data.notes !== undefined) updateData.notes = data.notes
 
-    const updated = await requestService.updateRequests(updateData)
+    const updated = await requestService.updateRequests({ id }, updateData)
 
     res.json({
       request: updated,

--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -50,11 +50,10 @@ class RequestModuleService extends MedusaService({
    * Update request status
    */
   async updateRequestStatus(requestId: string, status: RequestStatus) {
-    return this.updateRequests({
-      id: requestId,
-      status,
-      updated_at: new Date(),
-    })
+    return this.updateRequests(
+      { id: requestId },
+      { status }
+    )
   }
 
   /**


### PR DESCRIPTION
The vendor registration was failing because @mercurjs/requests plugin was removed but the /vendor/sellers route still imported from it. This change:

- Updates vendor sellers route to use custom Request module instead of @mercurjs/requests workflow
- Adds /admin/requests/:id/approve endpoint for approving seller requests
- Adds /admin/requests/:id/reject endpoint for rejecting requests
- Fixes updateRequests method calls to use correct selector/data pattern