### PR TITLE
fix: update all API routes to use new Request model schema

### DIFF
--- a/backend/src/api/admin/requests/[id]/approve/route.ts
+++ b/backend/src/api/admin/requests/[id]/approve/route.ts
@@ -42,14 +42,14 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       return
     }
 
-    const payload = request.payload as Record<string, unknown>
+    const data = request.data as Record<string, unknown>
 
     // Handle seller creation requests
-    if (payload?.type === SELLER_REQUEST_TYPE) {
-      const authIdentityId = payload.auth_identity_id as string
-      const member = payload.member as { name: string; email: string }
-      const seller = payload.seller as { name: string }
-      const vendorType = (payload.vendor_type as string) || "producer"
+    if (request.type === "seller" || request.type === SELLER_REQUEST_TYPE) {
+      const authIdentityId = data.auth_identity_id as string
+      const member = data.member as { name: string; email: string }
+      const seller = data.seller as { name: string }
+      const vendorType = (data.vendor_type as string) || "producer"
 
       if (!authIdentityId || !member || !seller) {
         res.status(400).json({

--- a/backend/src/api/admin/requests/[id]/reject/route.ts
+++ b/backend/src/api/admin/requests/[id]/reject/route.ts
@@ -39,11 +39,11 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       return
     }
 
-    // Update notes with rejection reason if provided
+    // Update reviewer note with rejection reason if provided
     if (reason) {
       await requestService.updateRequests(
         { id },
-        { notes: `${request.notes || ""}\n\nRejection reason: ${reason}`.trim() }
+        { reviewer_note: `${request.reviewer_note || ""}\n\nRejection reason: ${reason}`.trim() }
       )
     }
 

--- a/backend/src/api/store/requests/route.ts
+++ b/backend/src/api/store/requests/route.ts
@@ -9,9 +9,9 @@ import { requireCustomerId } from "../../../shared"
 // ===========================================
 
 const createRequestSchema = z.object({
-  provider_id: z.string().optional(),
-  payload: z.record(z.unknown()).optional(),
-  notes: z.string().optional(),
+  type: z.string().min(1, "Request type is required"),
+  data: z.record(z.unknown()).default({}),
+  reviewer_note: z.string().optional(),
 })
 
 // ===========================================
@@ -52,10 +52,10 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
 
     const request = await requestService.createRequest({
+      type: data.type,
+      data: data.data,
       requester_id: customerId,
-      provider_id: data.provider_id,
-      payload: data.payload,
-      notes: data.notes,
+      reviewer_note: data.reviewer_note,
     })
 
     res.status(201).json({

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -63,9 +63,8 @@ export const POST = async (
     const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
 
     const sellerRequest = await requestService.createRequest({
-      submitter_id: authIdentity.id,
-      payload: {
-        type: SELLER_REQUEST_TYPE,
+      type: "seller",
+      data: {
         auth_identity_id: authIdentity.id,
         member: {
           name: body.member.name,
@@ -77,7 +76,8 @@ export const POST = async (
         // Store vendor_type selection (defaults to "producer" if not provided)
         vendor_type: body.vendor_type || "producer",
       },
-      notes: `Seller registration request for "${body.name}" by ${body.member.email}`,
+      submitter_id: authIdentity.id,
+      reviewer_note: `Seller registration request for "${body.name}" by ${body.member.email}`,
     })
 
     console.log("[POST /vendor/sellers] Created seller request:", sellerRequest)


### PR DESCRIPTION
Fixed TypeScript errors from model migration:
- Changed 'payload' → 'data' throughout
- Changed 'notes' → 'reviewer_note'
- Moved 'type' from data object to direct parameter
- Removed 'provider_id' references (doesn't exist in DB)

Files updated:
- admin/requests/[id]/approve/route.ts: Use request.data and request.type
- admin/requests/[id]/reject/route.ts: Use reviewer_note instead of notes
- store/requests/route.ts: Updated schema and handler to use type/data
- vendor/sellers/route.ts: Separate type parameter from data object

This completes the Request model migration to match the database schema.