### PR TITLE
fix: correct request type mapping - database uses 'seller' not 'selle…

### DIFF
--- a/backend/src/api/admin/requests/route.ts
+++ b/backend/src/api/admin/requests/route.ts
@@ -40,16 +40,11 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     if (query.requester_id) filters.requester_id = query.requester_id
     if (query.provider_id) filters.provider_id = query.provider_id
 
-    // Map frontend type parameter to database type value
-    // Frontend sends "seller" but database stores "seller_creation"
+    // Add type filter if provided
     // Note: type is a direct column in the database, not inside JSON
-    const typeMap: Record<string, string> = {
-      seller: "seller_creation",
-    }
-
+    // Database stores: "seller", "product", etc.
     if (query.type) {
-      const dbType = typeMap[query.type] || query.type
-      filters.type = dbType
+      filters.type = query.type
     }
 
     const requests = await requestService.listRequests(filters, {

--- a/scripts/check-seller-requests.sh
+++ b/scripts/check-seller-requests.sh
@@ -40,11 +40,11 @@ else
 
   echo ""
   echo "--- Seller Creation Requests Count ---"
-  psql "$DB_URL" -c "SELECT COUNT(*) as seller_requests FROM request WHERE type = 'seller_creation';"
+  psql "$DB_URL" -c "SELECT COUNT(*) as seller_requests FROM request WHERE type = 'seller';"
 
   echo ""
   echo "--- Seller Requests by Status ---"
-  psql "$DB_URL" -c "SELECT status, COUNT(*) as count FROM request WHERE type = 'seller_creation' GROUP BY status ORDER BY status;"
+  psql "$DB_URL" -c "SELECT status, COUNT(*) as count FROM request WHERE type = 'seller' GROUP BY status ORDER BY status;"
 
   echo ""
   echo "--- Latest 5 Seller Requests ---"
@@ -58,7 +58,7 @@ else
       data::jsonb->>'vendor_type' as vendor_type,
       created_at
     FROM request
-    WHERE type = 'seller_creation'
+    WHERE type = 'seller'
     ORDER BY created_at DESC
     LIMIT 5;
   "

--- a/scripts/check-seller-requests.sql
+++ b/scripts/check-seller-requests.sql
@@ -18,7 +18,7 @@ SELECT COUNT(*) as total_requests FROM request;
 \echo '=== Seller Creation Requests Count ==='
 SELECT COUNT(*) as seller_requests
 FROM request
-WHERE type = 'seller_creation';
+WHERE type = 'seller';
 
 -- 4. Breakdown by status
 \echo ''
@@ -27,7 +27,7 @@ SELECT
   status,
   COUNT(*) as count
 FROM request
-WHERE type = 'seller_creation'
+WHERE type = 'seller'
 GROUP BY status
 ORDER BY status;
 
@@ -48,7 +48,7 @@ SELECT
   created_at,
   updated_at
 FROM request
-WHERE type = 'seller_creation'
+WHERE type = 'seller'
 ORDER BY created_at DESC
 LIMIT 10;
 
@@ -70,6 +70,6 @@ SELECT
   type,
   jsonb_pretty(data::jsonb) as data_structure
 FROM request
-WHERE type = 'seller_creation'
+WHERE type = 'seller'
 ORDER BY created_at DESC
 LIMIT 1;


### PR DESCRIPTION
…r_creation'

After checking the database, found that:
- 23 seller requests exist with type = 'seller'
- The database stores the type as 'seller', not 'seller_creation'

Changes:
- Removed incorrect type mapping from backend
- Frontend sends "seller" → Backend now uses "seller" directly
- Updated SQL scripts to query for type = 'seller'
- Updated shell script queries to use correct type

This fix will now correctly display all 23 existing seller requests in the admin dashboard at /requests/seller