### PR TITLE
fix: add security headers middleware to all API routes

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -5,6 +5,7 @@ import type {
   MedusaNextFunction,
 } from "@medusajs/framework/http"
 import { z } from "zod"
+import { defaultSecurityHeaders } from "../shared/security-headers"
 
 // Basic email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -144,6 +145,11 @@ const PostCartItemsRentalsBody = z.object({
 
 export default defineMiddlewares({
   routes: [
+    // Apply security headers to all routes
+    {
+      matcher: "/*",
+      middlewares: [defaultSecurityHeaders],
+    },
     // Product feed - public XML feed for Google Shopping/Facebook
     {
       matcher: "/product-feed",


### PR DESCRIPTION
Import and apply the security headers middleware globally to all routes. This ensures all API endpoints have proper security headers including HSTS, CSP, X-Frame-Options, and other security best practices.