### PR TITLE
fix: invalidate query cache after request status update

### DIFF
--- a/admin-panel/src/hooks/api/requests.tsx
+++ b/admin-panel/src/hooks/api/requests.tsx
@@ -1,4 +1,5 @@
 import { sdk } from "@lib/client";
+import { queryClient } from "@lib/query-client";
 import { queryKeysFactory } from "@lib/query-key-factory";
 import {
   type QueryKey,
@@ -72,6 +73,10 @@ export const useReviewRequest = (
         method: "POST",
         body: payload,
       }),
+    onSettled: () => {
+      // Invalidate all requests queries to ensure fresh data is fetched
+      queryClient.invalidateQueries({ queryKey: requestsQueryKeys.all });
+    },
     ...options,
   });
 };


### PR DESCRIPTION
The admin panel request list was not refreshing after approving/rejecting a request due to React Query's staleTime (90 seconds) causing cached data to be returned. Added onSettled callback to useReviewRequest mutation to invalidate all request queries, ensuring fresh data is fetched after any status update.