### PR TITLE
Delay request refetch to prevent status flicker and tighten URL/notification handling

### DIFF
--- a/admin-panel/src/hooks/api/requests.tsx
+++ b/admin-panel/src/hooks/api/requests.tsx
@@ -62,7 +62,7 @@ export const useVendorRequest = (
 
 export const useReviewRequest = (
   options: UseMutationOptions<
-    { id?: string; status?: string },
+    { request?: { id?: string; status?: string }; status?: string },
     Error,
     { id: string; payload: AdminReviewRequest }
   >,
@@ -73,9 +73,94 @@ export const useReviewRequest = (
         method: "POST",
         body: payload,
       }),
+    onSuccess: (data, variables) => {
+      const nextStatus =
+        data?.request?.status || data?.status || variables.payload.status;
+
+      if (nextStatus) {
+        const listQueries = queryClient
+          .getQueryCache()
+          .findAll({ queryKey: requestsQueryKeys.lists() });
+
+        listQueries.forEach((query) => {
+          const queryKey = query.queryKey as Array<unknown>;
+          const queryMeta = queryKey[queryKey.length - 1];
+          const listQuery =
+            typeof queryMeta === "object" &&
+            queryMeta !== null &&
+            "query" in queryMeta
+              ? (queryMeta as { query?: Record<string, unknown> }).query
+              : undefined;
+
+          queryClient.setQueryData(queryKey, (oldData) => {
+            if (!oldData) {
+              return oldData;
+            }
+
+            const typedData = oldData as {
+              requests?: AdminRequest[];
+              count?: number;
+            };
+
+            if (!typedData.requests) {
+              return oldData;
+            }
+
+            let nextRequests = typedData.requests.map((request) =>
+              request.id === variables.id
+                ? { ...request, status: nextStatus }
+                : request
+            );
+
+            if (
+              listQuery?.status &&
+              typeof listQuery.status === "string" &&
+              listQuery.status !== nextStatus
+            ) {
+              nextRequests = nextRequests.filter(
+                (request) => request.id !== variables.id
+              );
+            }
+
+            return {
+              ...typedData,
+              requests: nextRequests,
+              count:
+                typedData.count && nextRequests.length < typedData.requests.length
+                  ? typedData.count - 1
+                  : typedData.count,
+            };
+          });
+        });
+
+        queryClient.setQueryData(
+          requestsQueryKeys.detail(variables.id),
+          (oldData) => {
+            if (!oldData) {
+              return oldData;
+            }
+
+            const typedData = oldData as { request?: AdminRequest };
+            if (!typedData.request) {
+              return oldData;
+            }
+
+            return {
+              ...typedData,
+              request: { ...typedData.request, status: nextStatus },
+            };
+          }
+        );
+      }
+    },
     onSettled: () => {
-      // Invalidate all requests queries to ensure fresh data is fetched
-      queryClient.invalidateQueries({ queryKey: requestsQueryKeys.all });
+      // Delay refetch to avoid overwriting optimistic updates with stale data.
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: requestsQueryKeys.all,
+          refetchType: "inactive",
+        });
+      }, 2000);
     },
     ...options,
   });

--- a/admin-panel/src/lib/storefront.ts
+++ b/admin-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/backend/src/api/admin/sellers/invite/route.ts
+++ b/backend/src/api/admin/sellers/invite/route.ts
@@ -28,12 +28,20 @@ export const POST = async (
     )
 
     // Send invitation email
+    const fallbackBaseUrl =
+      process.env.VENDOR_PANEL_URL || req.headers.origin || ""
+    const resolvedRegistrationUrl =
+      registration_url ||
+      (fallbackBaseUrl
+        ? new URL("/vendor/register", fallbackBaseUrl).toString()
+        : "")
+
     await notificationModule.createNotifications({
       to: email,
       channel: "email",
       template: "seller-invitation",
       data: {
-        registration_url: registration_url || process.env.VENDOR_PANEL_URL || "http://localhost:3000/vendor/register",
+        registration_url: resolvedRegistrationUrl,
         email,
       },
     })

