### PR TITLE
fix: resolve seller auth registration loop for pending users

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -451,6 +451,11 @@ export default defineMiddlewares({
       matcher: "/admin/invites",
       middlewares: [normalizeEmailMiddleware],
     },
+    // Vendor registration status - seller auth to get auth_identity_id (no seller required)
+    {
+      matcher: "/vendor/registration-status",
+      middlewares: [authenticate("seller", "bearer")],
+    },
     // Vendor sellers/me route - seller authentication for profile access
     {
       matcher: "/vendor/sellers/me",

--- a/backend/src/api/vendor/registration-status/route.ts
+++ b/backend/src/api/vendor/registration-status/route.ts
@@ -1,0 +1,147 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { Modules } from "@medusajs/framework/utils"
+import { REQUEST_MODULE } from "../../../modules/request"
+import RequestModuleService from "../../../modules/request/service"
+
+/**
+ * GET /vendor/registration-status
+ *
+ * Check the registration status for the authenticated user.
+ * This endpoint helps the vendor panel determine if a user:
+ * - Has an approved seller account (can access dashboard)
+ * - Has a pending registration request (should see pending page)
+ * - Has no registration at all (should complete registration)
+ *
+ * This endpoint uses bearer auth but doesn't require a seller_id,
+ * allowing newly registered users to check their status.
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  try {
+    // Get auth_identity_id from the auth context
+    // This is available even if no seller has been created yet
+    const authIdentityId = req.auth_context?.auth_identity_id
+    const sellerId = req.auth_context?.actor_id
+
+    // If we have a seller_id, the user is approved
+    if (sellerId) {
+      return res.json({
+        status: "approved",
+        seller_id: sellerId,
+        message: "Your seller account is approved. You can access the vendor dashboard.",
+      })
+    }
+
+    // No seller_id - check if we have an auth_identity to look up requests
+    if (!authIdentityId) {
+      return res.status(401).json({
+        status: "unauthenticated",
+        message: "Authentication required. Please log in or register.",
+      })
+    }
+
+    // Look up the auth_identity to check app_metadata
+    const authModule = req.scope.resolve(Modules.AUTH)
+    const authIdentities = await authModule.listAuthIdentities({
+      id: [authIdentityId],
+    })
+
+    if (!authIdentities || authIdentities.length === 0) {
+      return res.status(401).json({
+        status: "unauthenticated",
+        message: "Invalid authentication. Please log in again.",
+      })
+    }
+
+    const authIdentity = authIdentities[0]
+
+    // Double-check app_metadata for seller_id (in case auth_context didn't have it)
+    const appMetadata = authIdentity.app_metadata as Record<string, unknown> | undefined
+    if (appMetadata?.seller_id) {
+      return res.json({
+        status: "approved",
+        seller_id: appMetadata.seller_id,
+        message: "Your seller account is approved. You can access the vendor dashboard.",
+      })
+    }
+
+    // No seller_id in app_metadata - check for pending requests
+    const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
+
+    // Find requests for this auth identity
+    const requests = await requestService.listRequests({
+      type: "seller",
+    })
+
+    // Filter to find requests that belong to this auth identity
+    // The auth_identity_id is stored in the request data
+    const userRequests = requests.filter((request) => {
+      const data = request.data as Record<string, unknown> | undefined
+      return data?.auth_identity_id === authIdentityId
+    })
+
+    if (userRequests.length === 0) {
+      // No requests found - user needs to complete registration
+      return res.json({
+        status: "no_request",
+        message: "No registration request found. Please complete the registration process.",
+      })
+    }
+
+    // Find the most recent request
+    const sortedRequests = userRequests.sort((a, b) => {
+      const dateA = new Date(a.created_at || 0).getTime()
+      const dateB = new Date(b.created_at || 0).getTime()
+      return dateB - dateA
+    })
+    const latestRequest = sortedRequests[0]
+
+    // Return status based on request status
+    switch (latestRequest.status) {
+      case "pending":
+        return res.json({
+          status: "pending",
+          request_id: latestRequest.id,
+          message: "Your registration request is pending approval. Please wait for an administrator to review your application.",
+          created_at: latestRequest.created_at,
+        })
+
+      case "accepted":
+        // Request was accepted but seller_id wasn't linked properly
+        // This shouldn't normally happen, but handle it gracefully
+        return res.json({
+          status: "approved",
+          request_id: latestRequest.id,
+          message: "Your registration has been approved. If you cannot access the dashboard, please contact support.",
+        })
+
+      case "rejected":
+        return res.json({
+          status: "rejected",
+          request_id: latestRequest.id,
+          message: "Your registration request was not approved. Please contact support for more information.",
+          reviewer_note: latestRequest.reviewer_note,
+        })
+
+      case "cancelled":
+        return res.json({
+          status: "cancelled",
+          request_id: latestRequest.id,
+          message: "Your registration request was cancelled. You may submit a new registration.",
+        })
+
+      default:
+        return res.json({
+          status: "unknown",
+          request_id: latestRequest.id,
+          message: "Unable to determine registration status. Please contact support.",
+        })
+    }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error"
+    console.error("[GET /vendor/registration-status] Error:", errorMessage)
+    return res.status(500).json({
+      status: "error",
+      message: "Failed to check registration status. Please try again later.",
+    })
+  }
+}

--- a/vendor-panel/src/components/authentication/protected-route/protected-route.tsx
+++ b/vendor-panel/src/components/authentication/protected-route/protected-route.tsx
@@ -1,15 +1,45 @@
 import { Spinner } from "@medusajs/icons"
 import { Navigate, Outlet, useLocation } from "react-router-dom"
-import { useMe } from "../../../hooks/api/users"
+import { useMe, useRegistrationStatus } from "../../../hooks/api/users"
 import { SearchProvider } from "../../../providers/search-provider"
 import { SidebarProvider } from "../../../providers/sidebar-provider"
 import { RocketChatProvider } from "../../../providers/rocketchat-provider"
+import { getAuthToken } from "../../../lib/client"
 
 export const ProtectedRoute = () => {
-  const { seller, isPending, error } = useMe()
-
   const location = useLocation()
-  if (isPending) {
+  const hasToken = Boolean(getAuthToken())
+
+  // First, check registration status to determine the appropriate redirect
+  // This check runs before useMe to prevent the auth loop
+  const {
+    registrationStatus,
+    isPending: isStatusPending
+  } = useRegistrationStatus({
+    // Only run this query if we have a token
+    enabled: hasToken,
+  })
+
+  // Only fetch seller data if registration status indicates approval
+  const isApproved = registrationStatus?.status === "approved"
+  const { seller, isPending: isSellerPending, error } = useMe({
+    // Only run useMe if we know the user is approved
+    enabled: isApproved,
+  })
+
+  // If no token, redirect to login immediately
+  if (!hasToken) {
+    return (
+      <Navigate
+        to="/login"
+        state={{ from: location }}
+        replace
+      />
+    )
+  }
+
+  // Show loading while checking registration status
+  if (isStatusPending) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner className="text-ui-fg-interactive animate-spin" />
@@ -17,6 +47,47 @@ export const ProtectedRoute = () => {
     )
   }
 
+  // Handle different registration statuses
+  if (registrationStatus) {
+    switch (registrationStatus.status) {
+      case "pending":
+      case "rejected":
+      case "cancelled":
+      case "no_request":
+        // Redirect to pending-approval page for non-approved states
+        return <Navigate to="/pending-approval" replace />
+
+      case "unauthenticated":
+        // Token is invalid or expired
+        return (
+          <Navigate
+            to="/login"
+            state={{ from: location }}
+            replace
+          />
+        )
+
+      case "approved":
+        // Continue to load seller data below
+        break
+
+      default:
+        // Unknown status - show pending page with error info
+        return <Navigate to="/pending-approval" replace />
+    }
+  }
+
+  // If approved, show loading while fetching seller data
+  if (isSellerPending) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner className="text-ui-fg-interactive animate-spin" />
+      </div>
+    )
+  }
+
+  // If we have an error or no seller after approval status, redirect to login
+  // This handles edge cases where approval succeeded but seller fetch fails
   if (!seller) {
     return (
       <Navigate
@@ -27,6 +98,7 @@ export const ProtectedRoute = () => {
     )
   }
 
+  // User is approved and seller data is loaded - render the protected content
   return (
     <RocketChatProvider>
       <SidebarProvider>

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -2057,6 +2057,10 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/reset-password"),
           },
           {
+            path: "/pending-approval",
+            lazy: () => import("../../routes/pending-approval"),
+          },
+          {
             path: "/invite",
             lazy: () => import("../../routes/invite"),
           },

--- a/vendor-panel/src/routes/pending-approval/index.ts
+++ b/vendor-panel/src/routes/pending-approval/index.ts
@@ -1,0 +1,1 @@
+export { PendingApproval as Component } from "./pending-approval"

--- a/vendor-panel/src/routes/pending-approval/pending-approval.tsx
+++ b/vendor-panel/src/routes/pending-approval/pending-approval.tsx
@@ -1,0 +1,186 @@
+import { Button, Heading, Text } from "@medusajs/ui"
+import { Link, Navigate } from "react-router-dom"
+import AvatarBox from "../../components/common/logo-box/avatar-box"
+import { useLogout } from "../../hooks/api/auth"
+import { useRegistrationStatus } from "../../hooks/api/users"
+import { Spinner } from "@medusajs/icons"
+import { clearAuthToken } from "../../lib/client"
+
+/**
+ * Pending Approval Page
+ *
+ * Shown to users who have registered but are waiting for admin approval.
+ * This prevents the login loop that occurs when a user has a valid auth token
+ * but no approved seller account linked to it.
+ */
+export const PendingApproval = () => {
+  const { registrationStatus, isPending, refetch } = useRegistrationStatus()
+  const { mutate: logout, isPending: isLoggingOut } = useLogout()
+
+  const handleLogout = () => {
+    logout(undefined, {
+      onSuccess: () => {
+        clearAuthToken()
+        window.location.href = "/login"
+      },
+      onError: () => {
+        // Force logout even on error
+        clearAuthToken()
+        window.location.href = "/login"
+      },
+    })
+  }
+
+  const handleRefresh = () => {
+    refetch()
+  }
+
+  // Show loading state
+  if (isPending) {
+    return (
+      <div className="bg-ui-bg-subtle flex min-h-dvh w-dvw items-center justify-center">
+        <Spinner className="text-ui-fg-interactive animate-spin" />
+      </div>
+    )
+  }
+
+  // If user is approved, redirect to dashboard
+  if (registrationStatus?.status === "approved") {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  // If user is not authenticated, redirect to login
+  if (registrationStatus?.status === "unauthenticated") {
+    return <Navigate to="/login" replace />
+  }
+
+  // Render appropriate content based on status
+  const renderContent = () => {
+    switch (registrationStatus?.status) {
+      case "pending":
+        return (
+          <>
+            <div className="w-16 h-16 rounded-full bg-ui-tag-orange-bg flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-ui-tag-orange-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <Heading>Pending Approval</Heading>
+            <Text size="small" className="text-ui-fg-subtle text-center mt-2 max-w-[320px]">
+              Your seller registration is being reviewed by our team. You will receive an email once your account has been approved.
+            </Text>
+            <Text size="xsmall" className="text-ui-fg-muted text-center mt-4 max-w-[280px]">
+              This usually takes 1-2 business days. If you have questions, please contact support.
+            </Text>
+          </>
+        )
+
+      case "rejected":
+        return (
+          <>
+            <div className="w-16 h-16 rounded-full bg-ui-tag-red-bg flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-ui-tag-red-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <Heading>Registration Not Approved</Heading>
+            <Text size="small" className="text-ui-fg-subtle text-center mt-2 max-w-[320px]">
+              Unfortunately, your seller registration was not approved.
+            </Text>
+            {registrationStatus.reviewer_note && (
+              <div className="bg-ui-bg-component p-3 rounded-lg mt-4 max-w-[320px]">
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  Note: {registrationStatus.reviewer_note}
+                </Text>
+              </div>
+            )}
+            <Text size="xsmall" className="text-ui-fg-muted text-center mt-4 max-w-[280px]">
+              Please contact support if you believe this is an error or would like more information.
+            </Text>
+          </>
+        )
+
+      case "cancelled":
+        return (
+          <>
+            <div className="w-16 h-16 rounded-full bg-ui-tag-neutral-bg flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-ui-tag-neutral-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+              </svg>
+            </div>
+            <Heading>Registration Cancelled</Heading>
+            <Text size="small" className="text-ui-fg-subtle text-center mt-2 max-w-[320px]">
+              Your seller registration has been cancelled. You may submit a new registration if you wish to join as a seller.
+            </Text>
+          </>
+        )
+
+      case "no_request":
+        return (
+          <>
+            <div className="w-16 h-16 rounded-full bg-ui-tag-blue-bg flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-ui-tag-blue-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <Heading>Registration Incomplete</Heading>
+            <Text size="small" className="text-ui-fg-subtle text-center mt-2 max-w-[320px]">
+              It looks like your seller registration is incomplete. Please complete the registration process to submit your application.
+            </Text>
+            <Link to="/register" className="mt-6">
+              <Button>Complete Registration</Button>
+            </Link>
+          </>
+        )
+
+      default:
+        return (
+          <>
+            <div className="w-16 h-16 rounded-full bg-ui-tag-neutral-bg flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-ui-tag-neutral-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <Heading>Unknown Status</Heading>
+            <Text size="small" className="text-ui-fg-subtle text-center mt-2 max-w-[320px]">
+              We couldn't determine the status of your registration. Please try refreshing or contact support.
+            </Text>
+          </>
+        )
+    }
+  }
+
+  return (
+    <div className="bg-ui-bg-subtle flex min-h-dvh w-dvw items-center justify-center">
+      <div className="m-4 flex flex-col items-center max-w-md">
+        <AvatarBox />
+
+        {renderContent()}
+
+        <div className="flex flex-col items-center gap-4 mt-8">
+          {registrationStatus?.status === "pending" && (
+            <Button variant="secondary" onClick={handleRefresh} disabled={isPending}>
+              Check Status
+            </Button>
+          )}
+
+          <Button variant="transparent" onClick={handleLogout} disabled={isLoggingOut}>
+            {isLoggingOut ? "Logging out..." : "Log out"}
+          </Button>
+
+          {registrationStatus?.status !== "no_request" && (
+            <Text size="xsmall" className="text-ui-fg-muted text-center mt-2">
+              Need help?{" "}
+              <a
+                href="mailto:support@freeblackmarket.com"
+                className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+              >
+                Contact Support
+              </a>
+            </Text>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
After registration, users get a valid auth token but their seller account isn't approved yet. The /vendor/sellers/me endpoint requires an approved seller_id, causing a 401 error that triggers a redirect to login, creating an infinite loop.

Changes:
- Add /vendor/registration-status endpoint to check approval state without requiring seller_id (backend)
- Add useRegistrationStatus hook to check user's registration status
- Update ProtectedRoute to check registration status before loading seller data, redirecting pending users to /pending-approval
- Add /pending-approval page showing status and appropriate messages for pending, rejected, cancelled, and incomplete registrations
- Add route configuration for the new pending-approval page

The fix prevents the auth loop by checking registration status first and redirecting non-approved users to an appropriate waiting page.