### PR TITLE
Guard missing auth and surface non-JSON fetch errors

### DIFF
--- a/vendor-panel/src/lib/client/client.ts
+++ b/vendor-panel/src/lib/client/client.ts
@@ -100,6 +100,11 @@ export const fetchQuery = async (
   const isPublic = isPublicAuthRoute(url)
   const token = getAuthToken()
 
+  if (!isPublic && !token) {
+    clearAuthToken()
+    throw new Error("Brak autoryzacji. Zaloguj się ponownie.")
+  }
+
   const params = Object.entries(query || {})
     .filter(([_, v]) => v !== undefined && v !== null)
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
@@ -114,8 +119,8 @@ export const fetchQuery = async (
             ...(publishableApiKey ? { "x-publishable-api-key": publishableApiKey } : {}),
           }
         : {
-            authorization: `Bearer ${token}`,
-            "x-publishable-api-key": publishableApiKey,
+            ...(token ? { authorization: `Bearer ${token}` } : {}),
+            ...(publishableApiKey ? { "x-publishable-api-key": publishableApiKey } : {}),
           }),
       ...(!isForm && { "Content-Type": "application/json" }),
       ...headers,
@@ -124,11 +129,17 @@ export const fetchQuery = async (
   })
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}))
+    const contentType = response.headers.get("content-type") || ""
+    const errorData = contentType.includes("application/json")
+      ? await response.json().catch(() => ({}))
+      : {}
+    const errorText = !contentType.includes("application/json")
+      ? await response.text().catch(() => "")
+      : ""
     if (!isPublic && (response.status === 401 || response.status === 403)) {
       clearAuthToken()
     }
-    throw new Error(errorData.message || "Nieznany błąd serwera")
+    throw new Error(errorData.message || errorText || "Nieznany błąd serwera")
   }
 
   return response.json()


### PR DESCRIPTION
### Motivation
- Prevent non-public vendor requests from being sent without a valid auth token so the app fails fast and forces re-login.  
- Avoid sending empty `authorization` or `x-publishable-api-key` headers to the backend.  
- Surface non-JSON error payloads from the backend to make server errors easier to diagnose.

### Description
- Added an early auth guard in `vendor-panel/src/lib/client/client.ts` that calls `clearAuthToken()` and throws when a non-public route is requested without a token.  
- Made request headers conditional so `authorization` and `x-publishable-api-key` are only included when `token` and `publishableApiKey` are present, respectively.  
- Enhanced error handling to detect `Content-Type` and parse either JSON (`response.json()`) or plain text (`response.text()`), and include that text in thrown `Error` messages.  
- Retained the existing behavior of clearing auth on `401`/`403` responses via `clearAuthToken()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69797c30d3d8832381e578a775a9d61b)