### PR TITLE
Include auth token header when creating seller registration request

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -120,6 +120,7 @@ export const useSignUpWithEmailPass = (
               email: variables.email.toLowerCase().trim(),
             },
           },
+          headers: token ? { authorization: `Bearer ${token}` } : undefined,
         })
       } catch (error) {
         console.error("Failed to create seller registration request:", error)


### PR DESCRIPTION
### Motivation
- Fix Unauthorized errors when the vendor panel creates a seller registration request after signup by ensuring the request is sent with the current bearer token when available.

### Description
- Add a conditional `authorization: Bearer <token>` header to the `fetchQuery("/auth/seller/register-request", ...)` call in `vendor-panel/src/hooks/api/auth.tsx` so the registration request is authenticated when a token exists.
- Only include the header when `token` is present to preserve public behavior for unauthenticated flows.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793c657864832386283bb40eceecce)