### PR TITLE
Add jsonwebtoken to backend dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -62,6 +62,7 @@
     "axios": "^1.13.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.3",
     "json-rpc-2.0": "^1.7.1",
     "medusajs-launch-utils": "^0.0.18",
     "minio": "^8.0.3",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       json-rpc-2.0:
         specifier: ^1.7.1
         version: 1.7.1


### PR DESCRIPTION
### Motivation
- Add `jsonwebtoken` to the `backend` dependencies so the seller registration auth route (`backend/src/api/auth/seller/registration-status/route.ts`) that imports `jsonwebtoken` can compile and run.

### Description
- Added `jsonwebtoken` at `^9.0.3` to `backend/package.json` and updated `backend/pnpm-lock.yaml` to include the new dependency in the importer section.

### Testing
- No automated tests were run for this change (dependency-only update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978fc1c1ba483239928d1b30625a25d)