### PR TITLE
fix: transfer email from sell page to registration form

### DIFF
--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Alert, Button, Heading, Hint, Input, Text } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
 import { Trans, useTranslation } from "react-i18next"
-import { Link } from "react-router-dom"
+import { Link, useSearchParams } from "react-router-dom"
 import * as z from "zod"
 
 import { Form } from "../../components/common/form"
@@ -76,12 +76,16 @@ export const Register = () => {
   const [success, setSuccess] = useState(false)
   const [showOptionalFields, setShowOptionalFields] = useState(false)
   const { t } = useTranslation()
+  const [searchParams] = useSearchParams()
+
+  // Extract email from URL parameter if present
+  const emailFromUrl = searchParams.get("email") || ""
 
   const form = useForm<z.infer<typeof RegisterSchema>>({
     resolver: zodResolver(RegisterSchema),
     defaultValues: {
       name: "",
-      email: "",
+      email: emailFromUrl,
       password: "",
       confirmPassword: "",
       website_url: "",


### PR DESCRIPTION
- Extract email parameter from URL using useSearchParams hook
- Pre-fill email field in registration form with URL parameter value
- Resolves duplicate email entry issue where users had to enter email twice

Fixes issue where email collected on /us/sell page was not being transferred to the vendor registration flow, causing users to re-enter their email address.