### PR TITLE
Normalize seller field query params

### DIFF
--- a/backend/src/api/vendor/sellers/me/route.ts
+++ b/backend/src/api/vendor/sellers/me/route.ts
@@ -12,16 +12,27 @@ const DEFAULT_METADATA_FIELDS = [
 
 const METADATA_FIELD_SET = new Set(DEFAULT_METADATA_FIELDS)
 
+const normalizeRequestedFields = (
+  requestedFields: unknown
+): string | string[] | undefined => {
+  if (typeof requestedFields === "string") {
+    return requestedFields
+  }
+
+  if (Array.isArray(requestedFields) && requestedFields.every(item => typeof item === "string")) {
+    return requestedFields
+  }
+
+  return undefined
+}
+
 const parseRequestedFields = (
-  requestedFields: string | string[] | undefined,
+  requestedFields: unknown,
   defaultSellerFields: string[]
 ) => {
+  const normalizedFields = normalizeRequestedFields(requestedFields)
   const requested =
-    typeof requestedFields === "string"
-      ? requestedFields
-      : Array.isArray(requestedFields)
-        ? requestedFields.join(",")
-        : undefined
+    typeof normalizedFields === "string" ? normalizedFields : normalizedFields?.join(",")
 
   if (!requested) {
     return {
@@ -62,9 +73,6 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
   try {
     const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-    // Parse fields from query params (comma-separated list)
-    const requestedFields = req.query.fields as string | undefined
-
     // Default seller fields to return
     const defaultSellerFields = [
       "id",
@@ -86,37 +94,10 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       // Include producer if linked
       "producer.*",
     ]
-    const defaultMetadataFields = [
-      "vendor_type",
-      "website_url",
-      "social_links",
-      "storefront_links",
-      "certifications",
-    ]
-    const metadataFieldSet = new Set(defaultMetadataFields)
-
-    // If specific fields requested, parse them
-    let sellerFields = defaultSellerFields
-    let metadataFields = defaultMetadataFields
-    let includeMediaAlias = true
-    if (requestedFields) {
-      const parsedFields = requestedFields.split(",").map(f => f.trim()).filter(Boolean)
-      if (parsedFields.length > 0) {
-        includeMediaAlias = parsedFields.includes("media")
-        metadataFields = parsedFields.filter(field => metadataFieldSet.has(field))
-        // Map frontend field names to actual seller entity fields
-        sellerFields = parsedFields
-          .filter(field => !metadataFieldSet.has(field))
-          .map(field => {
-            if (field === "media") return "photo" // media is alias for photo
-            return field
-          })
-        // Always ensure id is included
-        if (!sellerFields.includes("id")) {
-          sellerFields.unshift("id")
-        }
-      }
-    }
+    const { sellerFields, metadataFields, includeMediaAlias } = parseRequestedFields(
+      req.query.fields,
+      defaultSellerFields
+    )
 
     // Fetch seller data with related entities
     const { data: sellers } = await query.graph({
@@ -150,7 +131,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       }
     }
 
-    if (!requestedFields || includeMediaAlias) {
+    if (includeMediaAlias) {
       response.media = seller.photo
     }
 
@@ -238,58 +219,34 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       }
     }
 
-    const requestedFields = req.query.fields as string | undefined
-    const includeMediaAlias = !requestedFields || requestedFields.includes("media")
-    const includeMediaAlias = !req.query.fields || req.query.fields.includes("media")
-    const metadataFieldSet = new Set([
-      "vendor_type",
-      "website_url",
-      "social_links",
-      "storefront_links",
-      "certifications",
-    ])
+    const defaultSellerFields = [
+      "id",
+      "name",
+      "description",
+      "phone",
+      "email",
+      "handle",
+      "photo",
+      "address_line",
+      "postal_code",
+      "city",
+      "country_code",
+      "tax_id",
+      "store_status",
+      "metadata",
+      "created_at",
+      "updated_at",
+    ]
 
-    const requestedFields = req.query.fields as string | undefined
-    const parsedFields = requestedFields
-      ? requestedFields.split(",").map(field => field.trim()).filter(Boolean)
-      : []
-
-    const responseMetadataFields = requestedFields
-      ? parsedFields.filter(field => metadataFieldSet.has(field))
-      : Array.from(metadataFieldSet)
-
-    const responseSellerFields = requestedFields
-    const metadataFields = requestedFields
-      ? parsedFields.filter(field => metadataFieldSet.has(field))
-      : Array.from(metadataFieldSet)
-
-    const sellerFields = requestedFields
-      ? parsedFields
-          .filter(field => !metadataFieldSet.has(field))
-          .map(field => (field === "media" ? "photo" : field))
-      : [
-          "id", "name", "description", "phone", "email", "handle", "photo",
-          "address_line", "postal_code", "city", "country_code",
-          "tax_id", "store_status", "metadata", "created_at", "updated_at",
-        ]
-
-    if (!responseSellerFields.includes("id")) {
-      responseSellerFields.unshift("id")
-    if (!sellerFields.includes("id")) {
-      sellerFields.unshift("id")
-    }
+    const { sellerFields, metadataFields, includeMediaAlias } = parseRequestedFields(
+      req.query.fields,
+      defaultSellerFields
+    )
 
     // Fetch and return updated seller data
     const { data: sellers } = await query.graph({
       entity: "seller",
-      fields: responseSellerFields,
       fields: sellerFields,
-      fields: [
-        "id", "name", "description", "phone", "email", "handle", "photo",
-        "address_line", "postal_code", "city", "country_code",
-        "tax_id", "store_status", "metadata", "created_at", "updated_at",
-        "seller_metadata.*",
-      ],
       filters: { id: sellerId },
     })
 
@@ -303,14 +260,6 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     const seller = sellers[0] as Record<string, unknown>
     const response: Record<string, unknown> = { ...seller }
 
-    if (responseMetadataFields.length > 0) {
-      const { data: metadataRecords } = await query.graph({
-        entity: "seller_metadata",
-        fields: responseMetadataFields,
-        filters: { seller_id: sellerId },
-      })
-      const sellerMetadata = (metadataRecords?.[0] ?? {}) as Record<string, unknown>
-      for (const field of responseMetadataFields) {
     if (metadataFields.length > 0) {
       const { data: metadataRecords } = await query.graph({
         entity: "seller_metadata",


### PR DESCRIPTION
### Motivation
- The backend build was failing with a `TS2345` type error when reading `req.query.fields` because Express `ParsedQs` values were being passed to helpers expecting `string | string[] | undefined`, so the query params needed safe normalization before parsing. 
- The seller profile handlers also contained duplicated and inconsistent field-parsing code between `GET` and `POST`, which made maintenance harder and risked regressions.

### Description
- Added `normalizeRequestedFields(requestedFields: unknown)` to safely accept unknown query input and return `string | string[] | undefined` only when values are valid strings or string arrays. 
- Changed `parseRequestedFields` to accept `requestedFields: unknown` and to use `normalizeRequestedFields` before building the comma-separated `requested` string. 
- Replaced duplicated inline parsing in both `GET` and `POST` handlers with calls to `parseRequestedFields(req.query.fields, defaultSellerFields)`, preserving default field sets, mapping `media` to `photo`, always including `id`, and exposing `includeMediaAlias` consistently. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697978e988f48323ae550926420c566d)