### PR TITLE
fix: add backward compatibility for old request payload format

### DIFF
--- a/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
@@ -21,6 +21,26 @@ export function RequestSellerDetail({ request, open, close }: Props) {
   }
   const requestData = request.payload;
 
+  // Handle both old and new payload formats
+  const sellerName =
+    requestData?.seller?.name ||
+    requestData?.name ||
+    "-";
+
+  const memberName =
+    requestData?.member?.name ||
+    requestData?.name ||
+    "-";
+
+  const memberEmail =
+    requestData?.member?.email ||
+    requestData?.email ||
+    "N/A";
+
+  const vendorType =
+    requestData?.vendor_type ||
+    "producer";
+
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);
 
@@ -50,25 +70,25 @@ export function RequestSellerDetail({ request, open, close }: Props) {
           <fieldset>
             <legend className="mb-2">Seller name</legend>
             <Container>
-              <Text>{requestData?.seller?.name ?? "-"}</Text>
+              <Text>{sellerName}</Text>
             </Container>
           </fieldset>
           <fieldset className="mt-2">
             <legend className="mb-2">Member</legend>
             <Container>
-              <Text>{requestData?.member?.name ?? "-"}</Text>
+              <Text>{memberName}</Text>
             </Container>
           </fieldset>
           <fieldset className="mt-2">
             <legend className="mb-2">Email</legend>
             <Container>
-              <Text>{requestData?.member?.email ?? "N/A"}</Text>
+              <Text>{memberEmail}</Text>
             </Container>
           </fieldset>
           <fieldset className="mt-2">
             <legend className="mb-2">Vendor Type</legend>
             <Container>
-              <Text className="capitalize">{requestData?.vendor_type ?? "producer"}</Text>
+              <Text className="capitalize">{vendorType}</Text>
             </Container>
           </fieldset>
           <Container className="mt-4">

--- a/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
@@ -77,20 +77,21 @@ export const RequestSellerList = () => {
             {requests?.map((request) => {
               const requestData = request.payload as Record<string, unknown> | undefined;
 
+              // Handle both old and new payload formats
+              const sellerName =
+                ((requestData?.seller as Record<string, unknown> | undefined)?.name as string) ||
+                (requestData?.name as string) ||
+                "N/A";
+
+              const memberEmail =
+                ((requestData?.member as Record<string, unknown> | undefined)?.email as string) ||
+                (requestData?.email as string) ||
+                "N/A";
+
               return (
                 <Table.Row key={request.id}>
-                  <Table.Cell>
-                    {
-                      ((requestData?.seller as Record<string, unknown> | undefined)
-                        ?.name as string) ?? "N/A"
-                    }
-                  </Table.Cell>
-                  <Table.Cell>
-                    {
-                      ((requestData?.member as Record<string, unknown> | undefined)
-                        ?.email as string) ?? "N/A"
-                    }
-                  </Table.Cell>
+                  <Table.Cell>{sellerName}</Table.Cell>
+                  <Table.Cell>{memberEmail}</Table.Cell>
                   <Table.Cell>
                     <div className="flex items-center gap-2">
                       <History />


### PR DESCRIPTION
Handle both old and new payload structures:
- Old format: payload.name, payload.email (flat structure)
- New format: payload.seller.name, payload.member.email (nested structure)

This ensures that existing seller requests created before the payload structure change will still display correctly in the admin panel, while new requests with the updated structure will also work.