### PR TITLE
fix: use jwt auth type with local storage for Medusa SDK

### DIFF
--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -28,7 +28,8 @@ export const sdk = new Medusa({
   baseUrl: backendUrl,
   publishableKey: publishableApiKey,
   auth: {
-    type: "bearer",
+    type: "jwt",
+    jwtTokenStorageMethod: "local",
   },
 })
 


### PR DESCRIPTION
Changed SDK auth configuration from type "bearer" to type "jwt" with jwtTokenStorageMethod "local" as per Medusa JS SDK documentation. This ensures proper token storage and retrieval from localStorage.