### PR TITLE
Remove localhost defaults; require Apprise API URL and update admin/vendor panel request flows

### DIFF
--- a/admin-panel/src/lib/storefront.ts
+++ b/admin-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/backend/src/api/admin/sellers/invite/route.ts
+++ b/backend/src/api/admin/sellers/invite/route.ts
@@ -28,12 +28,20 @@ export const POST = async (
     )
 
     // Send invitation email
+    const fallbackBaseUrl =
+      process.env.VENDOR_PANEL_URL || req.headers.origin || ""
+    const resolvedRegistrationUrl =
+      registration_url ||
+      (fallbackBaseUrl
+        ? new URL("/vendor/register", fallbackBaseUrl).toString()
+        : "")
+
     await notificationModule.createNotifications({
       to: email,
       channel: "email",
       template: "seller-invitation",
       data: {
-        registration_url: registration_url || process.env.VENDOR_PANEL_URL || "http://localhost:3000/vendor/register",
+        registration_url: resolvedRegistrationUrl,
         email,
       },
     })

--- a/backend/src/services/apprise/apprise.service.ts
+++ b/backend/src/services/apprise/apprise.service.ts
@@ -84,7 +84,7 @@ export class AppriseService {
   private configKey?: string
 
   constructor(config: AppriseConfig) {
-    this.apiUrl = config.apiUrl || process.env.APPRISE_API_URL || "http://localhost:8000"
+    this.apiUrl = config.apiUrl || process.env.APPRISE_API_URL || ""
     this.defaultUrls = config.defaultUrls || []
     this.configKey = config.configKey
   }
@@ -103,6 +103,10 @@ export class AppriseService {
     }
 
     try {
+      if (!this.apiUrl) {
+        return { success: false, error: "Apprise API URL not configured" }
+      }
+
       const endpoint = this.configKey 
         ? `${this.apiUrl}/notify/${this.configKey}`
         : `${this.apiUrl}/notify`

--- a/backend/src/workflows/send-vendor-accepted-notification.ts
+++ b/backend/src/workflows/send-vendor-accepted-notification.ts
@@ -28,9 +28,9 @@ export const sendVendorAcceptedNotificationStep = createStep(
     const notificationModuleService: INotificationModuleService = container
       .resolve(Modules.NOTIFICATION)
 
-    const vendorPanelUrl = input.vendor_panel_url || 
-      process.env.VENDOR_PANEL_URL || 
-      "http://localhost:7000"
+    const vendorPanelUrl = input.vendor_panel_url ||
+      process.env.VENDOR_PANEL_URL ||
+      ""
 
     const notification = await notificationModuleService.createNotifications({
       to: input.member_email,
@@ -40,7 +40,7 @@ export const sendVendorAcceptedNotificationStep = createStep(
         seller_name: input.seller_name,
         member_name: input.member_name,
         vendor_panel_url: vendorPanelUrl,
-        login_url: `${vendorPanelUrl}/login`,
+        login_url: vendorPanelUrl ? `${vendorPanelUrl}/login` : undefined,
       }
     })
 

--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -120,6 +120,7 @@ export const useSignUpWithEmailPass = (
               email: variables.email.toLowerCase().trim(),
             },
           },
+          headers: token ? { authorization: `Bearer ${token}` } : undefined,
         })
       } catch (error) {
         console.error("Failed to create seller registration request:", error)

--- a/vendor-panel/src/lib/storefront.ts
+++ b/vendor-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/vendor-panel/src/routes/login/login.tsx
+++ b/vendor-panel/src/routes/login/login.tsx
@@ -102,6 +102,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
+                        <Form.Label className="sr-only">
+                          {t("fields.email")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             autoComplete="email"
@@ -120,7 +123,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
-                        <Form.Label>{}</Form.Label>
+                        <Form.Label className="sr-only">
+                          {t("fields.password")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             type="password"

--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -42,6 +42,7 @@ function getNamePlaceholder(type: VendorType): string {
   const placeholders: Record<VendorType, string> = {
     producer: "Farm or business name",
     garden: "Garden name",
+    kitchen: "Kitchen name",
     maker: "Business or studio name",
     restaurant: "Restaurant name",
     mutual_aid: "Organization name",
@@ -54,6 +55,7 @@ function getOptionalFieldsHint(type: VendorType): string {
   const hints: Record<VendorType, string> = {
     producer: "Add your farm website & social media",
     garden: "Add your garden's website & social media",
+    kitchen: "Add your kitchen website & social media",
     maker: "Add your portfolio & social media",
     restaurant: "Add your restaurant website & social media",
     mutual_aid: "Add your organization's website & social media",

--- a/vendor-panel/src/utils/images-conventer.ts
+++ b/vendor-panel/src/utils/images-conventer.ts
@@ -1,15 +1,32 @@
 import { backendUrl } from "../lib/client"
 
 export default function imagesConverter(images: string) {
-  const isLocalhost =
-    images.startsWith("http://localhost:9000") ||
-    images.startsWith("https://localhost:9000")
-
-  if (isLocalhost) {
+  if (typeof window === "undefined") {
     return images
-      .replace("http://localhost:9000", backendUrl)
-      .replace("https://localhost:9000", backendUrl)
   }
 
-  return images
+  let imageUrl: URL
+  try {
+    imageUrl = new URL(images)
+  } catch {
+    return images
+  }
+
+  let backendOrigin: string
+  try {
+    backendOrigin = new URL(backendUrl, window.location.origin).origin
+  } catch {
+    return images
+  }
+
+  if (!backendOrigin || imageUrl.origin === backendOrigin) {
+    return images
+  }
+
+  if (!imageUrl.pathname.startsWith("/uploads")) {
+    return images
+  }
+
+  const updatedUrl = new URL(imageUrl.pathname + imageUrl.search + imageUrl.hash, backendOrigin)
+  return updatedUrl.toString()
 }


### PR DESCRIPTION
### Motivation
- Avoid embedding `localhost` URLs in outgoing notifications and admin/vendor links so emails and request flows work correctly in production.
- Fail fast when Apprise integration is misconfigured by surfacing a clear error if the `APPRISE_API_URL` is missing.
- Apply the same removal of localhost fallbacks to the admin panel request feature and align vendor-panel behavior and accessibility.

### Description
- Backend: in `backend/src/api/admin/sellers/invite/route.ts` compute a `resolvedRegistrationUrl` using `registration_url`, `process.env.VENDOR_PANEL_URL`, or `req.headers.origin` and remove the hardcoded `http://localhost:3000/vendor/register` fallback so emails never include a localhost link.
- Backend: in `backend/src/workflows/send-vendor-accepted-notification.ts` stop defaulting `vendor_panel_url` to `http://localhost:7000` and only include `login_url` when a vendor panel URL is present.
- Backend: in `backend/src/services/apprise/apprise.service.ts` remove the `http://localhost:8000` fallback and return `{ success: false, error: "Apprise API URL not configured" }` when the API URL is missing.
- Admin panel: in `admin-panel/src/lib/storefront.ts` use `window.location.origin` as a runtime fallback instead of a `localhost` hardcoded URL for `MEDUSA_STOREFRONT_URL` so request flows use the correct origin.
- Vendor panel: mirror the storefront change in `vendor-panel/src/lib/storefront.ts` and add an authorization header to `fetchQuery("/auth/seller/register-request")` when a token is present in `vendor-panel/src/hooks/api/auth.tsx`.
- Vendor panel UI/accessibility: add visually-hidden (`sr-only`) `Form.Label`s for email and password fields in `vendor-panel/src/routes/login/login.tsx`.
- Vendor panel content: extend placeholders and hints in `vendor-panel/src/routes/register/register.tsx` (add `kitchen`) to cover request-related form variations.
- Vendor panel image handling: improve `vendor-panel/src/utils/images-conventer.ts` to safely parse URLs in the browser, compute the backend origin via `backendUrl` and `window.location.origin`, and only rewrite image URLs when appropriate (ensuring `/uploads` paths are correctly converted to the configured backend origin).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793c657864832386283bb40eceecce)