### PR TITLE
Fix vendor auth ReferenceError, update requests cache handling, and improve URL fallbacks

### DIFF
--- a/admin-panel/src/hooks/api/requests.tsx
+++ b/admin-panel/src/hooks/api/requests.tsx
@@ -62,7 +62,7 @@ export const useVendorRequest = (
 
 export const useReviewRequest = (
   options: UseMutationOptions<
-    { id?: string; status?: string },
+    { request?: { id?: string; status?: string }; status?: string },
     Error,
     { id: string; payload: AdminReviewRequest }
   >,
@@ -73,9 +73,94 @@ export const useReviewRequest = (
         method: "POST",
         body: payload,
       }),
+    onSuccess: (data, variables) => {
+      const nextStatus =
+        data?.request?.status || data?.status || variables.payload.status;
+
+      if (nextStatus) {
+        const listQueries = queryClient
+          .getQueryCache()
+          .findAll({ queryKey: requestsQueryKeys.lists() });
+
+        listQueries.forEach((query) => {
+          const queryKey = query.queryKey as Array<unknown>;
+          const queryMeta = queryKey[queryKey.length - 1];
+          const listQuery =
+            typeof queryMeta === "object" &&
+            queryMeta !== null &&
+            "query" in queryMeta
+              ? (queryMeta as { query?: Record<string, unknown> }).query
+              : undefined;
+
+          queryClient.setQueryData(queryKey, (oldData) => {
+            if (!oldData) {
+              return oldData;
+            }
+
+            const typedData = oldData as {
+              requests?: AdminRequest[];
+              count?: number;
+            };
+
+            if (!typedData.requests) {
+              return oldData;
+            }
+
+            let nextRequests = typedData.requests.map((request) =>
+              request.id === variables.id
+                ? { ...request, status: nextStatus }
+                : request
+            );
+
+            if (
+              listQuery?.status &&
+              typeof listQuery.status === "string" &&
+              listQuery.status !== nextStatus
+            ) {
+              nextRequests = nextRequests.filter(
+                (request) => request.id !== variables.id
+              );
+            }
+
+            return {
+              ...typedData,
+              requests: nextRequests,
+              count:
+                typedData.count && nextRequests.length < typedData.requests.length
+                  ? typedData.count - 1
+                  : typedData.count,
+            };
+          });
+        });
+
+        queryClient.setQueryData(
+          requestsQueryKeys.detail(variables.id),
+          (oldData) => {
+            if (!oldData) {
+              return oldData;
+            }
+
+            const typedData = oldData as { request?: AdminRequest };
+            if (!typedData.request) {
+              return oldData;
+            }
+
+            return {
+              ...typedData,
+              request: { ...typedData.request, status: nextStatus },
+            };
+          }
+        );
+      }
+    },
     onSettled: () => {
-      // Invalidate all requests queries to ensure fresh data is fetched
-      queryClient.invalidateQueries({ queryKey: requestsQueryKeys.all });
+      // Delay refetch to avoid overwriting optimistic updates with stale data.
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: requestsQueryKeys.all,
+          refetchType: "inactive",
+        });
+      }, 2000);
     },
     ...options,
   });

