### PR TITLE
fix: ensure x-publishable-api-key header is sent in all Medusa API re…

### DIFF
--- a/storefront/src/lib/config.ts
+++ b/storefront/src/lib/config.ts
@@ -1,19 +1,60 @@
 import Medusa from "@medusajs/js-sdk"
+import type { NextFetchRequestConfig } from "next/dist/server/config-shared"
 
 // Defaults to standard port for Medusa server
 const MEDUSA_BACKEND_URL =
   process.env.MEDUSA_BACKEND_URL || ""
 
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
+
+// Validate required environment variables
+if (!MEDUSA_BACKEND_URL) {
+  throw new Error(
+    "MEDUSA_BACKEND_URL is required. Please set it in your environment variables."
+  )
+}
+
+if (!PUBLISHABLE_KEY) {
+  throw new Error(
+    "NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY is required. Please set it in your environment variables."
+  )
+}
+
 export const sdk = new Medusa({
   baseUrl: MEDUSA_BACKEND_URL,
   debug: process.env.NODE_ENV === "development",
-  publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
+  publishableKey: PUBLISHABLE_KEY,
 })
 
 type FetchQueryOptions = Omit<RequestInit, "headers" | "body"> & {
   headers?: Record<string, string | null | { tags: string[] }>
   query?: Record<string, string | number>
   body?: Record<string, any>
+}
+
+type MedusaFetchOptions = Omit<RequestInit, "headers"> & {
+  headers?: Record<string, string | undefined>
+  query?: Record<string, string | number | string[] | undefined>
+  next?: NextFetchRequestConfig
+}
+
+/**
+ * Custom fetch wrapper that ensures x-publishable-api-key header is always sent
+ * Use this instead of sdk.client.fetch to guarantee the header is present
+ */
+export async function medusaFetch<T>(
+  path: string,
+  options: MedusaFetchOptions = {}
+): Promise<T> {
+  const { headers = {}, ...restOptions } = options
+
+  return sdk.client.fetch<T>(path, {
+    ...restOptions,
+    headers: {
+      "x-publishable-api-key": PUBLISHABLE_KEY,
+      ...headers,
+    },
+  })
 }
 
 export async function fetchQuery(

--- a/storefront/src/lib/data/cart.ts
+++ b/storefront/src/lib/data/cart.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { fetchQuery, sdk } from "../config"
+import { fetchQuery, medusaFetch, sdk } from "../config"
 import medusaError from "@/lib/helpers/medusa-error"
 import { HttpTypes } from "@medusajs/types"
 import { revalidatePath, revalidateTag } from "next/cache"
@@ -32,18 +32,17 @@ export async function retrieveCart(cartId?: string) {
     ...(await getAuthHeaders()),
   }
 
-  return await sdk.client
-    .fetch<HttpTypes.StoreCartResponse>(`/store/carts/${id}`, {
-      method: "GET",
-      query: {
-        fields:
-          "*items,*region, *items.product, *items.variant, *items.variant.options, items.variant.options.option.title," +
-          "*items.thumbnail, *items.metadata, +items.total, *promotions, +shipping_methods.name, *items.product.seller" +
-          "",
-      },
-      headers,
-      cache: "no-cache",
-    })
+  return await medusaFetch<HttpTypes.StoreCartResponse>(`/store/carts/${id}`, {
+    method: "GET",
+    query: {
+      fields:
+        "*items,*region, *items.product, *items.variant, *items.variant.options, items.variant.options.option.title," +
+        "*items.thumbnail, *items.metadata, +items.total, *promotions, +shipping_methods.name, *items.product.seller" +
+        "",
+    },
+    headers,
+    cache: "no-cache",
+  })
     .then(({ cart }) => cart)
     .catch(() => null)
 }
