### PR TITLE
Add screen-reader labels, normalize image/backend URLs, and include auth header on registration request

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -120,6 +120,7 @@ export const useSignUpWithEmailPass = (
               email: variables.email.toLowerCase().trim(),
             },
           },
+          headers: token ? { authorization: `Bearer ${token}` } : undefined,
         })
       } catch (error) {
         console.error("Failed to create seller registration request:", error)

--- a/vendor-panel/src/lib/storefront.ts
+++ b/vendor-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/vendor-panel/src/routes/login/login.tsx
+++ b/vendor-panel/src/routes/login/login.tsx
@@ -102,6 +102,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
+                        <Form.Label className="sr-only">
+                          {t("fields.email")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             autoComplete="email"
@@ -120,7 +123,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
-                        <Form.Label>{}</Form.Label>
+                        <Form.Label className="sr-only">
+                          {t("fields.password")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             type="password"

--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -42,6 +42,7 @@ function getNamePlaceholder(type: VendorType): string {
   const placeholders: Record<VendorType, string> = {
     producer: "Farm or business name",
     garden: "Garden name",
+    kitchen: "Kitchen name",
     maker: "Business or studio name",
     restaurant: "Restaurant name",
     mutual_aid: "Organization name",
@@ -54,6 +55,7 @@ function getOptionalFieldsHint(type: VendorType): string {
   const hints: Record<VendorType, string> = {
     producer: "Add your farm website & social media",
     garden: "Add your garden's website & social media",
+    kitchen: "Add your kitchen website & social media",
     maker: "Add your portfolio & social media",
     restaurant: "Add your restaurant website & social media",
     mutual_aid: "Add your organization's website & social media",

--- a/vendor-panel/src/utils/images-conventer.ts
+++ b/vendor-panel/src/utils/images-conventer.ts
@@ -1,15 +1,32 @@
 import { backendUrl } from "../lib/client"
 
 export default function imagesConverter(images: string) {
-  const isLocalhost =
-    images.startsWith("http://localhost:9000") ||
-    images.startsWith("https://localhost:9000")
-
-  if (isLocalhost) {
+  if (typeof window === "undefined") {
     return images
-      .replace("http://localhost:9000", backendUrl)
-      .replace("https://localhost:9000", backendUrl)
   }
 
-  return images
+  let imageUrl: URL
+  try {
+    imageUrl = new URL(images)
+  } catch {
+    return images
+  }
+
+  let backendOrigin: string
+  try {
+    backendOrigin = new URL(backendUrl, window.location.origin).origin
+  } catch {
+    return images
+  }
+
+  if (!backendOrigin || imageUrl.origin === backendOrigin) {
+    return images
+  }
+
+  if (!imageUrl.pathname.startsWith("/uploads")) {
+    return images
+  }
+
+  const updatedUrl = new URL(imageUrl.pathname + imageUrl.search + imageUrl.hash, backendOrigin)
+  return updatedUrl.toString()
 }


### PR DESCRIPTION
### Motivation
- Improve accessibility of the vendor login form by ensuring inputs have proper labels for screen readers.  
- Fix production URL handling so uploaded images and storefront origin do not assume `localhost`.  
- Ensure requests that create a seller registration include an auth header when an auth token is available.

### Description
- Added screen-reader-only labels for email and password fields in the vendor login form by rendering `Form.Label` with the `sr-only` class and using `t("fields.email")`/`t("fields.password")` (`vendor-panel/src/routes/login/login.tsx`).
- Changed storefront fallback to use `window.location.origin` when `__STOREFRONT_URL__` is not set and handled SSR by returning an empty string when `window` is undefined (`vendor-panel/src/lib/storefront.ts`).
- Rewrote `imagesConverter` to be SSR-safe and robust by parsing input with `new URL`, resolving `backendUrl` relative to `window.location.origin`, only rewriting `/uploads` paths to the backend origin (preserving query/hash), and returning original input on parse failure (`vendor-panel/src/utils/images-conventer.ts`).
- Added the authorization header to the seller registration POST when a token is available (`vendor-panel/src/hooks/api/auth.tsx`).
- Added small register UI text entries for `kitchen` type placeholders and hints (`vendor-panel/src/routes/register/register.tsx`).

### Testing
- No automated tests were run for this change.  
- Basic repository inspections and file checks were performed (code edits reviewed and committed locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793c657864832386283bb40eceecce)