### PR TITLE
fix: resolve new Date() hydration mismatches in Footer and CartItems

### DIFF
--- a/storefront/src/components/organisms/CartItems/CartItems.tsx
+++ b/storefront/src/components/organisms/CartItems/CartItems.tsx
@@ -48,7 +48,7 @@ function groupItemsBySeller(cart: HttpTypes.StoreCart) {
             name: "Fleek",
             id: "fleek",
             photo: "/Logo.svg",
-            created_at: new Date(),
+            created_at: "2024-01-01T00:00:00.000Z", // Static date to prevent hydration mismatch
           },
           items: [],
         }

--- a/storefront/src/components/organisms/Footer/Footer.tsx
+++ b/storefront/src/components/organisms/Footer/Footer.tsx
@@ -1,6 +1,13 @@
 import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 import footerLinks from "@/data/footerLinks"
 
+// Client component for copyright year to prevent hydration mismatch
+function CopyrightYear() {
+  // Use suppressHydrationWarning since new Date().getFullYear() will differ
+  // between server and client render times, but the difference is acceptable
+  return <span suppressHydrationWarning>{new Date().getFullYear()}</span>
+}
+
 export function Footer() {
   return (
     <footer className="bg-primary container">
@@ -47,7 +54,7 @@ export function Footer() {
       {/* Solarpunk-styled footer bottom with gradient accent */}
       <div className="py-6 border rounded-sm relative overflow-hidden">
         <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-solarpunk" />
-        <p className="text-md text-secondary text-center">© {new Date().getFullYear()} Black Market Coalition LLC</p>
+        <p className="text-md text-secondary text-center">© <CopyrightYear /> Black Market Coalition LLC</p>
       </div>
     </footer>
   )

--- a/storefront/src/components/sections/CartReview/CartItems.tsx
+++ b/storefront/src/components/sections/CartReview/CartItems.tsx
@@ -38,7 +38,7 @@ function groupItemsBySeller(cart: HttpTypes.StoreCart) {
             name: "Fleek",
             id: "fleek",
             photo: "/Logo.svg",
-            created_at: new Date(),
+            created_at: "2024-01-01T00:00:00.000Z", // Static date to prevent hydration mismatch
           },
           items: [],
         }


### PR DESCRIPTION
Fixed three more hydration mismatch issues causing Server Components errors:

1. Footer component: Used new Date().getFullYear() in Server Component
   - Server: timestamp at build/render time
   - Client: timestamp at hydration time (different!)
   - Fix: Added suppressHydrationWarning to copyright year since the difference is acceptable for this use case

2. CartItems component: Used new Date() for fallback seller created_at
   - Created dynamic Date object during groupItemsBySeller function
   - Fix: Replaced with static ISO date string "2024-01-01T00:00:00.000Z"

3. CartReview/CartItems component: Same issue as above
   - Fix: Replaced with static ISO date string "2024-01-01T00:00:00.000Z"

These fixes ensure consistent rendering between server and client, preventing React hydration errors while maintaining functionality.