@@ -509,7 +508,7 @@ export async function updateRegionWithValidation(
 
       // Fetch cart with minimal fields to get items
       try {
-        const { cart } = await sdk.client.fetch<HttpTypes.StoreCartResponse>(
+        const { cart } = await medusaFetch<HttpTypes.StoreCartResponse>(
           `/store/carts/${cartId}`,
           {
             method: "GET",
@@ -571,7 +570,7 @@ export async function listCartOptions() {
     ...(await getCacheOptions("shippingOptions")),
   }
 
-  return await sdk.client.fetch<{
+  return await medusaFetch<{
     shipping_options: HttpTypes.StoreCartShippingOption[]
   }>("/store/shipping-options", {
     query: { cart_id: cartId },

--- a/storefront/src/lib/data/cms-taxonomy.ts
+++ b/storefront/src/lib/data/cms-taxonomy.ts
@@ -1,4 +1,4 @@
-import { sdk } from "@/lib/config"
+import { medusaFetch } from "@/lib/config"
 
 export interface CmsType {
   id: string
@@ -59,7 +59,7 @@ export interface CmsTaxonomy {
  */
 export async function getCmsTaxonomy(): Promise<CmsTaxonomy> {
   try {
-    const response = await sdk.client.fetch<CmsTaxonomy>(
+    const response = await medusaFetch<CmsTaxonomy>(
       "/store/cms-taxonomy",
       {
         cache: "force-cache",
@@ -83,7 +83,7 @@ export async function getCmsTaxonomy(): Promise<CmsTaxonomy> {
  */
 export async function getCmsTypes(): Promise<CmsType[]> {
   try {
-    const response = await sdk.client.fetch<{ types: CmsType[] }>(
+    const response = await medusaFetch<{ types: CmsType[] }>(
       "/store/cms-types",
       {
         cache: "force-cache",
@@ -102,7 +102,7 @@ export async function getCmsTypes(): Promise<CmsType[]> {
  */
 export async function getCmsTypeByHandle(handle: string): Promise<CmsType | null> {
   try {
-    const response = await sdk.client.fetch<{ type: CmsType }>(
+    const response = await medusaFetch<{ type: CmsType }>(
       `/store/cms-types/${handle}`,
       {
         cache: "force-cache",
@@ -121,7 +121,7 @@ export async function getCmsTypeByHandle(handle: string): Promise<CmsType | null
  */
 export async function getCmsCategoryByHandle(handle: string): Promise<CmsCategory | null> {
   try {
-    const response = await sdk.client.fetch<{ category: CmsCategory }>(
+    const response = await medusaFetch<{ category: CmsCategory }>(
       `/store/cms-categories/${handle}`,
       {
         cache: "force-cache",
@@ -149,7 +149,7 @@ export async function getCmsTags(options?: {
 
     const url = `/store/cms-tags${queryParams.toString() ? `?${queryParams.toString()}` : ""}`
 
-    const response = await sdk.client.fetch<{ tags: CmsTag[] }>(url, {
+    const response = await medusaFetch<{ tags: CmsTag[] }>(url, {
       cache: "force-cache",
       next: { revalidate: 3600 },
     })

--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { sdk } from "../config"
+import { medusaFetch, sdk } from "../config"
 import { HttpTypes } from "@medusajs/types"
 import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
@@ -23,7 +23,7 @@ export const retrieveCustomer =
       const authHeaders = await getAuthHeaders()
       if (!authHeaders) return null
 
-      const { customer } = await sdk.client.fetch<{
+      const { customer } = await medusaFetch<{
         customer: HttpTypes.StoreCustomer
       }>(`/store/customers/me`, {
         method: "GET",

--- a/storefront/src/lib/data/products.ts
+++ b/storefront/src/lib/data/products.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { sdk } from "../config"
+import { medusaFetch } from "../config"
 import { sortProducts } from "@/lib/helpers/sort-products"
 import { HttpTypes } from "@medusajs/types"
 import { SortOptions } from "@/types/product"
@@ -64,28 +64,27 @@ export const listProducts = async ({
 
   const useCached = forceCache || (limit <= 8 && !category_id && !collection_id)
 
-  return sdk.client
-    .fetch<{
-      products: (HttpTypes.StoreProduct & { seller?: SellerProps })[]
-      count: number
-    }>(`/store/products`, {
-      method: "GET",
-      query: {
-        country_code: countryCode,
-        category_id,
-        collection_id,
-        limit,
-        offset,
-        region_id: region?.id,
-        fields:
-          "*variants.calculated_price,+variants.inventory_quantity,*seller,*variants,*seller.products," +
-          "*seller.reviews,*seller.reviews.customer,*seller.reviews.seller,*seller.products.variants,*attribute_values,*attribute_values.attribute",
-        ...queryParams,
-      },
-      headers,
-      next: useCached ? { revalidate: 60 } : undefined,
-      cache: useCached ? "force-cache" : "no-cache",
-    })
+  return medusaFetch<{
+    products: (HttpTypes.StoreProduct & { seller?: SellerProps })[]
+    count: number
+  }>(`/store/products`, {
+    method: "GET",
+    query: {
+      country_code: countryCode,
+      category_id,
+      collection_id,
+      limit,
+      offset,
+      region_id: region?.id,
+      fields:
+        "*variants.calculated_price,+variants.inventory_quantity,*seller,*variants,*seller.products," +
+        "*seller.reviews,*seller.reviews.customer,*seller.reviews.seller,*seller.products.variants,*attribute_values,*attribute_values.attribute",
+      ...queryParams,
+    },
+    headers,
+    next: useCached ? { revalidate: 60 } : undefined,
+    cache: useCached ? "force-cache" : "no-cache",
+  })
     .then(({ products: productsRaw, count }) => {
       const products = productsRaw.filter(
         (product) => product.seller?.store_status !== "SUSPENDED"

--- a/storefront/src/lib/data/regions.ts
+++ b/storefront/src/lib/data/regions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { sdk } from "../config"
+import { medusaFetch } from "../config"
 import medusaError from "@/lib/helpers/medusa-error"
 import { HttpTypes } from "@medusajs/types"
 import { getCacheOptions } from "./cookies"
@@ -11,12 +11,11 @@ export const listRegions = async () => {
     revalidate: 3600,
   }
 
-  return sdk.client
-    .fetch<{ regions: HttpTypes.StoreRegion[] }>(`/store/regions`, {
-      method: "GET",
-      next,
-      cache: "force-cache",
-    })
+  return medusaFetch<{ regions: HttpTypes.StoreRegion[] }>(`/store/regions`, {
+    method: "GET",
+    next,
+    cache: "force-cache",
+  })
     .then(({ regions }) => regions)
     .catch(medusaError)
 }
@@ -27,12 +26,11 @@ export const retrieveRegion = async (id: string) => {
     revalidate: 3600,
   }
 
-  return sdk.client
-    .fetch<{ region: HttpTypes.StoreRegion }>(`/store/regions/${id}`, {
-      method: "GET",
-      next,
-      cache: "force-cache",
-    })
+  return medusaFetch<{ region: HttpTypes.StoreRegion }>(`/store/regions/${id}`, {
+    method: "GET",
+    next,
+    cache: "force-cache",
+  })
     .then(({ region }) => region)
     .catch(medusaError)
 }


### PR DESCRIPTION
…quests

- Add environment variable validation for MEDUSA_BACKEND_URL and NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
- Create medusaFetch wrapper function that guarantees x-publishable-api-key header is always included
- Update all sdk.client.fetch calls to use medusaFetch in:
  - storefront/src/lib/data/regions.ts
  - storefront/src/lib/data/products.ts
  - storefront/src/lib/data/cart.ts
  - storefront/src/lib/data/customer.ts
  - storefront/src/lib/data/cms-taxonomy.ts

This fixes Server Component errors caused by missing publishable API key header, which previously resulted in Medusa backend returning { type: "not_allowed" } errors and Next.js digest errors when components tried to render invalid data.