### PR TITLE
fix: run database migrations before seed script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "medusa build",
     "ib": "init-backend",
-    "start": "pnpm seed && medusa db:migrate --execute-safe-links && init-backend && cd .medusa/server && medusa start",
+    "start": "medusa db:migrate --execute-safe-links && pnpm seed && init-backend && cd .medusa/server && medusa start",
     "dev": "medusa develop",
     "seed": "medusa exec ./src/scripts/seed.ts",
     "test:integration:http": "TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",


### PR DESCRIPTION
The start script was running seed before migrations, causing failures when new columns (like raw_min_quantity from Medusa 2.12.5) didn't exist yet.