### PR TITLE
fix: remove unsupported links config and fix updateRequests return type

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -321,29 +321,6 @@ module.exports = defineConfig({
         ]
       : []),
   ],
-  links: [
-    // Link seller to seller metadata for vendor_type and extended fields
-    {
-      resolve: './src/links/seller-metadata',
-    },
-    // Note: Wishlist model renamed from customer_wishlist to shopper_wishlist
-    // to avoid alias collision with the Customer module
-
-    // Rental module links
-    {
-      resolve: './src/links/product-rental-config',
-    },
-    {
-      resolve: './src/links/rental-variant',
-    },
-    {
-      resolve: './src/links/rental-order',
-    },
-    {
-      resolve: './src/links/rental-line-item',
-    },
-    {
-      resolve: './src/links/customer-rental',
-    },
-  ],
+  // Note: Links are auto-discovered from src/links directory in MedusaJS v2
+  // No explicit registration needed here
 })

--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -43,7 +43,7 @@ class RequestModuleService extends MedusaService({
    * Accept a request (update status to ACCEPTED)
    */
   async acceptRequest(id: string) {
-    const [request] = await this.updateRequests(
+    const request = await this.updateRequests(
       { id },
       { status: RequestStatus.ACCEPTED }
     )
@@ -54,7 +54,7 @@ class RequestModuleService extends MedusaService({
    * Reject a request (update status to REJECTED)
    */
   async rejectRequest(id: string) {
-    const [request] = await this.updateRequests(
+    const request = await this.updateRequests(
       { id },
       { status: RequestStatus.REJECTED }
     )
@@ -65,7 +65,7 @@ class RequestModuleService extends MedusaService({
    * Cancel a request (update status to CANCELLED)
    */
   async cancelRequest(id: string) {
-    const [request] = await this.updateRequests(
+    const request = await this.updateRequests(
       { id },
       { status: RequestStatus.CANCELLED }
     )


### PR DESCRIPTION
- Remove 'links' property from medusa-config.ts as it's not supported in the defineConfig schema (links are auto-discovered from src/links)
- Fix updateRequests calls in RequestModuleService - the method returns a single object, not an array, so remove array destructuring