### PR TITLE
fix: pass vendor_type to backend during seller registration

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -48,13 +48,14 @@ export const useSignUpWithEmailPass = (
     onSuccess: async (data, variables, context) => {
       const normalizedEmail = variables.email.toLowerCase().trim()
 
-      // MercurJS vendor endpoint ONLY accepts name + member
+      // Create seller registration request with vendor type
       // Wrap in try/catch to prevent uncaught fetch errors
       try {
         await fetchQuery("/vendor/sellers", {
           method: "POST",
           body: {
             name: variables.name,
+            vendor_type: variables.vendor_type || "producer",
             member: {
               name: variables.name,
               email: normalizedEmail,


### PR DESCRIPTION
The vendor_type selection was being extracted from the payload but never sent to the /vendor/sellers endpoint, causing all sellers to default to "producer" regardless of their selection during registration.