### PR TITLE
fix: correct seller ID reference in metadata creation

### DIFF
--- a/backend/src/api/admin/requests/[id]/approve/route.ts
+++ b/backend/src/api/admin/requests/[id]/approve/route.ts
@@ -87,7 +87,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
         await createSellerMetadataWorkflow.run({
           container: req.scope,
           input: {
-            seller_id: createdSeller.seller.id,
+            seller_id: createdSeller.id,
             vendor_type: vendorTypeEnum,
           },
         })


### PR DESCRIPTION
Change createdSeller.seller.id to createdSeller.id since the workflow returns the seller object directly, not nested under a 'seller' property.