### PR TITLE
fix: add null safety checks for request payload

### DIFF
--- a/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
@@ -75,19 +75,19 @@ export const RequestSellerList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.payload as Record<string, unknown>;
+              const requestData = request.payload as Record<string, unknown> | undefined;
 
               return (
                 <Table.Row key={request.id}>
                   <Table.Cell>
                     {
-                      (requestData.seller as Record<string, unknown>)
-                        ?.name as string
+                      ((requestData?.seller as Record<string, unknown> | undefined)
+                        ?.name as string) ?? "N/A"
                     }
                   </Table.Cell>
                   <Table.Cell>
                     {
-                      ((requestData.member as Record<string, unknown>)
+                      ((requestData?.member as Record<string, unknown> | undefined)
                         ?.email as string) ?? "N/A"
                     }
                   </Table.Cell>


### PR DESCRIPTION
Add optional chaining to handle cases where request.payload might be undefined, preventing 'Cannot read properties of undefined' errors when rendering the seller request list in the admin panel.