### PR TITLE
Handle approved sellers without linked seller_id in vendor panel

### DIFF
--- a/vendor-panel/src/components/authentication/protected-route/protected-route.tsx
+++ b/vendor-panel/src/components/authentication/protected-route/protected-route.tsx
@@ -21,7 +21,8 @@ export const ProtectedRoute = () => {
   })
 
   // Only fetch seller data if registration status indicates approval
-  const isApproved = registrationStatus?.status === "approved"
+  const hasSellerId = Boolean(registrationStatus?.seller_id)
+  const isApproved = registrationStatus?.status === "approved" && hasSellerId
   const { seller, isPending: isSellerPending, error } = useMe({
     // Only run useMe if we know the user is approved
     enabled: isApproved,
@@ -68,7 +69,10 @@ export const ProtectedRoute = () => {
         )
 
       case "approved":
-        // Continue to load seller data below
+        if (!hasSellerId) {
+          return <Navigate to="/pending-approval" replace />
+        }
+        // Continue to load seller data below when seller_id is available
         break
 
       default:

--- a/vendor-panel/src/routes/pending-approval/pending-approval.tsx
+++ b/vendor-panel/src/routes/pending-approval/pending-approval.tsx
@@ -44,8 +44,8 @@ export const PendingApproval = () => {
     )
   }
 
-  // If user is approved, redirect to dashboard
-  if (registrationStatus?.status === "approved") {
+  // If user is approved and linked to a seller, redirect to dashboard
+  if (registrationStatus?.status === "approved" && registrationStatus.seller_id) {
     return <Navigate to="/dashboard" replace />
   }
 
@@ -56,6 +56,23 @@ export const PendingApproval = () => {
 
   // Render appropriate content based on status
   const renderContent = () => {
+    if (registrationStatus?.status === "approved" && !registrationStatus.seller_id) {
+      return (
+        <>
+          <div className="w-16 h-16 rounded-full bg-ui-tag-blue-bg flex items-center justify-center mb-4">
+            <svg className="w-8 h-8 text-ui-tag-blue-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <Heading>Account Linking In Progress</Heading>
+          <Text size="small" className="text-ui-fg-subtle text-center mt-2 max-w-[320px]">
+            Your seller account has been approved, but we are still linking it to your profile.
+            Please refresh in a moment or log out and log back in.
+          </Text>
+        </>
+      )
+    }
+
     switch (registrationStatus?.status) {
       case "pending":
         return (
@@ -158,7 +175,8 @@ export const PendingApproval = () => {
         {renderContent()}
 
         <div className="flex flex-col items-center gap-4 mt-8">
-          {registrationStatus?.status === "pending" && (
+          {(registrationStatus?.status === "pending" ||
+            (registrationStatus?.status === "approved" && !registrationStatus.seller_id)) && (
             <Button variant="secondary" onClick={handleRefresh} disabled={isPending}>
               Check Status
             </Button>


### PR DESCRIPTION
### Motivation
- Prevent a login loop and 500 errors when `/auth/seller/registration-status` returns `approved` but the account is not yet linked to a `seller_id`, which causes the vendor panel to fetch `/vendor/sellers/me` prematurely.

### Description
- Gate vendor data fetching by adding a `hasSellerId` check and enable `useMe` only when `registrationStatus.status === "approved" && registrationStatus.seller_id` in `vendor-panel/src/components/authentication/protected-route/protected-route.tsx`.
- When an account is `approved` but lacks `seller_id`, redirect from the protected route to the pending page to avoid hitting vendor APIs without context in `protected-route.tsx`.
- Add a new UI state to `vendor-panel/src/routes/pending-approval/pending-approval.tsx` that displays an "Account Linking In Progress" message for `approved` users without `seller_id` and keep the `Check Status` button enabled for that case.
- Ensure the pending-approval page only redirects to the dashboard when `registrationStatus.status === "approved" && registrationStatus.seller_id`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ab46be5508323b300ebc4ba10688d)