### PR TITLE
Add public auth endpoint for seller registration requests and centralize handler

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -62,6 +62,7 @@
     "axios": "^1.13.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.3",
     "json-rpc-2.0": "^1.7.1",
     "medusajs-launch-utils": "^0.0.18",
     "minio": "^8.0.3",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.1
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       json-rpc-2.0:
         specifier: ^1.7.1
         version: 1.7.1

--- a/backend/src/api/auth/seller/register-request/route.ts
+++ b/backend/src/api/auth/seller/register-request/route.ts
@@ -1,0 +1,14 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { handleSellerRegistration } from "../../../shared/seller-registration"
+
+export const AUTHENTICATE = false
+
+/**
+ * POST /auth/seller/register-request
+ *
+ * Public endpoint used by the vendor panel to submit a seller registration request
+ * without triggering vendor actor authentication.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  return handleSellerRegistration(req, res)
+}

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -344,6 +344,11 @@ export default defineMiddlewares({
       matcher: "/auth/seller/registration-status",
       middlewares: [vendorCorsMiddleware],
     },
+    // CORS for seller registration request (vendor panel signup)
+    {
+      matcher: "/auth/seller/register-request",
+      middlewares: [vendorCorsMiddleware],
+    },
     // CORS for custom admin routes (requests, sellers, etc.)
     {
       matcher: "/admin/requests*",

--- a/backend/src/api/shared/seller-registration.ts
+++ b/backend/src/api/shared/seller-registration.ts
@@ -1,0 +1,115 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { REQUEST_MODULE } from "../../modules/request"
+import RequestModuleService from "../../modules/request/service"
+import { REQUEST_TYPES } from "../../modules/request/validators"
+import {
+  createSellerRegistrationSchema,
+  CreateSellerRegistrationInput,
+} from "../vendor/register/validators"
+import { maskEmail } from "../../shared/seller-approval-service"
+
+export const handleSellerRegistration = async (
+  req: MedusaRequest,
+  res: MedusaResponse
+) => {
+  let body: CreateSellerRegistrationInput
+  try {
+    body = createSellerRegistrationSchema.parse(req.body)
+  } catch (validationError: any) {
+    console.error("[Seller registration] Validation error")
+    return res.status(400).json({
+      type: "invalid_data",
+      message: validationError.errors?.[0]?.message || "Invalid request data",
+      errors: validationError.errors,
+    })
+  }
+
+  console.log(
+    `[Seller registration] Creating request: "${body.name}" (email: ${maskEmail(
+      body.member.email
+    )})`
+  )
+
+  try {
+    const authModule = req.scope.resolve(Modules.AUTH)
+    const [authIdentity] = await authModule.listAuthIdentities({
+      provider_identities: {
+        entity_id: body.member.email,
+      },
+    })
+
+    if (!authIdentity) {
+      console.error(
+        `[Seller registration] Auth identity not found for email: ${maskEmail(
+          body.member.email
+        )}`
+      )
+      return res.status(400).json({
+        type: "invalid_data",
+        message: "Please complete authentication registration first",
+      })
+    }
+
+    console.log(`[Seller registration] Found auth identity: ${authIdentity.id}`)
+
+    const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
+    const existingRequests = await requestService.listRequests({
+      type: REQUEST_TYPES.SELLER,
+    })
+
+    const userExistingRequest = existingRequests.find((request) => {
+      const data = request.data as Record<string, unknown> | undefined
+      return data?.auth_identity_id === authIdentity.id && request.status === "pending"
+    })
+
+    if (userExistingRequest) {
+      console.log(
+        `[Seller registration] Found existing pending request: ${userExistingRequest.id}`
+      )
+      return res.status(200).json({
+        request: {
+          id: userExistingRequest.id,
+          status: userExistingRequest.status || "pending",
+          message:
+            "You already have a pending registration request. Please wait for admin approval.",
+        },
+      })
+    }
+
+    const sellerRequest = await requestService.createRequest({
+      type: REQUEST_TYPES.SELLER,
+      data: {
+        auth_identity_id: authIdentity.id,
+        member: {
+          name: body.member.name,
+          email: body.member.email,
+        },
+        seller: {
+          name: body.name,
+        },
+        vendor_type: body.vendor_type || "producer",
+      },
+      submitter_id: authIdentity.id,
+      reviewer_note: `Seller registration request for "${body.name}"`,
+    })
+
+    console.log(`[Seller registration] Created request: ${sellerRequest.id}`)
+
+    return res.status(201).json({
+      request: {
+        id: sellerRequest.id,
+        status: sellerRequest.status || "pending",
+        message:
+          "Your seller registration request has been submitted and is pending approval.",
+      },
+    })
+  } catch (error: any) {
+    console.error("[Seller registration] Failed to create request:", error.message)
+
+    return res.status(400).json({
+      type: "invalid_data",
+      message: error.message || "Failed to submit seller registration request",
+    })
+  }
+}

--- a/backend/src/api/vendor/register/route.ts
+++ b/backend/src/api/vendor/register/route.ts
@@ -1,10 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { Modules } from "@medusajs/framework/utils"
-import { REQUEST_MODULE } from "../../../modules/request"
-import RequestModuleService from "../../../modules/request/service"
-import { REQUEST_TYPES } from "../../../modules/request/validators"
-import { createSellerRegistrationSchema, CreateSellerRegistrationInput } from "./validators"
-import { maskEmail } from "../../../shared/seller-approval-service"
+import { handleSellerRegistration } from "../../shared/seller-registration"
 
 // Disable automatic authentication to allow public registration
 export const AUTHENTICATE = false
@@ -26,98 +21,5 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
-  // Manually validate request body using Zod schema
-  let body: CreateSellerRegistrationInput
-  try {
-    body = createSellerRegistrationSchema.parse(req.body)
-  } catch (validationError: any) {
-    console.error("[POST /vendor/register] Validation error")
-    return res.status(400).json({
-      type: "invalid_data",
-      message: validationError.errors?.[0]?.message || "Invalid request data",
-      errors: validationError.errors,
-    })
-  }
-
-  console.log(`[POST /vendor/register] Creating seller request: "${body.name}" (email: ${maskEmail(body.member.email)})`)
-
-  try {
-    // Look up the auth identity by email (created during auth registration)
-    const authModule = req.scope.resolve(Modules.AUTH)
-    const [authIdentity] = await authModule.listAuthIdentities({
-      provider_identities: {
-        entity_id: body.member.email,
-      },
-    })
-
-    if (!authIdentity) {
-      console.error(`[POST /vendor/register] Auth identity not found for email: ${maskEmail(body.member.email)}`)
-      return res.status(400).json({
-        type: "invalid_data",
-        message: "Please complete authentication registration first",
-      })
-    }
-
-    console.log(`[POST /vendor/register] Found auth identity: ${authIdentity.id}`)
-
-    // Check if there's already a pending request for this auth identity
-    const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
-    const existingRequests = await requestService.listRequests({
-      type: REQUEST_TYPES.SELLER,
-    })
-
-    const userExistingRequest = existingRequests.find((request) => {
-      const data = request.data as Record<string, unknown> | undefined
-      return data?.auth_identity_id === authIdentity.id && request.status === "pending"
-    })
-
-    if (userExistingRequest) {
-      console.log(`[POST /vendor/register] Found existing pending request: ${userExistingRequest.id}`)
-      return res.status(200).json({
-        request: {
-          id: userExistingRequest.id,
-          status: userExistingRequest.status || "pending",
-          message: "You already have a pending registration request. Please wait for admin approval.",
-        },
-      })
-    }
-
-    // Create a seller creation REQUEST using the custom Request module
-    // This will appear in the admin panel for approval
-    const sellerRequest = await requestService.createRequest({
-      type: REQUEST_TYPES.SELLER,
-      data: {
-        auth_identity_id: authIdentity.id,
-        member: {
-          name: body.member.name,
-          email: body.member.email,
-        },
-        seller: {
-          name: body.name,
-        },
-        // Store vendor_type selection (defaults to "producer" if not provided)
-        vendor_type: body.vendor_type || "producer",
-      },
-      submitter_id: authIdentity.id,
-      reviewer_note: `Seller registration request for "${body.name}"`,
-    })
-
-    console.log(`[POST /vendor/register] Created seller request: ${sellerRequest.id}`)
-
-    return res.status(201).json({
-      request: {
-        id: sellerRequest.id,
-        status: sellerRequest.status || "pending",
-        message: "Your seller registration request has been submitted and is pending approval.",
-      },
-    })
-  } catch (error: any) {
-    console.error("[POST /vendor/register] Failed to create seller request:", error.message)
-
-    // Return proper error response
-    return res.status(400).json({
-      type: "invalid_data",
-      message: error.message || "Failed to submit seller registration request",
-    })
-  }
+  return handleSellerRegistration(req, res)
 }

--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -99,10 +99,12 @@ export const fetchQuery = async (
 
   const response = await fetch(`${backendUrl}${url}${params ? `?${params}` : ""}`, {
     method,
-    credentials: "include",
+    credentials: isPublic ? "omit" : "include",
     headers: {
       ...(isPublic
-        ? {}
+        ? {
+            ...(publishableApiKey ? { "x-publishable-api-key": publishableApiKey } : {}),
+          }
         : {
             authorization: `Bearer ${token}`,
             "x-publishable-api-key": publishableApiKey,


### PR DESCRIPTION
### Motivation
- Fix 403/authorization issues when the vendor panel tries to create a seller request and avoid duplicate/failing vendor registration attempts by checking existing registration status before creating a request. 
- Allow the vendor panel to submit seller registration requests without requiring vendor-actor authentication by exposing a public auth endpoint. 
- Centralize seller registration logic to ensure consistent validation, identity lookup, pending-request detection, and request creation across routes.

### Description
- Added `backend/src/api/shared/seller-registration.ts` implementing `handleSellerRegistration` with Zod validation, auth identity lookup, pending-request detection, and creation via the `REQUEST_MODULE`. 
- Introduced a public endpoint `POST /auth/seller/register-request` at `backend/src/api/auth/seller/register-request/route.ts` with `AUTHENTICATE = false` and refactored `POST /vendor/register` to reuse the shared handler. 
- Enabled vendor CORS for `/auth/seller/register-request` in `backend/src/api/middlewares.ts`. 
- Updated vendor panel code to post registration requests to `/auth/seller/register-request`, added `fetchRegistrationStatus` helpers in `vendor-panel/src/hooks/api/auth.tsx` and `vendor-panel/src/hooks/api/users.tsx`, normalized emails and added a register->login fallback in `useSignUpWithEmailPass`, and adjusted `fetchQuery` in `vendor-panel/src/lib/client/client.ts` to omit credentials for public auth routes and include the `x-publishable-api-key` header when appropriate.

### Testing
- No automated tests were run for these changes (auth/registration flow updates only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978fc1c1ba483239928d1b30625a25d)