### PR TITLE
Handle vendor menu profile fetch failures gracefully

### DIFF
--- a/vendor-panel/src/components/layout/user-menu/user-menu.tsx
+++ b/vendor-panel/src/components/layout/user-menu/user-menu.tsx
@@ -27,6 +27,7 @@ import { queryClient } from "../../../lib/query-client"
 import { useGlobalShortcuts } from "../../../providers/keybind-provider/hooks"
 import { useTheme } from "../../../providers/theme-provider"
 import { ImageAvatar } from "../../common/image-avatar"
+import { isFetchError } from "../../../lib/is-fetch-error"
 
 export const UserMenu = () => {
   const { t } = useTranslation()
@@ -86,7 +87,36 @@ const UserBadge = () => {
   }
 
   if (isError) {
-    throw error
+    if (isFetchError(error) && error.status === 401) {
+      throw error
+    }
+
+    return (
+      <div className="p-3">
+        <DropdownMenu.Trigger
+          disabled
+          className={clx(
+            "bg-ui-bg-subtle grid w-full cursor-not-allowed grid-cols-[24px_1fr_15px] items-center gap-2 rounded-md py-1 pl-0.5 pr-2 outline-none",
+            "opacity-70"
+          )}
+        >
+          <div className="flex size-7 items-center justify-center">
+            <ImageAvatar src="/logo.svg" size={7} rounded />
+          </div>
+          <div className="flex items-center overflow-hidden">
+            <Text
+              size="xsmall"
+              weight="plus"
+              leading="compact"
+              className="truncate text-ui-fg-muted"
+            >
+              Account unavailable
+            </Text>
+          </div>
+          <EllipsisHorizontal className="text-ui-fg-muted" />
+        </DropdownMenu.Trigger>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
### Motivation
- Prevent the vendor panel from crashing when the user profile fetch fails with server errors (e.g. 500) while still preserving redirect behavior for authentication failures (401). 

### Description
- Update `vendor-panel/src/components/layout/user-menu/user-menu.tsx` to import `isFetchError` and only rethrow when the profile error is a `401` fetch error. 
- Render a disabled, non-interactive user badge labeled "Account unavailable" for non-auth fetch errors instead of throwing, so the rest of the UI remains usable. 
- Preserve the original behavior of throwing on `401` so authentication flows still redirect to login. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4be44acc8323a5f207d3fe16e389)