### PR TITLE
fix: increase healthcheck timeout to 300s for Metal builder scheduling

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -19,7 +19,7 @@
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 120,
+    "healthcheckTimeout": 300,
     "numReplicas": 1
   }
 }

--- a/backend/railway.staging.json
+++ b/backend/railway.staging.json
@@ -19,7 +19,7 @@
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 90,
+    "healthcheckTimeout": 300,
     "numReplicas": 1
   }
 }


### PR DESCRIPTION
The healthcheck was timing out because:
- Startup takes ~88 seconds (migrations + seeding + init + server)
- Previous timeout of 120s (prod) / 90s (staging) left too little buffer
- Railway's exponential backoff meant attempt #6 happened only 3 seconds after server became ready, then immediately gave up

Increased timeout to 300s (5 minutes) for both environments to provide sufficient buffer for the slow startup sequence.

https://claude.ai/code/session_013EAo2gVuSP2e3qLagsnYbh