### PR TITLE
fix: remove invalid filters wrapper in Hawala settlement job query

### DIFF
--- a/backend/src/jobs/hawala-settlement.ts
+++ b/backend/src/jobs/hawala-settlement.ts
@@ -15,9 +15,7 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
   try {
     // Get unsettled entries from the last 24 hours
     const entries = await hawalaService.listLedgerEntries({
-      filters: {
-        status: "COMPLETED",
-      },
+      status: "COMPLETED",
     })
 
     // Filter to only unsettled entries


### PR DESCRIPTION
The listLedgerEntries method expects filter criteria directly as object properties, not nested under a 'filters' key. This was causing the error: "Trying to query by not existing property HawalaLedgerEntry.filters"