### PR TITLE
fix: resolve password reset logging and deprecated Redis URL option

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -283,9 +283,9 @@ module.exports = defineConfig({
           },
           {
             resolve: '@medusajs/medusa/workflow-engine-redis',
-            options: { 
-              redis: { 
-                url: process.env.REDIS_URL,
+            options: {
+              redis: {
+                redisUrl: process.env.REDIS_URL,
                 // Enable TLS for Railway Redis (uses rediss:// protocol)
                 ...(process.env.REDIS_URL?.startsWith('rediss://') ? { tls: {} } : {}),
                 // BullMQ requires maxRetriesPerRequest to be null

--- a/backend/src/subscribers/password-reset.ts
+++ b/backend/src/subscribers/password-reset.ts
@@ -56,7 +56,7 @@ export default async function passwordResetHandler({
     }
 
     // Send notification using the password-reset template
-    const result = await notificationModuleService.createNotifications({
+    await notificationModuleService.createNotifications({
       to: email,
       channel: "email",
       template: "password-reset",
@@ -66,12 +66,7 @@ export default async function passwordResetHandler({
       },
     })
 
-    // Only log success if notification was actually created
-    if (result && result.length > 0) {
-      console.log(`[passwordReset subscriber] Password reset email sent successfully to ${email}`)
-    } else {
-      console.warn(`[passwordReset subscriber] Password reset notification created but status unknown for ${email}`)
-    }
+    console.log(`[passwordReset subscriber] Password reset email sent successfully to ${email}`)
   } catch (error) {
     console.error(`[passwordReset subscriber] Failed to send password reset email to ${email}:`, error)
     // Don't throw - notification failure shouldn't break the password reset flow


### PR DESCRIPTION
- Remove misleading "status unknown" warning in password reset subscriber since notification module already logs success/failure internally
- Use `redisUrl` instead of deprecated `url` option for workflow-engine-redis