### PR TITLE
fix: store auth token in localStorage for vendor panel bearer authent…

### DIFF
--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -8,13 +8,27 @@ const runtimeBackend =
 export const backendUrl = (runtimeBackend || __BACKEND_URL__) ?? "/"
 export const publishableApiKey = __PUBLISHABLE_API_KEY__ ?? ""
 
-const token = typeof window !== "undefined" ? window.localStorage.getItem("medusa_auth_token") || "" : ""
+export const getAuthToken = () => {
+  return typeof window !== "undefined" ? window.localStorage.getItem("medusa_auth_token") || "" : ""
+}
+
+export const setAuthToken = (token: string) => {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem("medusa_auth_token", token)
+  }
+}
+
+export const clearAuthToken = () => {
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem("medusa_auth_token")
+  }
+}
 
 export const sdk = new Medusa({
   baseUrl: backendUrl,
   publishableKey: publishableApiKey,
   auth: {
-    type: "session",
+    type: "bearer",
   },
 })
 
@@ -33,7 +47,7 @@ export const importProductsQuery = async (file: File) => {
     body: formData,
     credentials: 'include',
     headers: {
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${getAuthToken()}`,
       "x-publishable-api-key": publishableApiKey,
     },
   })
@@ -53,7 +67,7 @@ export const uploadFilesQuery = async (files: any[]) => {
     body: formData,
     credentials: 'include',
     headers: {
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${getAuthToken()}`,
       "x-publishable-api-key": publishableApiKey,
     },
   })


### PR DESCRIPTION
…ication

- Changed SDK auth type from "session" to "bearer" for proper token-based auth
- Added setAuthToken, getAuthToken, and clearAuthToken helper functions
- Store token in localStorage after successful login and registration
- Clear token on logout
- Fixed importProductsQuery and uploadFilesQuery to read token dynamically instead of using a static variable that was always empty

The issue was that requests to vendor API were being sent with "Bearer " (empty token) because the token was read once at module load time when localStorage was empty, and the SDK was configured for session auth which doesn't store tokens in localStorage.