### PR TITLE
Send auth token for vendor registration request

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -62,6 +62,7 @@
     "axios": "^1.13.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.3",
     "json-rpc-2.0": "^1.7.1",
     "medusajs-launch-utils": "^0.0.18",
     "minio": "^8.0.3",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       json-rpc-2.0:
         specifier: ^1.7.1
         version: 1.7.1

--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -3,7 +3,6 @@ import Medusa from "@medusajs/js-sdk"
 // PUBLIC ROUTE CHECKER
 export const isPublicAuthRoute = (url: string) => {
   return (
-    url.startsWith("/vendor/register") ||
     url.startsWith("/auth/") ||
     url.startsWith("/vendor/auth")
   )


### PR DESCRIPTION
### Motivation
- Treat `/vendor/register` as an authenticated route so the vendor registration request includes the bearer token and avoids `Unauthorized` errors when creating seller registration requests.

### Description
- Remove `/vendor/register` from the public route checker by updating `isPublicAuthRoute` in `vendor-panel/src/lib/client/client.ts` so `fetchQuery` will include the `Authorization: Bearer <token>` header for vendor registration.

### Testing
- No automated tests were run for this client-side auth change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978fc1c1ba483239928d1b30625a25d)