### PR TITLE
fix: align Request model with database schema to fix type filtering

### DIFF
--- a/backend/src/modules/request/models/request.ts
+++ b/backend/src/modules/request/models/request.ts
@@ -23,21 +23,23 @@ export enum RequestStatus {
  */
 const Request = model.define("request", {
   id: model.id().primaryKey(),
-  submitter_id: model.text().nullable(),
-  provider_id: model.text().nullable(),
+  type: model.text(),
+  data: model.json().default({}),
+  submitter_id: model.text(),
+  reviewer_id: model.text().nullable(),
+  reviewer_note: model.text().nullable(),
   status: model.enum(RequestStatus).default(RequestStatus.PENDING),
-  payload: model.json().default({}),
-  notes: model.text().nullable(),
+  requester_id: model.text().nullable(),
 })
 .indexes([
   {
     on: ["submitter_id"],
   },
   {
-    on: ["provider_id"],
+    on: ["status"],
   },
   {
-    on: ["status"],
+    on: ["type"],
   },
 ])
 

--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -18,22 +18,27 @@ class RequestModuleService extends MedusaService({
   /**
    * Create a single request (convenience wrapper)
    */
-  async createRequest(data: {
+  async createRequest(input: {
+    type: string
+    data: Record<string, unknown>
     submitter_id?: string
     requester_id?: string
-    provider_id?: string
-    payload?: Record<string, unknown>
-    notes?: string
+    reviewer_note?: string
   }) {
     // Support both submitter_id and requester_id for backwards compatibility
-    const submitterId = data.submitter_id || data.requester_id
+    const submitterId = input.submitter_id || input.requester_id
+
+    if (!submitterId) {
+      throw new Error("submitter_id or requester_id is required")
+    }
 
     const [request] = await this.createRequests([{
+      type: input.type,
+      data: input.data,
       submitter_id: submitterId,
-      provider_id: data.provider_id,
+      requester_id: input.requester_id,
+      reviewer_note: input.reviewer_note,
       status: RequestStatus.PENDING,
-      payload: data.payload || {},
-      notes: data.notes,
     }])
 
     return request
@@ -78,16 +83,6 @@ class RequestModuleService extends MedusaService({
   async getRequesterRequests(requesterId: string) {
     const requests = await this.listRequests({
       submitter_id: requesterId,
-    })
-    return requests
-  }
-
-  /**
-   * Get requests by provider ID
-   */
-  async getProviderRequests(providerId: string) {
-    const requests = await this.listRequests({
-      provider_id: providerId,
     })
     return requests
   }


### PR DESCRIPTION
The backend was failing with "Trying to query by not existing property Request.type" because the model definition didn't match the actual database schema.

Database schema (actual):
- type: text column for request type
- data: jsonb column for request data
- submitter_id, reviewer_id, reviewer_note, requester_id, status

Model definition (was incorrect):
- payload: jsonb (should be 'data')
- Missing 'type' field
- Missing reviewer fields

Changes:
- Updated Request model to match database schema exactly
- Changed 'payload' to 'data' throughout
- Added 'type' field and index
- Added reviewer_id, reviewer_note, requester_id fields
- Updated service createRequest() signature
- Updated API route schemas and handlers
- Removed provider_id references (doesn't exist in DB)
- Removed getProviderRequests() method

This fixes the type filtering so seller requests will now display correctly.