### PR TITLE
fix: add authentication guard and error handling for returns page

### DIFF
--- a/storefront/src/app/[locale]/(main)/user/returns/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/returns/page.tsx
@@ -1,3 +1,4 @@
+import { LoginForm } from "@/components/molecules"
 import { UserNavigation } from "@/components/molecules/UserNavigation/UserNavigation"
 import { OrderReturnRequests } from "@/components/sections/OrderReturnRequests/OrderReturnRequests"
 import { retrieveCustomer } from "@/lib/data/customer"
@@ -8,12 +9,19 @@ export default async function ReturnsPage({
 }: {
   searchParams: Promise<{ page: string; return: string }>
 }) {
-  const { order_return_requests } = await getReturns()
-  const returnReasons = await retrieveReturnReasons()
-
+  // Check authentication first
   const user = await retrieveCustomer()
 
+  if (!user) return <LoginForm />
+
+  // Fetch returns data with error handling
+  const returnsData = await getReturns()
+  const returnReasons = await retrieveReturnReasons()
+
   const { page, return: returnId } = await searchParams
+
+  // Handle case where returns data is null or undefined
+  const order_return_requests = returnsData?.order_return_requests || []
 
   return (
     <main className="container">

--- a/storefront/src/lib/data/cookies.ts
+++ b/storefront/src/lib/data/cookies.ts
@@ -2,13 +2,13 @@ import 'server-only';
 import { cookies as nextCookies } from 'next/headers';
 
 export const getAuthHeaders = async (): Promise<
-  { authorization: string } | {}
+  { authorization: string } | null
 > => {
   const cookies = await nextCookies();
   const token = cookies.get('_medusa_jwt')?.value;
 
   if (!token) {
-    return {};
+    return null;
   }
 
   return { authorization: `Bearer ${token}` };

--- a/storefront/src/lib/data/orders.ts
+++ b/storefront/src/lib/data/orders.ts
@@ -73,7 +73,10 @@ export const getReturns = async () => {
     query: { fields: "*line_items.reason_id" },
   })
     .then((res) => res)
-    .catch((err) => medusaError(err))
+    .catch((err) => {
+      console.error("[getReturns] Failed to fetch returns:", err?.message || err)
+      return { order_return_requests: [] }
+    })
 }
 
 export const retriveReturnMethods = async (order_id: string) => {
@@ -190,5 +193,8 @@ export const retrieveReturnReasons = async () => {
     cache: "force-cache",
   })
     .then(({ return_reasons }) => return_reasons)
-    .catch((err) => medusaError(err))
+    .catch((err) => {
+      console.error("[retrieveReturnReasons] Failed to fetch return reasons:", err?.message || err)
+      return []
+    })
 }


### PR DESCRIPTION
- Change getAuthHeaders() to return null instead of {} when no token exists, making authentication checks work correctly
- Add authentication guard to returns page to show login form for unauthenticated users
- Update getReturns() to return empty array on error instead of throwing
- Update retrieveReturnReasons() to return empty array on error instead of throwing
- Add null/undefined handling for returns data to prevent crashes

This fixes the 401 Unauthorized and 404 Not Found errors from crashing the application.