### PR TITLE
fix: update Next.js 15 Server Components to use async params and headers

### DIFF
--- a/storefront/src/app/[locale]/(main)/layout.tsx
+++ b/storefront/src/app/[locale]/(main)/layout.tsx
@@ -10,10 +10,10 @@ export default async function RootLayout({
   params,
 }: {
   children: React.ReactNode
-  params: { locale: string }
+  params: Promise<{ locale: string }>
 }) {
   const ROCKETCHAT_URL = process.env.NEXT_PUBLIC_ROCKETCHAT_URL
-  const { locale } = params
+  const { locale } = await params
 
   let user = null
   let regionIsValid = false

--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -21,11 +21,11 @@ import { toHreflang } from "@/lib/helpers/hreflang"
 export async function generateMetadata({
   params,
 }: {
-  params: { locale: string }
+  params: Promise<{ locale: string }>
 }): Promise<Metadata> {
-  const { locale } = params
+  const { locale } = await params
 
-  const headersList = headers()
+  const headersList = await headers()
   const host = headersList.get("host")
   const protocol = headersList.get("x-forwarded-proto") || "https"
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`
@@ -108,11 +108,11 @@ export async function generateMetadata({
 export default async function Home({
   params,
 }: {
-  params: { locale: string }
+  params: Promise<{ locale: string }>
 }) {
-  const { locale } = params
+  const { locale } = await params
 
-  const headersList = headers()
+  const headersList = await headers()
   const host = headersList.get("host")
   const protocol = headersList.get("x-forwarded-proto") || "https"
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`

--- a/storefront/src/app/layout.tsx
+++ b/storefront/src/app/layout.tsx
@@ -36,9 +36,9 @@ export default async function RootLayout({
   params,
 }: Readonly<{
   children: React.ReactNode
-  params: { locale: string }
+  params: Promise<{ locale: string }>
 }>) {
-  const { locale } = params
+  const { locale } = await params
   const cart = await retrieveCart()
   const ALGOLIA_APP = process.env.NEXT_PUBLIC_ALGOLIA_ID
   const htmlLang = locale || "en"


### PR DESCRIPTION
- Change params type from `{ locale: string }` to `Promise<{ locale: string }>` in layouts and pages
- Add `await` for params destructuring in root layout, main layout, and home page
- Add `await` for headers() calls in generateMetadata and Home component

Next.js 15+ with React 19 requires params and headers() to be awaited in Server Components.