### PR TITLE
fix: resolve React error #31 by passing calculated_price string inste…

### DIFF
--- a/storefront/src/components/cells/ProductDetailsHeader/ProductDetailsHeader.tsx
+++ b/storefront/src/components/cells/ProductDetailsHeader/ProductDetailsHeader.tsx
@@ -202,7 +202,7 @@ export const ProductDetailsHeader = ({
       {/* Mobile Sticky Add to Cart */}
       <MobileStickyAddToCart
         product={product}
-        price={variantPrice}
+        price={variantPrice?.calculated_price || null}
         variantStock={variantStock}
         variantHasPrice={variantHasPrice}
         hasAnyPrice={hasAnyPrice}


### PR DESCRIPTION
…ad of price object

The MobileStickyAddToCart component was receiving the entire variantPrice object but trying to render it directly in JSX, which caused React error #31 (Objects are not valid as a React child). Fixed by passing variantPrice?.calculated_price which is the formatted price string.