### PR TITLE
fix: correct updateRequests return type handling in request service

### DIFF
--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -252,7 +252,7 @@ class RequestModuleService extends MedusaService({
 
     // Use retrieveRequest + update pattern for more reliable single-record update
     try {
-      const [updatedRequest] = await this.updateRequests(
+      const updatedRequest = await this.updateRequests(
         { id },
         updateData
       )
@@ -304,7 +304,7 @@ class RequestModuleService extends MedusaService({
       updateData.reviewer_note = reviewerNote
     }
 
-    const [updatedRequest] = await this.updateRequests(
+    const updatedRequest = await this.updateRequests(
       { id },
       updateData
     )


### PR DESCRIPTION
The MedusaService.updateRequests method returns a single object, not an array. Removed array destructuring that was causing TypeScript errors.

https://claude.ai/code/session_01PRVV5qTaQPVYawuSkB6NBz