### PR TITLE
fix: remove unsupported databaseExtra config property

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -125,11 +125,10 @@ ENABLE_STRIPE_ACH=false
 NODE_MEMORY_MB=512
 
 # Database Connection Pool Settings
-# Optimized for Railway's connection behavior
-DB_POOL_MIN=2
-DB_POOL_MAX=10
-DB_POOL_IDLE_TIMEOUT=30000
-DB_POOL_ACQUIRE_TIMEOUT=60000
+# For Railway, add these parameters to your DATABASE_URL:
+# ?connection_limit=10&pool_timeout=30&connect_timeout=10
+# Example: postgres://user:pass@host:5432/db?connection_limit=10&pool_timeout=30
+# Or use Railway's PgBouncer add-on for production connection pooling
 
 # Startup Optimization
 # Skip seeding on subsequent deployments (set to true after first successful seed)

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -77,27 +77,14 @@ const getAdminCors = () => {
   return Array.from(origins).join(',')
 }
 
-// Database connection pool configuration optimized for Railway
-const getDatabasePoolConfig = () => {
-  // Parse connection pool settings from environment or use optimized defaults
-  const poolMin = parseInt(process.env.DB_POOL_MIN || '2', 10)
-  const poolMax = parseInt(process.env.DB_POOL_MAX || '10', 10)
-  const poolIdleTimeout = parseInt(process.env.DB_POOL_IDLE_TIMEOUT || '30000', 10)
-  const poolAcquireTimeout = parseInt(process.env.DB_POOL_ACQUIRE_TIMEOUT || '60000', 10)
-
-  return {
-    min: poolMin,
-    max: poolMax,
-    idleTimeoutMillis: poolIdleTimeout,
-    acquireTimeoutMillis: poolAcquireTimeout,
-  }
-}
+// Note: Database connection pooling is configured via DATABASE_URL parameters
+// Add these to your DATABASE_URL for Railway optimization:
+// ?connection_limit=10&pool_timeout=30&connect_timeout=10
+// Or use PgBouncer for connection pooling in production
 
 module.exports = defineConfig({
   projectConfig: {
     databaseUrl: process.env.DATABASE_URL,
-    // Connection pool settings for Railway reliability
-    databaseExtra: getDatabasePoolConfig(),
     ...(process.env.REDIS_URL ? { redisUrl: process.env.REDIS_URL } : {}),
     http: {
       storeCors: getStoreCors(),


### PR DESCRIPTION
MedusaJS's defineConfig doesn't support databaseExtra or databaseDriverOptions. Connection pooling should be configured via DATABASE_URL parameters instead:
- ?connection_limit=10&pool_timeout=30&connect_timeout=10
- Or use Railway's PgBouncer add-on for production

Updated .env.template with correct DATABASE_URL parameter documentation.

https://claude.ai/code/session_01VxS2QXySBjm4iyG4j8tmZn