### PR TITLE
fix: correct query filters and remove unsupported POST method

### DIFF
--- a/backend/src/api/admin/sellers/[id]/customer-groups/route.ts
+++ b/backend/src/api/admin/sellers/[id]/customer-groups/route.ts
@@ -41,7 +41,7 @@ export const GET = async (
     entity: "customer_group",
     fields,
     filters: {
-      seller_id: id,
+      seller: { id },
     },
     pagination: {
       skip: req.query.offset ? Number(req.query.offset) : 0,

--- a/backend/src/api/admin/sellers/[id]/orders/route.ts
+++ b/backend/src/api/admin/sellers/[id]/orders/route.ts
@@ -41,7 +41,7 @@ export const GET = async (
     entity: "order",
     fields,
     filters: {
-      seller_id: id,
+      seller: { id },
     },
     pagination: {
       skip: req.query.offset ? Number(req.query.offset) : 0,

--- a/backend/src/api/admin/sellers/[id]/products/route.ts
+++ b/backend/src/api/admin/sellers/[id]/products/route.ts
@@ -41,7 +41,7 @@ export const GET = async (
     entity: "product",
     fields,
     filters: {
-      seller_id: id,
+      seller: { id },
     },
     pagination: {
       skip: req.query.offset ? Number(req.query.offset) : 0,

--- a/backend/src/api/admin/sellers/[id]/route.ts
+++ b/backend/src/api/admin/sellers/[id]/route.ts
@@ -1,5 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 type RouteParams = {
   id: string
@@ -60,87 +60,4 @@ export const GET = async (
   }
 
   return res.json({ seller })
-}
-
-/**
- * POST /admin/sellers/:id
- *
- * Update seller information
- */
-export const POST = async (
-  req: MedusaRequest<{
-    name?: string
-    email?: string
-    phone?: string
-    description?: string
-    handle?: string
-    address_line?: string
-    city?: string
-    postal_code?: string
-    country_code?: string
-    tax_id?: string
-    store_status?: string
-  }, RouteParams>,
-  res: MedusaResponse
-) => {
-  const { id } = req.params
-  const sellerModule = req.scope.resolve(Modules.SELLER)
-
-  try {
-    const updateData: Record<string, unknown> = { id }
-
-    // Only include fields that are provided
-    const fields = [
-      "name",
-      "email",
-      "phone",
-      "description",
-      "handle",
-      "address_line",
-      "city",
-      "postal_code",
-      "country_code",
-      "tax_id",
-      "store_status",
-    ]
-
-    for (const field of fields) {
-      if (req.body[field as keyof typeof req.body] !== undefined) {
-        updateData[field] = req.body[field as keyof typeof req.body]
-      }
-    }
-
-    const updatedSeller = await sellerModule.updateSellers(updateData)
-
-    // Fetch the updated seller with metadata
-    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-    const { data: sellers } = await query.graph({
-      entity: "seller",
-      fields: [
-        "id",
-        "name",
-        "email",
-        "phone",
-        "description",
-        "handle",
-        "address_line",
-        "city",
-        "postal_code",
-        "country_code",
-        "tax_id",
-        "store_status",
-        "created_at",
-        "updated_at",
-        "seller_metadata.*",
-        "producer.*",
-      ],
-      filters: { id },
-    })
-
-    return res.json({ seller: sellers?.[0] })
-  } catch (error) {
-    return res.status(400).json({
-      message: error instanceof Error ? error.message : "Failed to update seller",
-    })
-  }
 }


### PR DESCRIPTION
- Fix seller relation filters in orders, products, and customer-groups routes (use seller: { id } instead of seller_id: id)
- Remove POST method from sellers/:id route as MercurJS already provides seller update functionality through its own endpoints
- This resolves TypeScript compilation errors in the build