--- a/admin-panel/src/lib/storefront.ts
+++ b/admin-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/request-seller-list.tsx
@@ -33,7 +33,7 @@ export const RequestSellerList = () => {
 
   const [currentFilter, setCurrentFilter] = useState<FilterState>("");
 
-  const { requests, isLoading, refetch, count } = useVendorRequests({
+  const { requests, isLoading, count } = useVendorRequests({
     offset: currentPage * PAGE_SIZE,
     limit: PAGE_SIZE,
     type: "seller",
@@ -55,7 +55,6 @@ export const RequestSellerList = () => {
             open={detailOpen}
             close={() => {
               setDetailOpen(false);
-              refetch();
             }}
           />
           <FilterRequests

--- a/backend/src/api/admin/sellers/invite/route.ts
+++ b/backend/src/api/admin/sellers/invite/route.ts
@@ -28,12 +28,20 @@ export const POST = async (
     )
 
     // Send invitation email
+    const fallbackBaseUrl =
+      process.env.VENDOR_PANEL_URL || req.headers.origin || ""
+    const resolvedRegistrationUrl =
+      registration_url ||
+      (fallbackBaseUrl
+        ? new URL("/vendor/register", fallbackBaseUrl).toString()
+        : "")
+
     await notificationModule.createNotifications({
       to: email,
       channel: "email",
       template: "seller-invitation",
       data: {
-        registration_url: registration_url || process.env.VENDOR_PANEL_URL || "http://localhost:3000/vendor/register",
+        registration_url: resolvedRegistrationUrl,
         email,
       },
     })

--- a/backend/src/services/apprise/apprise.service.ts
+++ b/backend/src/services/apprise/apprise.service.ts
@@ -84,7 +84,7 @@ export class AppriseService {
   private configKey?: string
 
   constructor(config: AppriseConfig) {
-    this.apiUrl = config.apiUrl || process.env.APPRISE_API_URL || "http://localhost:8000"
+    this.apiUrl = config.apiUrl || process.env.APPRISE_API_URL || ""
     this.defaultUrls = config.defaultUrls || []
     this.configKey = config.configKey
   }
@@ -103,6 +103,10 @@ export class AppriseService {
     }
 
     try {
+      if (!this.apiUrl) {
+        return { success: false, error: "Apprise API URL not configured" }
+      }
+
       const endpoint = this.configKey 
         ? `${this.apiUrl}/notify/${this.configKey}`
         : `${this.apiUrl}/notify`

--- a/backend/src/workflows/send-vendor-accepted-notification.ts
+++ b/backend/src/workflows/send-vendor-accepted-notification.ts
@@ -28,9 +28,9 @@ export const sendVendorAcceptedNotificationStep = createStep(
     const notificationModuleService: INotificationModuleService = container
       .resolve(Modules.NOTIFICATION)
 
-    const vendorPanelUrl = input.vendor_panel_url || 
-      process.env.VENDOR_PANEL_URL || 
-      "http://localhost:7000"
+    const vendorPanelUrl = input.vendor_panel_url ||
+      process.env.VENDOR_PANEL_URL ||
+      ""
 
     const notification = await notificationModuleService.createNotifications({
       to: input.member_email,
@@ -40,7 +40,7 @@ export const sendVendorAcceptedNotificationStep = createStep(
         seller_name: input.seller_name,
         member_name: input.member_name,
         vendor_panel_url: vendorPanelUrl,
-        login_url: `${vendorPanelUrl}/login`,
+        login_url: vendorPanelUrl ? `${vendorPanelUrl}/login` : undefined,
       }
     })
 

--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -6,6 +6,7 @@ import {
   clearAuthToken,
   fetchQuery,
   getAuthToken,
+  publicAuthSdk,
   sdk,
   setAuthToken,
 } from "../../lib/client"
@@ -120,6 +121,7 @@ export const useSignUpWithEmailPass = (
               email: variables.email.toLowerCase().trim(),
             },
           },
+          headers: token ? { authorization: `Bearer ${token}` } : undefined,
         })
       } catch (error) {
         console.error("Failed to create seller registration request:", error)

--- a/vendor-panel/src/lib/storefront.ts
+++ b/vendor-panel/src/lib/storefront.ts
@@ -1,2 +1,3 @@
 export const MEDUSA_STOREFRONT_URL =
-  __STOREFRONT_URL__ ?? "http://localhost:8000"
+  __STOREFRONT_URL__ ??
+  (typeof window !== "undefined" ? window.location.origin : "")

--- a/vendor-panel/src/routes/login/login.tsx
+++ b/vendor-panel/src/routes/login/login.tsx
@@ -102,6 +102,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
+                        <Form.Label className="sr-only">
+                          {t("fields.email")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             autoComplete="email"
@@ -120,7 +123,9 @@ export const Login = () => {
                   render={({ field }) => {
                     return (
                       <Form.Item>
-                        <Form.Label>{}</Form.Label>
+                        <Form.Label className="sr-only">
+                          {t("fields.password")}
+                        </Form.Label>
                         <Form.Control>
                           <Input
                             type="password"

--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -42,6 +42,7 @@ function getNamePlaceholder(type: VendorType): string {
   const placeholders: Record<VendorType, string> = {
     producer: "Farm or business name",
     garden: "Garden name",
+    kitchen: "Kitchen name",
     maker: "Business or studio name",
     restaurant: "Restaurant name",
     mutual_aid: "Organization name",
@@ -54,6 +55,7 @@ function getOptionalFieldsHint(type: VendorType): string {
   const hints: Record<VendorType, string> = {
     producer: "Add your farm website & social media",
     garden: "Add your garden's website & social media",
+    kitchen: "Add your kitchen website & social media",
     maker: "Add your portfolio & social media",
     restaurant: "Add your restaurant website & social media",
     mutual_aid: "Add your organization's website & social media",

--- a/vendor-panel/src/utils/images-conventer.ts
+++ b/vendor-panel/src/utils/images-conventer.ts
@@ -1,15 +1,32 @@
 import { backendUrl } from "../lib/client"
 
 export default function imagesConverter(images: string) {
-  const isLocalhost =
-    images.startsWith("http://localhost:9000") ||
-    images.startsWith("https://localhost:9000")
-
-  if (isLocalhost) {
+  if (typeof window === "undefined") {
     return images
-      .replace("http://localhost:9000", backendUrl)
-      .replace("https://localhost:9000", backendUrl)
   }
 
-  return images
+  let imageUrl: URL
+  try {
+    imageUrl = new URL(images)
+  } catch {
+    return images
+  }
+
+  let backendOrigin: string
+  try {
+    backendOrigin = new URL(backendUrl, window.location.origin).origin
+  } catch {
+    return images
+  }
+
+  if (!backendOrigin || imageUrl.origin === backendOrigin) {
+    return images
+  }
+
+  if (!imageUrl.pathname.startsWith("/uploads")) {
+    return images
+  }
+
+  const updatedUrl = new URL(imageUrl.pathname + imageUrl.search + imageUrl.hash, backendOrigin)
+  return updatedUrl.toString()
 }


### PR DESCRIPTION
### Motivation
- Fix a runtime `ReferenceError` thrown from the vendor auth hook by ensuring `publicAuthSdk` is imported and used for public auth flows. 
- Prevent UI races and stale overwrites when reviewing requests by applying optimistic cache updates and delaying refetches. 
- Make storefront and vendor panel URL fallbacks more robust for environments where `__STOREFRONT_URL__` is not set and handle absent Apprise/API URLs safely. 
- No Codex skills were used for these changes.

### Description
- Import `publicAuthSdk` into `vendor-panel/src/hooks/api/auth.tsx` and use it for public `register` and `login` mutation flows, and include auth header when creating seller registration requests via `fetchQuery`. 
- Update `admin-panel/src/hooks/api/requests.tsx` to update list/detail cache entries in `onSuccess` of `useReviewRequest` and replace immediate invalidation with a delayed `invalidateQueries` (2s) using `refetchType: "inactive"` to avoid overwriting optimistic updates. 
- Remove the `refetch()` call from `RequestSellerDetail` close handler in `request-seller-list.tsx` so the list relies on cache updates instead of refetching on close. 
- Change storefront URL fallbacks in both admin and vendor panels (`admin-panel/src/lib/storefront.ts` and `vendor-panel/src/lib/storefront.ts`) to use `window.location.origin` when available instead of hardcoded `http://localhost` values. 
- Improve seller invitation URL resolution in `backend/src/api/admin/sellers/invite/route.ts` to derive a `registration_url` from `registration_url`, `VENDOR_PANEL_URL`, or `req.headers.origin`. 
- Harden Apprise service in `backend/src/services/apprise/apprise.service.ts` to return a clear error when `APPRISE_API_URL` is not configured instead of defaulting to `http://localhost:8000`. 
- Update `backend/src/workflows/send-vendor-accepted-notification.ts` to avoid constructing invalid login URLs when `VENDOR_PANEL_URL` is not set by omitting `login_url` in that case. 
- Accessibility and UX tweaks in `vendor-panel/src/routes/login/login.tsx` by adding `sr-only` `Form.Label`s for `email` and `password`, and small content updates in `vendor-panel/src/routes/register/register.tsx` for `kitchen` placeholders and hints. 
- Fix `vendor-panel/src/utils/images-conventer.ts` to run only in the browser, parse URLs safely, and rewrite backend-origin image URLs to use the `backendUrl` origin when applicable.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793c657864832386283bb40eceecce)