### PR TITLE
fix: clear stale auth token on 401/403 errors

### DIFF
--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -117,6 +117,10 @@ export const fetchQuery = async (
 
   if (!response.ok) {
     const errorData = await response.json()
+    // Clear stale token on auth errors to prevent redirect loops
+    if (response.status === 401 || response.status === 403) {
+      clearAuthToken()
+    }
     throw new Error(errorData.message || "Nieznany błąd serwera")
   }
 


### PR DESCRIPTION
When a stale token exists in localStorage from a previous session, the app would show "Seller is not active" error before the user even logs in. Now the token is automatically cleared on auth errors so users see a clean login page instead of an error message.