### PR TITLE
fix: add 'use client' directive to client-side components

### DIFF
--- a/storefront/src/components/cells/ProductPageDetails/ProductPageDetails.tsx
+++ b/storefront/src/components/cells/ProductPageDetails/ProductPageDetails.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { ProductPageAccordion } from "@/components/molecules"
 import DOMPurify from "dompurify"
 

--- a/storefront/src/components/providers/Cart/CartProvider.tsx
+++ b/storefront/src/components/providers/Cart/CartProvider.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { PropsWithChildren, useEffect, useState } from "react"
 
 import { CartContext } from "./context"

--- a/storefront/src/components/providers/Cart/context.tsx
+++ b/storefront/src/components/providers/Cart/context.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { createContext, useContext } from "react"
 
 import { Cart, StoreCartLineItemOptimisticUpdate } from "@/types/cart"

--- a/storefront/src/components/sections/SellerPageHeader/SellerPageHeader.tsx
+++ b/storefront/src/components/sections/SellerPageHeader/SellerPageHeader.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { SellerFooter, SellerHeading } from "@/components/organisms"
 import { HttpTypes } from "@medusajs/types"
 import DOMPurify from "dompurify"


### PR DESCRIPTION
Resolves Server Components error (digest: 568598297) by properly marking components that use client-side React features (hooks, browser APIs) with the "use client" directive.

Fixed components:
- CartProvider: uses useState and useEffect hooks
- Cart context: uses createContext and useContext hooks
- SellerPageHeader: uses DOMPurify browser API
- ProductPageDetails: uses DOMPurify browser API

This ensures proper hydration between server and client components in Next.js 15 with React Server Components.