### PR TITLE
fix: sync vendor, seller, and producer information in admin panel

### DIFF
--- a/admin-panel/src/hooks/table/columns/use-seller-table-columns.tsx
+++ b/admin-panel/src/hooks/table/columns/use-seller-table-columns.tsx
@@ -1,9 +1,11 @@
 import { createColumnHelper } from "@tanstack/react-table";
 import { useMemo } from "react";
+import { Badge } from "@medusajs/ui";
 
 import { formatDate } from "../../../lib/date";
 import { VendorSeller } from "../../../types";
 import { SellerStatusBadge } from "../../../components/common/seller-status-badge";
+import { VendorTypeLabels } from "../../../types/domain";
 
 const columnHelper = createColumnHelper<VendorSeller>();
 
@@ -21,11 +23,33 @@ export const useSellersTableColumns = () => {
         cell: ({ row }) => row.original.name,
       }),
       columnHelper.display({
+        id: "vendor_type",
+        header: "Vendor Type",
+        cell: ({ row }) => {
+          const vendorType = row.original.seller_metadata?.vendor_type;
+          if (!vendorType) return "-";
+          const label = VendorTypeLabels[vendorType as keyof typeof VendorTypeLabels] || vendorType;
+          return <Badge color="blue">{label}</Badge>;
+        },
+      }),
+      columnHelper.display({
         id: "store_status",
         header: "Account Status",
         cell: ({ row }) => (
           <SellerStatusBadge status={row.original.store_status || "-"} />
         ),
+      }),
+      columnHelper.display({
+        id: "verified",
+        header: "Verified",
+        cell: ({ row }) => {
+          const verified = row.original.seller_metadata?.verified;
+          return verified ? (
+            <Badge color="green">Yes</Badge>
+          ) : (
+            <Badge color="orange">No</Badge>
+          );
+        },
       }),
       columnHelper.display({
         id: "created_at",

--- a/admin-panel/src/routes/sellers/common/components/seller-general-section.tsx
+++ b/admin-panel/src/routes/sellers/common/components/seller-general-section.tsx
@@ -1,9 +1,10 @@
 import { PencilSquare, User } from "@medusajs/icons";
-import { Container, Divider, Heading, Text, usePrompt } from "@medusajs/ui";
+import { Badge, Container, Divider, Heading, Text, usePrompt } from "@medusajs/ui";
 
 import { useNavigate } from "react-router-dom";
 
 import type { VendorSeller } from "@custom-types/seller";
+import { VendorTypeLabels } from "@custom-types/domain";
 
 import { ActionsButton } from "@components/common/actions-button";
 import { SellerStatusBadge } from "@components/common/seller-status-badge";
@@ -44,6 +45,10 @@ export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
     }
   };
 
