### PR TITLE
Fix seller profile field parsing

### DIFF
--- a/backend/src/api/vendor/sellers/me/route.ts
+++ b/backend/src/api/vendor/sellers/me/route.ts
@@ -62,9 +62,6 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
   try {
     const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-    // Parse fields from query params (comma-separated list)
-    const requestedFields = req.query.fields as string | undefined
-
     // Default seller fields to return
     const defaultSellerFields = [
       "id",
@@ -86,37 +83,10 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       // Include producer if linked
       "producer.*",
     ]
-    const defaultMetadataFields = [
-      "vendor_type",
-      "website_url",
-      "social_links",
-      "storefront_links",
-      "certifications",
-    ]
-    const metadataFieldSet = new Set(defaultMetadataFields)
-
-    // If specific fields requested, parse them
-    let sellerFields = defaultSellerFields
-    let metadataFields = defaultMetadataFields
-    let includeMediaAlias = true
-    if (requestedFields) {
-      const parsedFields = requestedFields.split(",").map(f => f.trim()).filter(Boolean)
-      if (parsedFields.length > 0) {
-        includeMediaAlias = parsedFields.includes("media")
-        metadataFields = parsedFields.filter(field => metadataFieldSet.has(field))
-        // Map frontend field names to actual seller entity fields
-        sellerFields = parsedFields
-          .filter(field => !metadataFieldSet.has(field))
-          .map(field => {
-            if (field === "media") return "photo" // media is alias for photo
-            return field
-          })
-        // Always ensure id is included
-        if (!sellerFields.includes("id")) {
-          sellerFields.unshift("id")
-        }
-      }
-    }
+    const { sellerFields, metadataFields, includeMediaAlias } = parseRequestedFields(
+      req.query.fields,
+      defaultSellerFields
+    )
 
     // Fetch seller data with related entities
     const { data: sellers } = await query.graph({
@@ -150,7 +120,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       }
     }
 
-    if (!requestedFields || includeMediaAlias) {
+    if (includeMediaAlias) {
       response.media = seller.photo
     }
 
@@ -238,58 +208,34 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       }
     }
 
-    const requestedFields = req.query.fields as string | undefined
-    const includeMediaAlias = !requestedFields || requestedFields.includes("media")
-    const includeMediaAlias = !req.query.fields || req.query.fields.includes("media")
-    const metadataFieldSet = new Set([
-      "vendor_type",
-      "website_url",
-      "social_links",
-      "storefront_links",
-      "certifications",
-    ])
+    const defaultSellerFields = [
+      "id",
+      "name",
+      "description",
+      "phone",
+      "email",
+      "handle",
+      "photo",
+      "address_line",
+      "postal_code",
+      "city",
+      "country_code",
+      "tax_id",
+      "store_status",
+      "metadata",
+      "created_at",
+      "updated_at",
+    ]
 
-    const requestedFields = req.query.fields as string | undefined
-    const parsedFields = requestedFields
-      ? requestedFields.split(",").map(field => field.trim()).filter(Boolean)
-      : []
-
-    const responseMetadataFields = requestedFields
-      ? parsedFields.filter(field => metadataFieldSet.has(field))
-      : Array.from(metadataFieldSet)
-
-    const responseSellerFields = requestedFields
-    const metadataFields = requestedFields
-      ? parsedFields.filter(field => metadataFieldSet.has(field))
-      : Array.from(metadataFieldSet)
-
-    const sellerFields = requestedFields
-      ? parsedFields
-          .filter(field => !metadataFieldSet.has(field))
-          .map(field => (field === "media" ? "photo" : field))
-      : [
-          "id", "name", "description", "phone", "email", "handle", "photo",
-          "address_line", "postal_code", "city", "country_code",
-          "tax_id", "store_status", "metadata", "created_at", "updated_at",
-        ]
-
-    if (!responseSellerFields.includes("id")) {
-      responseSellerFields.unshift("id")
-    if (!sellerFields.includes("id")) {
-      sellerFields.unshift("id")
-    }
+    const { sellerFields, metadataFields, includeMediaAlias } = parseRequestedFields(
+      req.query.fields,
+      defaultSellerFields
+    )
 
     // Fetch and return updated seller data
     const { data: sellers } = await query.graph({
       entity: "seller",
-      fields: responseSellerFields,
       fields: sellerFields,
-      fields: [
-        "id", "name", "description", "phone", "email", "handle", "photo",
-        "address_line", "postal_code", "city", "country_code",
-        "tax_id", "store_status", "metadata", "created_at", "updated_at",
-        "seller_metadata.*",
-      ],
       filters: { id: sellerId },
     })
 
@@ -303,14 +249,6 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     const seller = sellers[0] as Record<string, unknown>
     const response: Record<string, unknown> = { ...seller }
 
-    if (responseMetadataFields.length > 0) {
-      const { data: metadataRecords } = await query.graph({
-        entity: "seller_metadata",
-        fields: responseMetadataFields,
-        filters: { seller_id: sellerId },
-      })
-      const sellerMetadata = (metadataRecords?.[0] ?? {}) as Record<string, unknown>
-      for (const field of responseMetadataFields) {
     if (metadataFields.length > 0) {
       const { data: metadataRecords } = await query.graph({
         entity: "seller_metadata",


### PR DESCRIPTION
### Motivation
- The build was failing with TypeScript errors caused by duplicate block-scoped declarations and duplicated/misaligned query field parsing logic in the seller profile endpoints, preventing the backend from compiling.
- The goal is to consolidate and reuse the parsing logic to remove duplicated variables and make field handling consistent between `GET` and `POST` handlers.

### Description
- Replaced duplicated inline parsing logic with the shared `parseRequestedFields` helper and now call it from both `GET` and `POST` handlers in `backend/src/api/vendor/sellers/me/route.ts`.
- Centralized default seller field sets and metadata field handling and removed repeated `const` declarations that caused `TS2451` redeclaration errors.
- Ensured `includeMediaAlias` is derived from the helper and that `sellerFields` and `metadataFields` are used when calling `query.graph` to fetch seller and metadata records.
- Cleaned up response construction so metadata fields and the `media` alias are assigned consistently after updates and fetches.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697978e988f48323ae550926420c566d)