### PR TITLE
fix: resolve Server Action not found error when saving account details

### DIFF
--- a/storefront/src/components/molecules/ProfileDetailsForm/ProfileDetailsForm.tsx
+++ b/storefront/src/components/molecules/ProfileDetailsForm/ProfileDetailsForm.tsx
@@ -11,7 +11,6 @@ import { profileDetailsSchema, ProfileDetailsFormData } from "./schema"
 import { LabeledInput } from "@/components/cells"
 import { Button } from "@/components/atoms"
 import { updateCustomer } from "@/lib/data/customer"
-import { HttpTypes } from "@medusajs/types"
 import { useState } from "react"
 
 interface Props {
@@ -49,15 +48,15 @@ const Form: React.FC<Props> = ({ handleClose }) => {
   } = useFormContext()
 
   const submit = async (data: FieldValues) => {
-    const body = {
-      first_name: data.firstName,
-      last_name: data.lastName,
-      phone: data.phone,
-    }
-    try {
-      await updateCustomer(body as HttpTypes.StoreUpdateCustomer)
-    } catch (err) {
-      setError((err as Error).message)
+    const formData = new FormData()
+    formData.append("first_name", data.firstName)
+    formData.append("last_name", data.lastName)
+    formData.append("phone", data.phone)
+
+    const result = await updateCustomer(formData)
+
+    if (!result.success) {
+      setError(result.error || "Failed to update profile")
       return
     }
 

--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -40,22 +40,30 @@ export const retrieveCustomer =
 /* ---------------------------------------------
  * UPDATE CUSTOMER
  * -------------------------------------------- */
-export const updateCustomer = async (
-  body: HttpTypes.StoreUpdateCustomer
-) => {
+export const updateCustomer = async (formData: FormData) => {
   const authHeaders = await getAuthHeaders()
   if (!authHeaders) {
-    throw new Error("Not authenticated")
+    return { success: false, error: "Not authenticated" }
   }
 
-  const customer = await sdk.store.customer
-    .update(body, {}, authHeaders)
-    .then(({ customer }) => customer)
+  const body: HttpTypes.StoreUpdateCustomer = {
+    first_name: formData.get("first_name") as string,
+    last_name: formData.get("last_name") as string,
+    phone: formData.get("phone") as string,
+  }
 
-  const cacheTag = await getCacheTag("customers")
-  revalidateTag(cacheTag)
+  try {
+    const customer = await sdk.store.customer
+      .update(body, {}, authHeaders)
+      .then(({ customer }) => customer)
 
-  return customer
+    const cacheTag = await getCacheTag("customers")
+    revalidateTag(cacheTag)
+
+    return { success: true, error: null, customer }
+  } catch (err) {
+    return { success: false, error: getErrorMessage(err) }
+  }
 }
 
 /* ---------------------------------------------


### PR DESCRIPTION
The updateCustomer server action was failing with "Server Action was not found" error because it accepted a typed object parameter instead of FormData. In Next.js, server actions called from client components work more reliably with FormData.

Changes:
- Modified updateCustomer to accept FormData parameter (consistent with other actions)
- Updated ProfileDetailsForm to pass FormData instead of typed object
- Added proper error handling with success/error response pattern
- Removed unused HttpTypes import from ProfileDetailsForm

This matches the pattern used by other working server actions in the file (addCustomerAddress, updateCustomerAddress, etc.) and resolves the server action hash mismatch issue.

Fixes the account settings save functionality.