### PR TITLE
fix: correct request data structure in admin panel

### DIFF
--- a/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
@@ -19,7 +19,7 @@ export function RequestSellerDetail({ request, open, close }: Props) {
   if (!request) {
     return null;
   }
-  const requestData = request.data;
+  const requestData = request.payload;
 
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);
@@ -62,7 +62,13 @@ export function RequestSellerDetail({ request, open, close }: Props) {
           <fieldset className="mt-2">
             <legend className="mb-2">Email</legend>
             <Container>
-              <Text>{requestData?.provider_identity_id ?? "N/A"}</Text>
+              <Text>{requestData?.member?.email ?? "N/A"}</Text>
+            </Container>
+          </fieldset>
+          <fieldset className="mt-2">
+            <legend className="mb-2">Vendor Type</legend>
+            <Container>
+              <Text className="capitalize">{requestData?.vendor_type ?? "producer"}</Text>
             </Container>
           </fieldset>
           <Container className="mt-4">

--- a/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
@@ -75,7 +75,7 @@ export const RequestSellerList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.data as Record<string, unknown>;
+              const requestData = request.payload as Record<string, unknown>;
 
               return (
                 <Table.Row key={request.id}>
@@ -86,7 +86,10 @@ export const RequestSellerList = () => {
                     }
                   </Table.Cell>
                   <Table.Cell>
-                    {(requestData.provider_identity_id as string) ?? "N/A"}
+                    {
+                      ((requestData.member as Record<string, unknown>)
+                        ?.email as string) ?? "N/A"
+                    }
                   </Table.Cell>
                   <Table.Cell>
                     <div className="flex items-center gap-2">

--- a/admin-panel/src/types/requests/common.ts
+++ b/admin-panel/src/types/requests/common.ts
@@ -3,7 +3,7 @@ import type { MemberDTO, SellerDTO } from "@custom-types/seller";
 export type RequestDTO = {
   id: string;
   type: string;
-  data: Record<string, unknown>;
+  payload: Record<string, unknown>;
   submitter_id: string;
   reviewer_id: string;
   reviewer_note: string;
@@ -16,7 +16,7 @@ export interface AdminRequest {
   created_at?: string;
   updated_at?: string;
   type?: string;
-  data?: object;
+  payload?: object;
   submitter_id?: string;
   reviewer_id?: string | null;
   reviewer_note?: string | null;
@@ -79,9 +79,11 @@ export interface AdminUpdateOrderReturnRequest {
 }
 
 export interface AdminSellerRequest extends RequestDTO {
-  data: {
+  payload: {
+    type: "seller_creation";
+    auth_identity_id: string;
     member: MemberDTO;
     seller: SellerDTO;
-    provider_identity_id?: string;
+    vendor_type?: "producer" | "garden" | "maker" | "restaurant" | "mutual_aid";
   };
 }


### PR DESCRIPTION
Changes:
- Update TypeScript types to use 'payload' instead of 'data'
- Fix request-seller-list to access request.payload correctly
- Fix request-seller-detail to show member email instead of provider_identity_id
- Add vendor_type field display in seller request detail view
- Update AdminSellerRequest type to include vendor_type and auth_identity_id

This aligns the frontend with the backend Request model which stores data in the 'payload' field, fixing the runtime error when viewing seller registration requests in the admin panel.