### PR TITLE
Avoid sending empty auth headers in vendor client

### DIFF
--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -114,8 +114,8 @@ export const fetchQuery = async (
             ...(publishableApiKey ? { "x-publishable-api-key": publishableApiKey } : {}),
           }
         : {
-            authorization: `Bearer ${token}`,
-            "x-publishable-api-key": publishableApiKey,
+            ...(token ? { authorization: `Bearer ${token}` } : {}),
+            ...(publishableApiKey ? { "x-publishable-api-key": publishableApiKey } : {}),
           }),
       ...(!isForm && { "Content-Type": "application/json" }),
       ...headers,


### PR DESCRIPTION
### Motivation
- Prevent sending empty `authorization` and `x-publishable-api-key` headers from `fetchQuery`, which can cause unexpected backend errors.

### Description
- Update `vendor-panel/src/lib/client/client.ts` so `fetchQuery` only includes `authorization` when `token` is present and only includes `x-publishable-api-key` when `publishableApiKey` is set.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69797c30d3d8832381e578a775a9d61b)