### PR TITLE
fix: resolve additional hydration mismatches causing Server Component…

### DIFF
--- a/storefront/src/components/organisms/Reviews/ReviewCard.tsx
+++ b/storefront/src/components/organisms/Reviews/ReviewCard.tsx
@@ -1,10 +1,32 @@
+"use client"
+
 import { Button, Card } from "@/components/atoms"
 import { StarIcon } from "@/icons"
 import { Review } from "@/lib/data/reviews"
 import { cn } from "@/lib/utils"
 import Image from "next/image"
+import { useState, useEffect } from "react"
 
 export const ReviewCard = ({ review }: { review: Review }) => {
+  const [timeAgo, setTimeAgo] = useState<string>("")
+
+  // Calculate time ago on client side only to prevent hydration mismatch
+  useEffect(() => {
+    const now = Date.now()
+    const reviewTime = new Date(review.updated_at).getTime()
+    const diffMs = now - reviewTime
+    const diffDays = Math.ceil(diffMs / (24 * 60 * 60 * 1000))
+    const diffWeeks = Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000))
+
+    if (diffMs < 7 * 24 * 60 * 60 * 1000) {
+      // Less than 7 days
+      setTimeAgo(`${diffDays} day${diffDays !== 1 ? "s" : ""} ago`)
+    } else {
+      // 7 days or more
+      setTimeAgo(`${diffWeeks} week${diffWeeks !== 1 ? "s" : ""} ago`)
+    }
+  }, [review.updated_at])
+
   return (
     <Card
       className="flex flex-col gap-6 lg:grid lg:grid-cols-6 px-4"
@@ -34,20 +56,7 @@ export const ReviewCard = ({ review }: { review: Review }) => {
               ))}
             </div>
             <div className="h-2.5 w-px bg-action" />
-            <p className="text-md text-primary">
-              {new Date(review.updated_at).getTime() >
-              Date.now() - 7 * 24 * 60 * 60 * 1000
-                ? `${Math.ceil(
-                    (Date.now() - new Date(review.updated_at).getTime()) /
-                      (24 * 60 * 60 * 1000)
-                  )} day${Date.now() - 2 * 24 * 60 * 60 * 1000 ? "" : "s"} ago`
-                : `${Math.floor(
-                    (Date.now() - new Date(review.updated_at).getTime()) /
-                      (7 * 24 * 60 * 60 * 1000)
-                  )} week${
-                    Date.now() - 2 * 24 * 60 * 60 * 1000 ? "" : "s"
-                  } ago`}
-            </p>
+            <p className="text-md text-primary">{timeAgo}</p>
           </div>
           <div className="col-span-5 flex flex-col lg:flex-row justify-between lg:items-center gap-4">
             <p className="text-md text-primary">{review.customer_note}</p>

--- a/storefront/src/components/sections/ProductFeed/ProductFeedItem.tsx
+++ b/storefront/src/components/sections/ProductFeed/ProductFeedItem.tsx
@@ -7,6 +7,7 @@ import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedL
 import { getProductPrice } from "@/lib/helpers/get-product-price"
 import clsx from "clsx"
 import { FeedLayout } from "./ProductFeed"
+import { useState, useEffect } from "react"
 
 interface ProductFeedItemProps {
   product: HttpTypes.StoreProduct & { seller?: SellerProps }
@@ -22,22 +23,34 @@ export const ProductFeedItem = ({
   const { cheapestPrice } = getProductPrice({ product })
   const productName = product.title || "Product"
   const seller = product.seller
+  const [relativeTime, setRelativeTime] = useState<string>("")
 
-  // Format relative time
-  const getRelativeTime = (dateString?: string): string => {
-    if (!dateString) return ""
-    const date = new Date(dateString)
+  // Calculate relative time on client side only to prevent hydration mismatch
+  useEffect(() => {
+    if (!product.created_at) {
+      setRelativeTime("")
+      return
+    }
+
+    const date = new Date(product.created_at)
     const now = new Date()
     const diffMs = now.getTime() - date.getTime()
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 0) return "Today"
-    if (diffDays === 1) return "Yesterday"
-    if (diffDays < 7) return `${diffDays} days ago`
-    if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-    if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`
-    return `${Math.floor(diffDays / 365)} years ago`
-  }
+    if (diffDays === 0) {
+      setRelativeTime("Today")
+    } else if (diffDays === 1) {
+      setRelativeTime("Yesterday")
+    } else if (diffDays < 7) {
+      setRelativeTime(`${diffDays} days ago`)
+    } else if (diffDays < 30) {
+      setRelativeTime(`${Math.floor(diffDays / 7)} weeks ago`)
+    } else if (diffDays < 365) {
+      setRelativeTime(`${Math.floor(diffDays / 30)} months ago`)
+    } else {
+      setRelativeTime(`${Math.floor(diffDays / 365)} years ago`)
+    }
+  }, [product.created_at])
 
   // Grid Layout
   if (layout === "grid" || layout === "masonry") {
@@ -140,7 +153,7 @@ export const ProductFeedItem = ({
             </div>
             {product.created_at && (
               <span className="text-xs text-gray-400">
-                {getRelativeTime(product.created_at)}
+                {relativeTime}
               </span>
             )}
           </div>
@@ -229,7 +242,7 @@ export const ProductFeedItem = ({
               )}
               {product.created_at && (
                 <span className="text-xs text-gray-400">
-                  {getRelativeTime(product.created_at)}
+                  {relativeTime}
                 </span>
               )}
             </LocalizedClientLink>

--- a/storefront/src/providers/RocketChatProvider.tsx
+++ b/storefront/src/providers/RocketChatProvider.tsx
@@ -28,15 +28,14 @@ interface RocketChatProviderProps {
 
 export const RocketChatProvider = ({ children }: RocketChatProviderProps) => {
   const [unreadCount, setUnreadCount] = useState(0)
-  
-  const rocketChatUrl = typeof window !== "undefined" 
-    ? (process.env.NEXT_PUBLIC_ROCKETCHAT_URL || null)
-    : null
+
+  // NEXT_PUBLIC_ env vars are available on both server and client
+  const rocketChatUrl = process.env.NEXT_PUBLIC_ROCKETCHAT_URL || null
   const isConfigured = Boolean(rocketChatUrl)
 
   // Listen for messages from Rocket.Chat iframe for unread counts
   useEffect(() => {
-    if (typeof window === "undefined") return
+    if (!rocketChatUrl) return
 
     const handleMessage = (event: MessageEvent) => {
       // Verify the origin matches our Rocket.Chat URL


### PR DESCRIPTION
…s errors

Fixed multiple hydration mismatch issues that were causing Server Components render errors (digest: 666061175). The issues were:

1. RocketChatProvider: Used typeof window check for env var
   - Server: rocketChatUrl = null (typeof window === "undefined")
   - Client: rocketChatUrl = actual value (typeof window !== "undefined")
   - Fix: Removed typeof window check since NEXT_PUBLIC_ vars are available on both server and client

2. ReviewCard: Used Date.now() during render
   - Server: timestamp at server render time
   - Client: timestamp at client hydration time (different value)
   - Fix: Use useState + useEffect to calculate time on client side only

3. ProductFeedItem: Used new Date() in getRelativeTime during render
   - Server: timestamp at server render time
   - Client: timestamp at client hydration time (different value)
   - Fix: Use useState + useEffect to calculate relative time on client side only

All components now render consistently on server and client, preventing hydration mismatches while maintaining correct functionality.