### PR TITLE
fix: add router.refresh() to prevent logout after address operations

### DIFF
--- a/storefront/src/components/molecules/AddressForm/AddressForm.tsx
+++ b/storefront/src/components/molecules/AddressForm/AddressForm.tsx
@@ -14,6 +14,7 @@ import { addCustomerAddress, updateCustomerAddress } from "@/lib/data/customer"
 import { HttpTypes } from "@medusajs/types"
 import CountrySelect from "@/components/cells/CountrySelect/CountrySelect"
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 
 interface Props {
   defaultValues?: AddressFormData
@@ -51,6 +52,7 @@ export const AddressForm: React.FC<Props> = ({ defaultValues, ...props }) => {
 
 const Form: React.FC<Props> = ({ regions, handleClose }) => {
   const [error, setError] = useState<string>()
+  const router = useRouter()
   const {
     handleSubmit,
     register,
@@ -88,6 +90,9 @@ const Form: React.FC<Props> = ({ regions, handleClose }) => {
 
     setError("")
     handleClose && handleClose()
+
+    // Refresh the page to ensure authentication state is properly updated
+    router.refresh()
   }
 
   return (

--- a/storefront/src/components/organisms/Addressess/Addresses.tsx
+++ b/storefront/src/components/organisms/Addressess/Addresses.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils"
 import { HttpTypes } from "@medusajs/types"
 import { isEmpty } from "lodash"
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 
 export const Addresses = ({
   user,
@@ -18,6 +19,7 @@ export const Addresses = ({
 }) => {
   const [showForm, setShowForm] = useState(false)
   const [deleteAddress, setDeleteAddress] = useState<string | null>(null)
+  const router = useRouter()
 
   const [defaultValues, setDefaultValues] = useState<AddressFormData | null>(
     null
@@ -48,6 +50,9 @@ export const Addresses = ({
   const handleDelete = async (addressId: string) => {
     await deleteCustomerAddress(addressId)
     setDeleteAddress(null)
+
+    // Refresh the page to ensure authentication state is properly updated
+    router.refresh()
   }
 
   const handleAdd = () => {


### PR DESCRIPTION
- Add useRouter import to AddressForm and Addresses components
- Call router.refresh() after successfully adding, updating, or deleting addresses
- This ensures the page properly refreshes and maintains authentication state
- Fixes bug where users would appear logged out after modifying addresses

The issue was that revalidateTag() alone wasn't triggering a proper page refresh in Next.js client components, causing authentication state to become inconsistent.