### PR TITLE
fix: replace request.data with request.payload across all request types

### DIFF
--- a/admin-panel/src/routes/requests/request-product-category-list/components/product-category-detail.tsx
+++ b/admin-panel/src/routes/requests/request-product-category-list/components/product-category-detail.tsx
@@ -20,7 +20,7 @@ export function ProductCategoryRequestDetail({ request, open, close }: Props) {
   if (!request) {
     return null;
   }
-  const requestData = request.data as ProductCategoryDTO;
+  const requestData = request.payload as ProductCategoryDTO;
 
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);

--- a/admin-panel/src/routes/requests/request-product-category-list/request-product-category-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-category-list/request-product-category-list.tsx
@@ -76,7 +76,7 @@ export const RequestProductCategoryList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.data as ProductCategoryDTO;
+              const requestData = request.payload as ProductCategoryDTO;
 
               return (
                 <Table.Row key={request.id}>

--- a/admin-panel/src/routes/requests/request-product-collection-list/components/product-collection-detail.tsx
+++ b/admin-panel/src/routes/requests/request-product-collection-list/components/product-collection-detail.tsx
@@ -24,7 +24,7 @@ export function ProductCollectionRequestDetail({
   if (!request) {
     return null;
   }
-  const requestData = request.data as ProductCollectionDTO;
+  const requestData = request.payload as ProductCollectionDTO;
 
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);

--- a/admin-panel/src/routes/requests/request-product-collection-list/request-product-collection-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-collection-list/request-product-collection-list.tsx
@@ -77,7 +77,7 @@ export const RequestProductCollectionList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.data as ProductCollectionDTO;
+              const requestData = request.payload as ProductCollectionDTO;
 
               return (
                 <Table.Row key={request.id}>

--- a/admin-panel/src/routes/requests/request-product-list/components/product-summary.tsx
+++ b/admin-panel/src/routes/requests/request-product-list/components/product-summary.tsx
@@ -18,9 +18,9 @@ export function ProductSummaryDetail({ request, open, close }: Props) {
     return null;
   }
 
-  const product_id = (request.data as Record<string, unknown>).product_id || "";
+  const product_id = (request.payload as Record<string, unknown>)?.product_id || "";
   const navigate = useNavigate();
-  const requestData = request.data as ProductDTO;
+  const requestData = request.payload as ProductDTO;
 
   return (
     <Drawer open={open} onOpenChange={close}>

--- a/admin-panel/src/routes/requests/request-product-list/request-product-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-list/request-product-list.tsx
@@ -113,7 +113,7 @@ const ProductRequestsRow = ({
   handleDetail: (request: AdminRequest) => void;
 }) => {
   const navigate = useNavigate();
-  const requestData = request.data as ProductDTO;
+  const requestData = request.payload as ProductDTO;
 
   return (
     <Table.Row key={request.id}>

--- a/admin-panel/src/routes/requests/request-product-tag-list/components/product-tag-detail.tsx
+++ b/admin-panel/src/routes/requests/request-product-tag-list/components/product-tag-detail.tsx
@@ -20,7 +20,7 @@ export function ProductTagRequestDetail({ request, open, close }: Props) {
   if (!request) {
     return null;
   }
-  const requestData = request.data as ProductTagDTO;
+  const requestData = request.payload as ProductTagDTO;
 
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);

--- a/admin-panel/src/routes/requests/request-product-tag-list/request-product-tag-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-tag-list/request-product-tag-list.tsx
@@ -75,7 +75,7 @@ export const RequestProductTagList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.data as ProductTagDTO;
+              const requestData = request.payload as ProductTagDTO;
 
               return (
                 <Table.Row key={request.id}>

--- a/admin-panel/src/routes/requests/request-product-type-list/components/product-type-detail.tsx
+++ b/admin-panel/src/routes/requests/request-product-type-list/components/product-type-detail.tsx
@@ -20,7 +20,7 @@ export function ProductTypeRequestDetail({ request, open, close }: Props) {
   if (!request) {
     return null;
   }
-  const requestData = request.data as ProductTypeDTO;
+  const requestData = request.payload as ProductTypeDTO;
 
   const [promptOpen, setPromptOpen] = useState(false);
   const [requestAccept, setRequestAccept] = useState(false);

--- a/admin-panel/src/routes/requests/request-product-type-list/request-product-type-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-type-list/request-product-type-list.tsx
@@ -76,7 +76,7 @@ export const RequestProductTypeList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.data as ProductTypeDTO;
+              const requestData = request.payload as ProductTypeDTO;
 
               return (
                 <Table.Row key={request.id}>

--- a/admin-panel/src/routes/requests/request-product-update-list/request-product-update-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-update-list/request-product-update-list.tsx
@@ -26,7 +26,7 @@ export const RequestProductUpdateList = () => {
 
   const handleDetail = (request: AdminRequest) => {
     const product_id =
-      (request.data as Record<string, unknown>).product_id || "";
+      (request.payload as Record<string, unknown>).product_id || "";
     navigate(`/products/${product_id}`);
   };
 
@@ -65,7 +65,7 @@ export const RequestProductUpdateList = () => {
           </Table.Header>
           <Table.Body>
             {requests?.map((request) => {
-              const requestData = request.data as ProductDTO;
+              const requestData = request.payload as ProductDTO;
 
               return (
                 <Table.Row key={request.id}>


### PR DESCRIPTION
Updated all admin panel request components to use the correct 'payload' field instead of 'data' field. This fixes data display issues for:
- Product requests
- Product category requests
- Product collection requests
- Product tag requests
- Product type requests
- Product update requests

This aligns with the backend Request model which stores data in the 'payload' field and matches the previous fix for seller requests.