### PR TITLE
fix: handle legacy requests with undefined payload

### DIFF
--- a/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
@@ -21,25 +21,32 @@ export function RequestSellerDetail({ request, open, close }: Props) {
   }
   const requestData = request.payload;
 
+  // Check if this is a legacy request with no payload
+  const isLegacyRequest = !requestData || Object.keys(requestData).length === 0;
+
   // Handle both old and new payload formats
-  const sellerName =
-    requestData?.seller?.name ||
-    requestData?.name ||
-    "-";
+  const sellerName = isLegacyRequest
+    ? "Legacy request - no data available"
+    : (requestData?.seller?.name ||
+       requestData?.name ||
+       "-");
 
-  const memberName =
-    requestData?.member?.name ||
-    requestData?.name ||
-    "-";
+  const memberName = isLegacyRequest
+    ? "Legacy request - no data available"
+    : (requestData?.member?.name ||
+       requestData?.name ||
+       "-");
 
-  const memberEmail =
-    requestData?.member?.email ||
-    requestData?.email ||
-    "N/A";
+  const memberEmail = isLegacyRequest
+    ? "Legacy request - no data available"
+    : (requestData?.member?.email ||
+       requestData?.email ||
+       "N/A");
 
-  const vendorType =
-    requestData?.vendor_type ||
-    "producer";
+  const vendorType = isLegacyRequest
+    ? "unknown"
+    : (requestData?.vendor_type ||
+       "producer");
 
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);
@@ -67,6 +74,16 @@ export function RequestSellerDetail({ request, open, close }: Props) {
           <Drawer.Title>Review seller request</Drawer.Title>
         </Drawer.Header>
         <Drawer.Body className="p-4">
+          {isLegacyRequest && (
+            <Container className="mb-4 bg-ui-bg-subtle border border-ui-border-base">
+              <div className="flex items-center gap-2">
+                <InformationCircle className="text-ui-fg-muted" />
+                <Text className="text-ui-fg-muted">
+                  <strong>Legacy Request:</strong> This request was created before the current data structure was implemented. Request details are not available.
+                </Text>
+              </div>
+            </Container>
+          )}
           <fieldset>
             <legend className="mb-2">Seller name</legend>
             <Container>

--- a/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
@@ -77,6 +77,35 @@ export const RequestSellerList = () => {
             {requests?.map((request) => {
               const requestData = request.payload as Record<string, unknown> | undefined;
 
+              // Handle legacy requests with no payload data
+              if (!requestData || Object.keys(requestData).length === 0) {
+                return (
+                  <Table.Row key={request.id}>
+                    <Table.Cell className="text-ui-fg-muted italic">
+                      Legacy request - no data
+                    </Table.Cell>
+                    <Table.Cell className="text-ui-fg-muted italic">
+                      Legacy request - no data
+                    </Table.Cell>
+                    <Table.Cell>
+                      <div className="flex items-center gap-2">
+                        <History />
+                        {formatDate(request.created_at!)}
+                      </div>
+                    </Table.Cell>
+                    <Table.Cell>
+                      {getRequestStatusBadge(request.status!)}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <RequestMenu
+                        handleDetail={handleDetail}
+                        request={request}
+                      />
+                    </Table.Cell>
+                  </Table.Row>
+                );
+              }
+
               // Handle both old and new payload formats
               const sellerName =
                 ((requestData?.seller as Record<string, unknown> | undefined)?.name as string) ||


### PR DESCRIPTION
The debug logging revealed that old requests have payload: undefined (NULL in database). These requests were created before the current payload structure was implemented.

Changes:
- Display 'Legacy request - no data' for requests with no payload
- Add warning banner in detail view for legacy requests
- Handle empty/undefined payload gracefully
- Prevent runtime errors when payload is NULL

New requests created after the registration fixes will have properly structured payload data with seller, member, and vendor_type fields.