+  const vendorTypeLabel = seller.seller_metadata?.vendor_type
+    ? VendorTypeLabels[seller.seller_metadata.vendor_type as keyof typeof VendorTypeLabels] || seller.seller_metadata.vendor_type
+    : "Not set";
+
   return (
     <>
       <div>
@@ -52,6 +57,12 @@ export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
             <Heading>{seller.email || seller.name}</Heading>
             <div className="flex items-center gap-2">
               <SellerStatusBadge status={seller.store_status || "pending"} />
+              {seller.seller_metadata?.verified && (
+                <Badge color="green">Verified</Badge>
+              )}
+              {seller.seller_metadata?.featured && (
+                <Badge color="purple">Featured</Badge>
+              )}
               <ActionsButton
                 actions={[
                   {
@@ -103,6 +114,24 @@ export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
               </Text>
               <Text className="w-1/2">{seller.description}</Text>
             </div>
+            <Divider />
+            <div className="flex px-8 py-4">
+              <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                Vendor Type
+              </Text>
+              <Text className="w-1/2">{vendorTypeLabel}</Text>
+            </div>
+            {seller.seller_metadata?.growing_region && (
+              <>
+                <Divider />
+                <div className="flex px-8 py-4">
+                  <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                    Growing Region
+                  </Text>
+                  <Text className="w-1/2">{seller.seller_metadata.growing_region}</Text>
+                </div>
+              </>
+            )}
           </div>
         </Container>
         <Container className="px-0">
@@ -146,6 +175,76 @@ export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
           </div>
         </Container>
       </div>
+      {seller.producer && (
+        <Container className="px-0 mt-4">
+          <div className="flex items-center justify-between px-8 py-4">
+            <div>
+              <Heading>Producer Information</Heading>
+            </div>
+          </div>
+          <div>
+            <Divider />
+            <div className="flex px-8 py-4">
+              <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                Farm Name
+              </Text>
+              <Text className="w-1/2">{seller.producer.name}</Text>
+            </div>
+            {seller.producer.region && (
+              <>
+                <Divider />
+                <div className="flex px-8 py-4">
+                  <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                    Region
+                  </Text>
+                  <Text className="w-1/2">{seller.producer.region}</Text>
+                </div>
+              </>
+            )}
+            {seller.producer.farm_size_acres && (
+              <>
+                <Divider />
+                <div className="flex px-8 py-4">
+                  <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                    Farm Size
+                  </Text>
+                  <Text className="w-1/2">{seller.producer.farm_size_acres} acres</Text>
+                </div>
+              </>
+            )}
+            {seller.producer.practices && seller.producer.practices.length > 0 && (
+              <>
+                <Divider />
+                <div className="flex px-8 py-4">
+                  <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                    Practices
+                  </Text>
+                  <div className="w-1/2 flex flex-wrap gap-1">
+                    {seller.producer.practices.map((practice) => (
+                      <Badge key={practice} color="blue">
+                        {practice}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+            <Divider />
+            <div className="flex px-8 py-4">
+              <Text className="w-1/2 font-medium text-ui-fg-subtle">
+                Verified
+              </Text>
+              <Text className="w-1/2">
+                {seller.producer.verified ? (
+                  <Badge color="green">Yes</Badge>
+                ) : (
+                  <Badge color="orange">No</Badge>
+                )}
+              </Text>
+            </div>
+          </div>
+        </Container>
+      )}
     </>
   );
 };

--- a/admin-panel/src/routes/sellers/seller-list/seller-list.tsx
+++ b/admin-panel/src/routes/sellers/seller-list/seller-list.tsx
@@ -46,7 +46,6 @@ export const SellersList = () => {
 
   const { sellers, count, isLoading } = useSellers(
     {
-      fields: "id,email,name,created_at,store_status",
       ...searchParams,
     },
     {

--- a/admin-panel/src/types/seller/common.ts
+++ b/admin-panel/src/types/seller/common.ts
@@ -84,6 +84,62 @@ export interface VendorSeller {
   country_code?: string | null;
   tax_id?: string | null;
   members?: VendorMember[];
+  // Extended fields from backend links
+  seller_metadata?: SellerMetadata | null;
+  producer?: ProducerInfo | null;
+}
+
+export interface SellerMetadata {
+  id: string;
+  seller_id: string;
+  vendor_type: string;
+  business_registration_number?: string | null;
+  tax_classification?: string | null;
+  social_links?: Record<string, string> | null;
+  storefront_links?: Record<string, string> | null;
+  website_url?: string | null;
+  farm_practices?: Record<string, any> | null;
+  certifications?: Record<string, any>[] | null;
+  growing_region?: string | null;
+  cuisine_types?: string[] | null;
+  service_types?: string[] | null;
+  featured: boolean;
+  verified: boolean;
+  rating?: number | null;
+  review_count?: number;
+  metadata?: Record<string, any> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProducerInfo {
+  id: string;
+  seller_id: string;
+  name: string;
+  handle: string;
+  description?: string | null;
+  region?: string | null;
+  state?: string | null;
+  country_code?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  farm_size_acres?: number | null;
+  year_established?: number | null;
+  practices?: string[] | null;
+  certifications?: any[] | null;
+  story?: string | null;
+  photo?: string | null;
+  cover_image?: string | null;
+  gallery?: string[] | null;
+  website?: string | null;
+  social_links?: Record<string, string> | null;
+  public_profile_enabled: boolean;
+  featured: boolean;
+  verified: boolean;
+  verified_at?: string | null;
+  metadata?: Record<string, any> | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface VendorMember {

--- a/backend/src/api/admin/sellers/[id]/customer-groups/route.ts
+++ b/backend/src/api/admin/sellers/[id]/customer-groups/route.ts
@@ -1,0 +1,58 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RouteParams = {
+  id: string
+}
+
+/**
+ * GET /admin/sellers/:id/customer-groups
+ *
+ * Get all customer groups for a specific seller
+ */
+export const GET = async (
+  req: MedusaRequest<unknown, RouteParams>,
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Get requested fields or use defaults
+  const requestedFields = req.query.fields as string | undefined
+  const fields = requestedFields
+    ? requestedFields.split(",").map((f) => f.trim())
+    : ["*"]
+
+  // First verify the seller exists
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields: ["id"],
+    filters: { id },
+  })
+
+  if (!sellers || sellers.length === 0) {
+    return res.status(404).json({
+      message: `Seller with ID ${id} not found`,
+    })
+  }
+
+  // Get all customer groups for this seller
+  const { data: customerGroups, metadata } = await query.graph({
+    entity: "customer_group",
+    fields,
+    filters: {
+      seller_id: id,
+    },
+    pagination: {
+      skip: req.query.offset ? Number(req.query.offset) : 0,
+      take: req.query.limit ? Number(req.query.limit) : 50,
+    },
+  })
+
+  return res.json({
+    customer_groups: customerGroups || [],
+    count: metadata?.count || 0,
+    limit: metadata?.take || 50,
+    offset: metadata?.skip || 0,
+  })
+}

--- a/backend/src/api/admin/sellers/[id]/orders/route.ts
+++ b/backend/src/api/admin/sellers/[id]/orders/route.ts
@@ -1,0 +1,58 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RouteParams = {
+  id: string
+}
+
+/**
+ * GET /admin/sellers/:id/orders
+ *
+ * Get all orders for a specific seller
+ */
+export const GET = async (
+  req: MedusaRequest<unknown, RouteParams>,
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Get requested fields or use defaults
+  const requestedFields = req.query.fields as string | undefined
+  const fields = requestedFields
+    ? requestedFields.split(",").map((f) => f.trim())
+    : ["*"]
+
+  // First verify the seller exists
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields: ["id"],
+    filters: { id },
+  })
+
+  if (!sellers || sellers.length === 0) {
+    return res.status(404).json({
+      message: `Seller with ID ${id} not found`,
+    })
+  }
+
+  // Get all orders for this seller
+  const { data: orders, metadata } = await query.graph({
+    entity: "order",
+    fields,
+    filters: {
+      seller_id: id,
+    },
+    pagination: {
+      skip: req.query.offset ? Number(req.query.offset) : 0,
+      take: req.query.limit ? Number(req.query.limit) : 50,
+    },
+  })
+
+  return res.json({
+    orders: orders || [],
+    count: metadata?.count || 0,
+    limit: metadata?.take || 50,
+    offset: metadata?.skip || 0,
+  })
+}

--- a/backend/src/api/admin/sellers/[id]/products/route.ts
+++ b/backend/src/api/admin/sellers/[id]/products/route.ts
@@ -1,0 +1,58 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RouteParams = {
+  id: string
+}
+
+/**
+ * GET /admin/sellers/:id/products
+ *
+ * Get all products for a specific seller
+ */
+export const GET = async (
+  req: MedusaRequest<unknown, RouteParams>,
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Get requested fields or use defaults
+  const requestedFields = req.query.fields as string | undefined
+  const fields = requestedFields
+    ? requestedFields.split(",").map((f) => f.trim())
+    : ["*"]
+
+  // First verify the seller exists
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields: ["id"],
+    filters: { id },
+  })
+
+  if (!sellers || sellers.length === 0) {
+    return res.status(404).json({
+      message: `Seller with ID ${id} not found`,
+    })
+  }
+
+  // Get all products for this seller
+  const { data: products, metadata } = await query.graph({
+    entity: "product",
+    fields,
+    filters: {
+      seller_id: id,
+    },
+    pagination: {
+      skip: req.query.offset ? Number(req.query.offset) : 0,
+      take: req.query.limit ? Number(req.query.limit) : 50,
+    },
+  })
+
+  return res.json({
+    products: products || [],
+    count: metadata?.count || 0,
+    limit: metadata?.take || 50,
+    offset: metadata?.skip || 0,
+  })
+}

--- a/backend/src/api/admin/sellers/[id]/route.ts
+++ b/backend/src/api/admin/sellers/[id]/route.ts
@@ -1,0 +1,146 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+type RouteParams = {
+  id: string
+}
+
+/**
+ * GET /admin/sellers/:id
+ *
+ * Get a single seller with seller_metadata (vendor_type, certifications, etc.)
+ * and producer information if available.
+ */
+export const GET = async (
+  req: MedusaRequest<unknown, RouteParams>,
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Allow custom field selection via query params
+  const requestedFields = req.query.fields as string | undefined
+
+  // Default fields to include all seller info + metadata + producer
+  const fields = requestedFields
+    ? requestedFields.split(",").map((f) => f.trim())
+    : [
+        "id",
+        "name",
+        "email",
+        "phone",
+        "description",
+        "handle",
+        "address_line",
+        "city",
+        "postal_code",
+        "country_code",
+        "tax_id",
+        "store_status",
+        "created_at",
+        "updated_at",
+        // Include seller_metadata
+        "seller_metadata.*",
+        // Include producer if exists
+        "producer.*",
+      ]
+
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields,
+    filters: { id },
+  })
+
+  const seller = sellers?.[0]
+
+  if (!seller) {
+    return res.status(404).json({
+      message: `Seller with ID ${id} not found`,
+    })
+  }
+
+  return res.json({ seller })
+}
+
+/**
+ * POST /admin/sellers/:id
+ *
+ * Update seller information
+ */
+export const POST = async (
+  req: MedusaRequest<{
+    name?: string
+    email?: string
+    phone?: string
+    description?: string
+    handle?: string
+    address_line?: string
+    city?: string
+    postal_code?: string
+    country_code?: string
+    tax_id?: string
+    store_status?: string
+  }, RouteParams>,
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const sellerModule = req.scope.resolve(Modules.SELLER)
+
+  try {
+    const updateData: Record<string, unknown> = { id }
+
+    // Only include fields that are provided
+    const fields = [
+      "name",
+      "email",
+      "phone",
+      "description",
+      "handle",
+      "address_line",
+      "city",
+      "postal_code",
+      "country_code",
+      "tax_id",
+      "store_status",
+    ]
+
+    for (const field of fields) {
+      if (req.body[field as keyof typeof req.body] !== undefined) {
+        updateData[field] = req.body[field as keyof typeof req.body]
+      }
+    }
+
+    const updatedSeller = await sellerModule.updateSellers(updateData)
+
+    // Fetch the updated seller with metadata
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: [
+        "id",
+        "name",
+        "email",
+        "phone",
+        "description",
+        "handle",
+        "address_line",
+        "city",
+        "postal_code",
+        "country_code",
+        "tax_id",
+        "store_status",
+        "created_at",
+        "updated_at",
+        "seller_metadata.*",
+        "producer.*",
+      ],
+      filters: { id },
+    })
+
+    return res.json({ seller: sellers?.[0] })
+  } catch (error) {
+    return res.status(400).json({
+      message: error instanceof Error ? error.message : "Failed to update seller",
+    })
+  }
+}

--- a/backend/src/api/admin/sellers/invite/route.ts
+++ b/backend/src/api/admin/sellers/invite/route.ts
@@ -1,0 +1,51 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { INotificationModuleService } from "@medusajs/framework/types"
+
+/**
+ * POST /admin/sellers/invite
+ *
+ * Invite a seller by email
+ */
+export const POST = async (
+  req: MedusaRequest<{
+    email: string
+    registration_url?: string
+  }>,
+  res: MedusaResponse
+) => {
+  const { email, registration_url } = req.body
+
+  if (!email) {
+    return res.status(400).json({
+      message: "Email is required",
+    })
+  }
+
+  try {
+    const notificationModule: INotificationModuleService = req.scope.resolve(
+      Modules.NOTIFICATION
+    )
+
+    // Send invitation email
+    await notificationModule.createNotifications({
+      to: email,
+      channel: "email",
+      template: "seller-invitation",
+      data: {
+        registration_url: registration_url || process.env.VENDOR_PANEL_URL || "http://localhost:3000/vendor/register",
+        email,
+      },
+    })
+
+    return res.json({
+      message: "Invitation sent successfully",
+      email,
+    })
+  } catch (error) {
+    console.error("Failed to send seller invitation:", error)
+    return res.status(500).json({
+      message: error instanceof Error ? error.message : "Failed to send invitation",
+    })
+  }
+}

--- a/backend/src/api/admin/sellers/route.ts
+++ b/backend/src/api/admin/sellers/route.ts
@@ -1,0 +1,67 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+/**
+ * GET /admin/sellers
+ *
+ * List all sellers with their seller_metadata (vendor_type, certifications, etc.)
+ * and producer information if available.
+ */
+export const GET = async (
+  req: MedusaRequest,
+  res: MedusaResponse
+) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Build filters from query params
+  const filters: Record<string, unknown> = {}
+
+  if (req.query.q) {
+    // Search by name or email
+    filters.$or = [
+      { name: { $ilike: `%${req.query.q}%` } },
+      { email: { $ilike: `%${req.query.q}%` } },
+    ]
+  }
+
+  if (req.query.store_status) {
+    filters.store_status = req.query.store_status
+  }
+
+  // Get all sellers with their related seller_metadata and producer
+  const { data: sellers, metadata } = await query.graph({
+    entity: "seller",
+    fields: [
+      "id",
+      "name",
+      "email",
+      "phone",
+      "description",
+      "handle",
+      "address_line",
+      "city",
+      "postal_code",
+      "country_code",
+      "tax_id",
+      "store_status",
+      "created_at",
+      "updated_at",
+      // Include seller_metadata
+      "seller_metadata.*",
+      // Include producer if exists
+      "producer.*",
+    ],
+    filters,
+    pagination: {
+      skip: req.query.offset ? Number(req.query.offset) : 0,
+      take: req.query.limit ? Number(req.query.limit) : 20,
+    },
+  })
+
+  return res.json({
+    sellers,
+    count: metadata?.count || 0,
+    limit: metadata?.take || 20,
+    offset: metadata?.skip || 0,
+  })
+}


### PR DESCRIPTION
This commit addresses the issue where vendor, seller, and producer information was out of sync in the admin panel by:

Backend Changes:
- Created custom /admin/sellers endpoints to include seller_metadata and producer information in seller queries using graph relationships
- Added /admin/sellers/:id endpoint with full metadata
- Added /admin/sellers/:id/orders, /products, /customer-groups endpoints
- Added /admin/sellers/invite endpoint for seller invitations
- All endpoints properly query linked seller_metadata and producer data

Frontend Changes:
- Updated VendorSeller type to include seller_metadata and producer fields
- Added SellerMetadata and ProducerInfo interfaces to seller types
- Updated seller detail view to display vendor type, verification status, featured status, growing region, and producer information
- Updated seller list table to show vendor type and verification status
- Added visual badges for verified/featured sellers and vendor types

The synchronization now works because:
1. Backend endpoints fetch sellers with their linked seller_metadata and producer records using Medusa's query graph
2. Frontend components receive and display the complete vendor information
3. All three entities (Seller, SellerMetadata, Producer) are now properly linked and displayed together in the admin panel