### PR TITLE
fix: ensure x-publishable-api-key header is sent in all API requests

### DIFF
--- a/storefront/src/app/api/gardens/[handle]/route.ts
+++ b/storefront/src/app/api/gardens/[handle]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || "http://localhost:9000"
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || ""
 
 export async function GET(
   request: Request,
@@ -12,6 +13,7 @@ export async function GET(
     const response = await fetch(`${BACKEND_URL}/store/gardens/${handle}`, {
       headers: {
         "Content-Type": "application/json",
+        "x-publishable-api-key": PUBLISHABLE_KEY,
       },
       next: { revalidate: 60 },
     })

--- a/storefront/src/app/api/gardens/route.ts
+++ b/storefront/src/app/api/gardens/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || "http://localhost:9000"
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || ""
 
 export async function GET() {
   try {
     const response = await fetch(`${BACKEND_URL}/store/gardens`, {
       headers: {
         "Content-Type": "application/json",
+        "x-publishable-api-key": PUBLISHABLE_KEY,
       },
       next: { revalidate: 60 }, // Cache for 60 seconds
     })

--- a/storefront/src/app/api/producers/[handle]/route.ts
+++ b/storefront/src/app/api/producers/[handle]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || ""
 
 export async function GET(
   request: NextRequest,
@@ -8,11 +9,12 @@ export async function GET(
 ) {
   try {
     const { handle } = await params
-    
+
     const response = await fetch(`${BACKEND_URL}/store/producers/${handle}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+        "x-publishable-api-key": PUBLISHABLE_KEY,
       },
       next: { revalidate: 60 },
     })

--- a/storefront/src/app/api/producers/route.ts
+++ b/storefront/src/app/api/producers/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || ""
 
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
     const params = new URLSearchParams()
-    
+
     // Forward query params
     if (searchParams.has("limit")) params.set("limit", searchParams.get("limit")!)
     if (searchParams.has("offset")) params.set("offset", searchParams.get("offset")!)
@@ -18,6 +19,7 @@ export async function GET(request: NextRequest) {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+        "x-publishable-api-key": PUBLISHABLE_KEY,
       },
       next: { revalidate: 60 },
     })

--- a/storefront/src/lib/data/cart.ts
+++ b/storefront/src/lib/data/cart.ts
@@ -301,19 +301,13 @@ export async function removeShippingMethod(shippingMethodId: string) {
 
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  return fetch(
-    `${process.env.MEDUSA_BACKEND_URL}/store/carts/${cartId}/shipping-methods`,
-    {
-      method: "DELETE",
-      body: JSON.stringify({ shipping_method_ids: [shippingMethodId] }),
-      headers,
-    }
-  )
+  return medusaFetch(`/store/carts/${cartId}/shipping-methods`, {
+    method: "DELETE",
+    body: { shipping_method_ids: [shippingMethodId] },
+    headers,
+  })
     .then(async () => {
       const cartCacheTag = await getCacheTag("carts")
       revalidateTag(cartCacheTag)
@@ -329,19 +323,13 @@ export async function deletePromotionCode(promoId: string) {
   }
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  return fetch(
-    `${process.env.MEDUSA_BACKEND_URL}/store/carts/${cartId}/promotions`,
-    {
-      method: "DELETE",
-      body: JSON.stringify({ promo_codes: [promoId] }),
-      headers,
-    }
-  )
+  return medusaFetch(`/store/carts/${cartId}/promotions`, {
+    method: "DELETE",
+    body: { promo_codes: [promoId] },
+    headers,
+  })
     .then(async () => {
       const cartCacheTag = await getCacheTag("carts")
       revalidateTag(cartCacheTag)

--- a/storefront/src/lib/data/orders.ts
+++ b/storefront/src/lib/data/orders.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { SellerProps } from "@/types/seller"
-import { sdk } from "../config"
+import { medusaFetch, sdk } from "../config"
 import medusaError from "../helpers/medusa-error"
 import { getAuthHeaders, getCacheOptions } from "./cookies"
 import { HttpTypes } from "@medusajs/types"
@@ -11,12 +11,11 @@ export const retrieveOrderSet = async (id: string) => {
     ...(await getAuthHeaders()),
   }
 
-  return sdk.client
-    .fetch<any>(`/store/order-set/${id}`, {
-      method: "GET",
-      headers,
-      cache: "no-cache",
-    })
+  return medusaFetch<any>(`/store/order-set/${id}`, {
+    method: "GET",
+    headers,
+    cache: "no-cache",
+  })
     .then(({ order_set }) => order_set)
     .catch((err) => medusaError(err))
 }
@@ -30,20 +29,19 @@ export const retrieveOrder = async (id: string) => {
     ...(await getCacheOptions("orders")),
   }
 
-  return sdk.client
-    .fetch<HttpTypes.StoreOrderResponse & { seller: SellerProps }>(
-      `/store/orders/${id}`,
-      {
-        method: "GET",
-        query: {
-          fields:
-            "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,*seller,*order_set",
-        },
-        headers,
-        next,
-        cache: "force-cache",
-      }
-    )
+  return medusaFetch<HttpTypes.StoreOrderResponse & { seller: SellerProps }>(
+    `/store/orders/${id}`,
+    {
+      method: "GET",
+      query: {
+        fields:
+          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,*seller,*order_set",
+      },
+      headers,
+      next,
+      cache: "force-cache",
+    }
+  )
     .then(({ order }) => order)
     .catch((err) => medusaError(err))
 }
@@ -51,20 +49,13 @@ export const retrieveOrder = async (id: string) => {
 export const createReturnRequest = async (data: any) => {
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  const response = await fetch(
-    `${process.env.MEDUSA_BACKEND_URL}/store/return-request`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify(data),
-    }
-  )
-    .then(async (res) => await res.json())
+  const response = await medusaFetch<any>(`/store/return-request`, {
+    method: "POST",
+    headers,
+    body: data,
+  })
     .catch((err) => medusaError(err))
 
   return response
@@ -73,15 +64,14 @@ export const createReturnRequest = async (data: any) => {
 export const getReturns = async () => {
   const headers = await getAuthHeaders()
 
-  return sdk.client
-    .fetch<{
-      order_return_requests: Array<any>
-    }>(`/store/return-request`, {
-      method: "GET",
-      headers,
-      cache: "force-cache",
-      query: { fields: "*line_items.reason_id" },
-    })
+  return medusaFetch<{
+    order_return_requests: Array<any>
+  }>(`/store/return-request`, {
+    method: "GET",
+    headers,
+    cache: "force-cache",
+    query: { fields: "*line_items.reason_id" },
+  })
     .then((res) => res)
     .catch((err) => medusaError(err))
 }
@@ -89,14 +79,13 @@ export const getReturns = async () => {
 export const retriveReturnMethods = async (order_id: string) => {
   const headers = await getAuthHeaders()
 
-  return sdk.client
-    .fetch<{
-      shipping_options: Array<any>
-    }>(`/store/shipping-options/return?order_id=${order_id}`, {
-      method: "GET",
-      headers,
-      cache: "no-cache",
-    })
+  return medusaFetch<{
+    shipping_options: Array<any>
+  }>(`/store/shipping-options/return?order_id=${order_id}`, {
+    method: "GET",
+    headers,
+    cache: "no-cache",
+  })
     .then(({ shipping_options }) => shipping_options)
     .catch(() => [])
 }
@@ -114,28 +103,27 @@ export const listOrders = async (
     ...(await getCacheOptions("orders")),
   }
 
-  return sdk.client
-    .fetch<{
-      orders: Array<
-        HttpTypes.StoreOrder & {
-          seller: { id: string; name: string; reviews?: any[] }
-          reviews: any[]
-        }
-      >
-    }>(`/store/orders`, {
-      method: "GET",
-      query: {
-        limit,
-        offset,
-        order: "-created_at",
-        fields:
-          "*items,+items.metadata,*items.variant,*items.product,*seller,*reviews,*order_set,shipping_total,total,created_at",
-        ...filters,
-      },
-      headers,
-      next,
-      cache: "no-cache",
-    })
+  return medusaFetch<{
+    orders: Array<
+      HttpTypes.StoreOrder & {
+        seller: { id: string; name: string; reviews?: any[] }
+        reviews: any[]
+      }
+    >
+  }>(`/store/orders`, {
+    method: "GET",
+    query: {
+      limit,
+      offset,
+      order: "-created_at",
+      fields:
+        "*items,+items.metadata,*items.variant,*items.product,*seller,*reviews,*order_set,shipping_total,total,created_at",
+      ...filters,
+    },
+    headers,
+    next,
+    cache: "no-cache",
+  })
     .then(({ orders }) => orders)
     .catch((err) => medusaError(err))
 }
@@ -194,14 +182,13 @@ export const declineTransferRequest = async (id: string, token: string) => {
 export const retrieveReturnReasons = async () => {
   const headers = await getAuthHeaders()
 
-  return sdk.client
-    .fetch<{
-      return_reasons: Array<HttpTypes.StoreReturnReason>
-    }>(`/store/return-reasons`, {
-      method: "GET",
-      headers,
-      cache: "force-cache",
-    })
+  return medusaFetch<{
+    return_reasons: Array<HttpTypes.StoreReturnReason>
+  }>(`/store/return-reasons`, {
+    method: "GET",
+    headers,
+    cache: "force-cache",
+  })
     .then(({ return_reasons }) => return_reasons)
     .catch((err) => medusaError(err))
 }

--- a/storefront/src/lib/data/reviews.ts
+++ b/storefront/src/lib/data/reviews.ts
@@ -39,25 +39,19 @@ const getReviews = async () => {
 const createReview = async (review: any) => {
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  const response = await fetch(
-    `${process.env.MEDUSA_BACKEND_URL}/store/reviews`,
-    {
-      headers,
-      method: "POST",
-      body: JSON.stringify(review),
-    }
-  ).then((res) => {
+  const response = await fetchQuery("/store/reviews", {
+    headers,
+    method: "POST",
+    body: review,
+  }).then((res) => {
     revalidatePath("/user/reviews")
     revalidatePath("/user/reviews/written")
     return res
   })
 
-  return response.json()
+  return response.data
 }
 
 export { getReviews, createReview }

--- a/storefront/src/lib/data/wishlist.ts
+++ b/storefront/src/lib/data/wishlist.ts
@@ -1,23 +1,19 @@
 "use server"
 import { Wishlist } from "@/types/wishlist"
-import { sdk } from "../config"
+import { medusaFetch } from "../config"
 import { getAuthHeaders } from "./cookies"
 import { revalidatePath } from "next/cache"
 
 export const getUserWishlists = async () => {
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  return sdk.client
-    .fetch<{ wishlists: Wishlist[]; count: number }>(`/store/wishlist`, {
-      cache: "no-cache",
-      headers,
-      method: "GET",
-    })
+  return medusaFetch<{ wishlists: Wishlist[]; count: number }>(`/store/wishlist`, {
+    cache: "no-cache",
+    headers,
+    method: "GET",
+  })
     .then((res) => {
       return res
     })
@@ -32,22 +28,16 @@ export const addWishlistItem = async ({
 }) => {
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  const response = await fetch(
-    `${process.env.MEDUSA_BACKEND_URL}/store/wishlist`,
-    {
-      headers,
-      method: "POST",
-      body: JSON.stringify({
-        reference,
-        reference_id,
-      }),
-    }
-  ).then(() => {
+  const response = await medusaFetch(`/store/wishlist`, {
+    headers,
+    method: "POST",
+    body: {
+      reference,
+      reference_id,
+    },
+  }).then(() => {
     revalidatePath("/wishlist")
   })
 }
@@ -61,18 +51,12 @@ export const removeWishlistItem = async ({
 }) => {
   const headers = {
     ...(await getAuthHeaders()),
-    "Content-Type": "application/json",
-    "x-publishable-api-key": process.env
-      .NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY as string,
   }
 
-  const response = await fetch(
-    `${process.env.MEDUSA_BACKEND_URL}/store/wishlist/${wishlist_id}/product/${product_id}`,
-    {
-      headers,
-      method: "DELETE",
-    }
-  ).then(() => {
+  const response = await medusaFetch(`/store/wishlist/${wishlist_id}/product/${product_id}`, {
+    headers,
+    method: "DELETE",
+  }).then(() => {
     revalidatePath("/wishlist")
   })
 }


### PR DESCRIPTION
This commit ensures all Medusa API requests include the x-publishable-api-key header by:

1. Replacing sdk.client.fetch() calls with medusaFetch() wrapper in:
   - storefront/src/lib/data/orders.ts
   - storefront/src/lib/data/wishlist.ts

2. Replacing direct fetch() calls with medusaFetch() or fetchQuery() in:
   - storefront/src/lib/data/cart.ts (removeShippingMethod, deletePromotionCode)
   - storefront/src/lib/data/reviews.ts (createReview)
   - storefront/src/lib/data/wishlist.ts (all functions)

3. Adding x-publishable-api-key header to API route handlers:
   - storefront/src/app/api/gardens/route.ts
   - storefront/src/app/api/gardens/[handle]/route.ts
   - storefront/src/app/api/producers/route.ts
   - storefront/src/app/api/producers/[handle]/route.ts

The medusaFetch() wrapper function automatically includes the publishable key header in all requests, preventing "Unauthorized" and "not_allowed" errors from the Medusa backend.