### PR TITLE
fix: add 'use client' to pagination and search params hooks

### DIFF
--- a/storefront/src/hooks/useGetAllSearchParams.ts
+++ b/storefront/src/hooks/useGetAllSearchParams.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { useSearchParams } from 'next/navigation';
 
 function useGetAllSearchParams() {

--- a/storefront/src/hooks/usePagination.tsx
+++ b/storefront/src/hooks/usePagination.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useSearchParams } from 'next/navigation';
 import useUpdateSearchParams from './useUpdateSearchParams';
 


### PR DESCRIPTION
Resolves Server Components rendering error by adding 'use client' directive to the remaining hooks that use Next.js navigation features.

Fixed hooks:
- useGetAllSearchParams: uses useSearchParams from next/navigation
- usePagination: uses useSearchParams and useUpdateSearchParams

This completes the migration to properly separate Server and Client Components in Next.js 15 with React Server Components.