### PR TITLE
fix: resolve hydration mismatch in DOMPurify sanitization

### DIFF
--- a/storefront/src/components/cells/ProductPageDetails/ProductPageDetails.tsx
+++ b/storefront/src/components/cells/ProductPageDetails/ProductPageDetails.tsx
@@ -2,17 +2,24 @@
 
 import { ProductPageAccordion } from "@/components/molecules"
 import DOMPurify from "dompurify"
+import { useState, useEffect } from "react"
 
 export const ProductPageDetails = ({ details }: { details: string }) => {
-  if (!details) return null
+  // State to store sanitized details
+  const [sanitizedDetails, setSanitizedDetails] = useState(details)
 
-  // Sanitize HTML to prevent XSS attacks from user-generated content
-  const sanitizedDetails = typeof window !== "undefined" 
-    ? DOMPurify.sanitize(details, { 
+  // Sanitize on client side only to prevent hydration mismatch
+  useEffect(() => {
+    if (details) {
+      const cleaned = DOMPurify.sanitize(details, {
         ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'span', 'div'],
         ALLOWED_ATTR: ['href', 'target', 'rel', 'class']
       })
-    : details
+      setSanitizedDetails(cleaned)
+    }
+  }, [details])
+
+  if (!details) return null
 
   return (
     <ProductPageAccordion heading="Product details" defaultOpen={false}>

--- a/storefront/src/components/sections/SellerPageHeader/SellerPageHeader.tsx
+++ b/storefront/src/components/sections/SellerPageHeader/SellerPageHeader.tsx
@@ -3,6 +3,7 @@
 import { SellerFooter, SellerHeading } from "@/components/organisms"
 import { HttpTypes } from "@medusajs/types"
 import DOMPurify from "dompurify"
+import { useState, useEffect } from "react"
 
 export const SellerPageHeader = ({
   header = false,
@@ -13,13 +14,19 @@ export const SellerPageHeader = ({
   seller: any
   user: HttpTypes.StoreCustomer | null
 }) => {
-  // Sanitize seller description to prevent XSS attacks
-  const sanitizedDescription = typeof window !== "undefined" && seller.description
-    ? DOMPurify.sanitize(seller.description, {
+  // State to store sanitized description
+  const [sanitizedDescription, setSanitizedDescription] = useState(seller.description || "")
+
+  // Sanitize on client side only to prevent hydration mismatch
+  useEffect(() => {
+    if (seller.description) {
+      const cleaned = DOMPurify.sanitize(seller.description, {
         ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a', 'span'],
         ALLOWED_ATTR: ['href', 'target', 'rel', 'class']
       })
-    : seller.description || ""
+      setSanitizedDescription(cleaned)
+    }
+  }, [seller.description])
 
   return (
     <div className="border rounded-sm p-4">


### PR DESCRIPTION
Fixed Server Components error caused by hydration mismatch when using DOMPurify with typeof window checks. The issue occurred because:

- Server render: typeof window !== "undefined" returns false, uses unsanitized content
- Client render: typeof window !== "undefined" returns true, uses sanitized content
- This mismatch caused React hydration errors

Solution: Use useState and useEffect to sanitize content only on the client side after initial render, preventing hydration mismatch while maintaining XSS protection.

Components fixed:
- SellerPageHeader: seller description sanitization
- ProductPageDetails: product details sanitization