### PR TITLE
Omit cookies on public vendor requests; improve auth and registration checks

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -62,6 +62,7 @@
     "axios": "^1.13.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.3",
     "json-rpc-2.0": "^1.7.1",
     "medusajs-launch-utils": "^0.0.18",
     "minio": "^8.0.3",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       json-rpc-2.0:
         specifier: ^1.7.1
         version: 1.7.1

--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -99,10 +99,12 @@ export const fetchQuery = async (
 
   const response = await fetch(`${backendUrl}${url}${params ? `?${params}` : ""}`, {
     method,
-    credentials: "include",
+    credentials: isPublic ? "omit" : "include",
     headers: {
       ...(isPublic
-        ? {}
+        ? {
+            ...(publishableApiKey ? { "x-publishable-api-key": publishableApiKey } : {}),
+          }
         : {
             authorization: `Bearer ${token}`,
             "x-publishable-api-key": publishableApiKey,


### PR DESCRIPTION
### Motivation
- Prevent pending or inactive seller sessions from causing 403s on public endpoints like `/vendor/register` by avoiding sending cookies on public requests.
- Avoid failing signup when an auth identity already exists by falling back to login and unify email normalization for register/login flows.
- Ensure the UI only attempts to fetch seller details when the seller registration is `approved` to avoid unnecessary errors.

### Description
- Updated `fetchQuery` to detect public auth routes via `isPublicAuthRoute` and set `credentials` to `omit` for public requests while including a `x-publishable-api-key` header for public calls, and to continue using `include` for authenticated calls with `authorization: Bearer` token.
- Added `fetchRegistrationStatus` helper and updated `useRegistrationStatus` to use it, and changed `useMe` to return `null` when there is no token or the registration `status` is not `approved` to avoid fetching `/vendor/sellers/me` prematurely.
- Enhanced the signup flow in `useSignUpWithEmailPass` to normalize the email via `toLowerCase().trim()`, wrap `sdk.auth.register` in a `try/catch`, and on `409` or an "already exists" error attempt `sdk.auth.login` and call `setAuthToken` on success.
- Added `jsonwebtoken` to the backend `package.json` and updated `pnpm-lock.yaml` to include the new dependency.

### Testing
- No automated tests were run for these client- and hook-level changes.
- Changes were validated by adjusting client request behavior and code paths locally during development and committed without running CI tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978fc1c1ba483239928d1b30625a25d)