--- a/backend/src/services/apprise/apprise.service.ts
+++ b/backend/src/services/apprise/apprise.service.ts
@@ -84,7 +84,7 @@ export class AppriseService {
   private configKey?: string
 
   constructor(config: AppriseConfig) {
-    this.apiUrl = config.apiUrl || process.env.APPRISE_API_URL || "http://localhost:8000"
+    this.apiUrl = config.apiUrl || process.env.APPRISE_API_URL || ""
     this.defaultUrls = config.defaultUrls || []
     this.configKey = config.configKey
   }
@@ -103,6 +103,10 @@ export class AppriseService {
     }
 
     try {
+      if (!this.apiUrl) {
+        return { success: false, error: "Apprise API URL not configured" }
+      }
+
       const endpoint = this.configKey 
         ? `${this.apiUrl}/notify/${this.configKey}`
         : `${this.apiUrl}/notify`

--- a/backend/src/workflows/send-vendor-accepted-notification.ts
+++ b/backend/src/workflows/send-vendor-accepted-notification.ts
@@ -28,9 +28,9 @@ export const sendVendorAcceptedNotificationStep = createStep(
     const notificationModuleService: INotificationModuleService = container
       .resolve(Modules.NOTIFICATION)
 
-    const vendorPanelUrl = input.vendor_panel_url || 
-      process.env.VENDOR_PANEL_URL || 
-      "http://localhost:7000"
+    const vendorPanelUrl = input.vendor_panel_url ||
+      process.env.VENDOR_PANEL_URL ||
+      ""
 
     const notification = await notificationModuleService.createNotifications({
       to: input.member_email,
@@ -40,7 +40,7 @@ export const sendVendorAcceptedNotificationStep = createStep(
         seller_name: input.seller_name,
         member_name: input.member_name,
         vendor_panel_url: vendorPanelUrl,
-        login_url: `${vendorPanelUrl}/login`,
+        login_url: vendorPanelUrl ? `${vendorPanelUrl}/login` : undefined,
       }
     })
 

--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -120,6 +120,7 @@ export const useSignUpWithEmailPass = (
               email: variables.email.toLowerCase().trim(),
             },
           },
+          headers: token ? { authorization: `Bearer ${token}` } : undefined,
         })
       } catch (error) {
         console.error("Failed to create seller registration request:", error)

--- a/vendor-panel/src/lib/storefront.ts
+++ b/vendor-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/vendor-panel/src/routes/login/login.tsx
+++ b/vendor-panel/src/routes/login/login.tsx
@@ -102,6 +102,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
+                        <Form.Label className="sr-only">
+                          {t("fields.email")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             autoComplete="email"
@@ -120,7 +123,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
-                        <Form.Label>{}</Form.Label>
+                        <Form.Label className="sr-only">
+                          {t("fields.password")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             type="password"

--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -42,6 +42,7 @@ function getNamePlaceholder(type: VendorType): string {
   const placeholders: Record<VendorType, string> = {
     producer: "Farm or business name",
     garden: "Garden name",
+    kitchen: "Kitchen name",
     maker: "Business or studio name",
     restaurant: "Restaurant name",
     mutual_aid: "Organization name",
@@ -54,6 +55,7 @@ function getOptionalFieldsHint(type: VendorType): string {
   const hints: Record<VendorType, string> = {
     producer: "Add your farm website & social media",
     garden: "Add your garden's website & social media",
+    kitchen: "Add your kitchen website & social media",
     maker: "Add your portfolio & social media",
     restaurant: "Add your restaurant website & social media",
     mutual_aid: "Add your organization's website & social media",

--- a/vendor-panel/src/utils/images-conventer.ts
+++ b/vendor-panel/src/utils/images-conventer.ts
@@ -1,15 +1,32 @@
 import { backendUrl } from "../lib/client"
 
 export default function imagesConverter(images: string) {
-  const isLocalhost =
-    images.startsWith("http://localhost:9000") ||
-    images.startsWith("https://localhost:9000")
-
-  if (isLocalhost) {
+  if (typeof window === "undefined") {
     return images
-      .replace("http://localhost:9000", backendUrl)
-      .replace("https://localhost:9000", backendUrl)
   }
 
-  return images
+  let imageUrl: URL
+  try {
+    imageUrl = new URL(images)
+  } catch {
+    return images
+  }
+
+  let backendOrigin: string
+  try {
+    backendOrigin = new URL(backendUrl, window.location.origin).origin
+  } catch {
+    return images
+  }
+
+  if (!backendOrigin || imageUrl.origin === backendOrigin) {
+    return images
+  }
+
+  if (!imageUrl.pathname.startsWith("/uploads")) {
+    return images
+  }
+
+  const updatedUrl = new URL(imageUrl.pathname + imageUrl.search + imageUrl.hash, backendOrigin)
+  return updatedUrl.toString()
 }


### PR DESCRIPTION
### Motivation
- Prevent a UI race where a request briefly shows as accepted then reverts to pending by avoiding immediate refetch that can overwrite optimistic updates.
- Remove hardcoded localhost fallbacks in notification and vendor URLs so misconfiguration surfaces and production links are correct.
- Improve vendor-panel UX and safety by adding auth to registration requests, accessible labels on login, better placeholders for `kitchen`, and robust image URL rewriting.

### Description
- Update `useReviewRequest` to update list/detail cache entries on success and delay invalidation with `setTimeout` and `refetchType: "inactive"` to avoid overwriting optimistic updates (file: `admin-panel/src/hooks/api/requests.tsx`).
- Replace storefront runtime `localhost` fallbacks with `window.location.origin` when available in `admin-panel` and `vendor-panel` (files: `admin-panel/src/lib/storefront.ts`, `vendor-panel/src/lib/storefront.ts`).
- Resolve invitation `registration_url` using `process.env.VENDOR_PANEL_URL` or `req.headers.origin` without falling back to `http://localhost:3000` (file: `backend/src/api/admin/sellers/invite/route.ts`).
- Make `AppriseService` fail fast when no API URL is configured by removing the `localhost` default and returning `{ success: false, error: "Apprise API URL not configured" }` (file: `backend/src/services/apprise/apprise.service.ts`).
- Stop defaulting vendor panel notifications to `http://localhost:7000` and only include `login_url` when a vendor panel URL exists (file: `backend/src/workflows/send-vendor-accepted-notification.ts`).
- Add authorization header to `fetchQuery("/auth/seller/register-request")` when a token exists (file: `vendor-panel/src/hooks/api/auth.tsx`).
- Improve accessibility on login by adding visually-hidden `Form.Label`s for `email` and `password` fields (file: `vendor-panel/src/routes/login/login.tsx`).
- Add `kitchen` placeholders and optional-field hints in the register flow (file: `vendor-panel/src/routes/register/register.tsx`).
- Make image rewriting robust and safe for SSR by validating URLs, deriving backend origin from `backendUrl`, and only rewriting `/uploads` paths to the backend origin (file: `vendor-panel/src/utils/images-conventer.ts`).

### Testing
- No automated tests were run for these changes.
- Manual runtime verification was the intended validation path but no CI or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793c657864832386283bb40eceecce)