### PR TITLE
Ensure seller request status persists after review

### DIFF
--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -252,13 +252,18 @@ class RequestModuleService extends MedusaService({
 
     // Use retrieveRequest + update pattern for more reliable single-record update
     try {
-      const updatedRequest = await this.updateRequests(
+      await this.updateRequests(
         { id },
         updateData
       )
 
+      const [updatedRequest] = await this.listRequests({ id })
       if (!updatedRequest) {
-        throw new Error("Update did not return a request")
+        throw new Error("Updated request could not be retrieved")
+      }
+
+      if (updatedRequest.status !== RequestStatus.ACCEPTED) {
+        throw new Error("Request status update did not persist")
       }
 
       console.log(`[RequestService] Request updated successfully, new status: ${updatedRequest.status}`)
@@ -304,10 +309,19 @@ class RequestModuleService extends MedusaService({
       updateData.reviewer_note = reviewerNote
     }
 
-    const updatedRequest = await this.updateRequests(
+    await this.updateRequests(
       { id },
       updateData
     )
+
+    const [updatedRequest] = await this.listRequests({ id })
+    if (!updatedRequest) {
+      throw new Error("Updated request could not be retrieved")
+    }
+
+    if (updatedRequest.status !== RequestStatus.REJECTED) {
+      throw new Error("Request status update did not persist")
+    }
 
     console.log(`[RequestService] Request rejected successfully`)
     return updatedRequest

--- a/backend/src/shared/seller-approval-service.ts
+++ b/backend/src/shared/seller-approval-service.ts
@@ -378,9 +378,10 @@ export class SellerApprovalService {
         ? `${request.reviewer_note}\n${sanitizedNote}`.trim()
         : sanitizedNote
 
+      let updatedRequest
       try {
         // Use the dedicated acceptRequestWithReview method for reliable status update
-        await requestService.acceptRequestWithReview(
+        updatedRequest = await requestService.acceptRequestWithReview(
           requestId,
           reviewerId,
           updatedNote || undefined
@@ -401,8 +402,8 @@ export class SellerApprovalService {
           handle: seller.handle,
         },
         request: {
-          id: requestId,
-          status: RequestStatus.ACCEPTED,
+          id: updatedRequest.id,
+          status: updatedRequest.status as RequestStatus,
         },
         rocketchatCreated,
       }
@@ -442,7 +443,7 @@ export class SellerApprovalService {
 
     // Use the dedicated rejectRequestWithReview method
     const sanitizedReason = sanitizeInput(reason)
-    await requestService.rejectRequestWithReview(
+    const updatedRequest = await requestService.rejectRequestWithReview(
       requestId,
       reviewerId,
       sanitizedReason || undefined
@@ -451,8 +452,8 @@ export class SellerApprovalService {
     console.log(`[SellerApproval] Request ${requestId} rejected by reviewer ${reviewerId}${sanitizedReason ? `: ${sanitizedReason}` : ""}`)
 
     return {
-      id: requestId,
-      status: RequestStatus.REJECTED,
+      id: updatedRequest.id,
+      status: updatedRequest.status as RequestStatus,
     }
   }
 
@@ -483,7 +484,7 @@ export class SellerApprovalService {
       : sanitizedNote
 
     // Use the dedicated acceptRequestWithReview method
-    await requestService.acceptRequestWithReview(
+    const updatedRequest = await requestService.acceptRequestWithReview(
       requestId,
       reviewerId,
       updatedNote || undefined
@@ -492,8 +493,8 @@ export class SellerApprovalService {
     console.log(`[SellerApproval] Generic request ${requestId} approved by reviewer ${reviewerId}`)
 
     return {
-      id: requestId,
-      status: RequestStatus.ACCEPTED,
+      id: updatedRequest.id,
+      status: updatedRequest.status as RequestStatus,
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Fix a race/consistency issue where accepting or rejecting a request from the admin UI could appear to revert to `pending` after a page refresh because the update wasn't verified against persisted state.
- Ensure approval flows return the actual persisted request status so callers get reliable data about the final state.

### Description
- In `RequestModuleService.acceptRequestWithReview` re-fetch the request after `updateRequests`, validate the returned record exists and that its `status` is `accepted`, and throw a clear error if the update did not persist.
- In `RequestModuleService.rejectRequestWithReview` re-fetch the request after `updateRequests`, validate the returned record exists and that its `status` is `rejected`, and throw a clear error if the update did not persist.
- Update `SellerApprovalService` to capture the `updatedRequest` returned by the request service for accept/reject/generic-approve flows and return the persisted `id`/`status` in responses rather than assuming the update succeeded.
- Add extra logging/error messages around update failures to aid debugging.

### Testing
- No automated tests were executed as part of this change (none requested during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ab68ec7488323bd0fa7937016596c)