### PR TITLE
Fix seller-metadata method compatibility and request status updates

### DIFF
--- a/backend/src/api/admin/requests/[id]/route.ts
+++ b/backend/src/api/admin/requests/[id]/route.ts
@@ -169,7 +169,7 @@ export async function PATCH(req: AuthenticatedMedusaRequest, res: MedusaResponse
     if (data.payload) updateData.payload = data.payload
     if (data.notes !== undefined) updateData.notes = sanitizeInput(data.notes)
 
-    const updated = await requestService.updateRequests({ id }, updateData)
+    const updated = await requestService.updateRequests({ id, ...updateData })
 
     res.json({
       request: updated,

--- a/backend/src/api/admin/seller-metadata/[seller_id]/route.ts
+++ b/backend/src/api/admin/seller-metadata/[seller_id]/route.ts
@@ -4,6 +4,10 @@ import { IEventBusModuleService } from "@medusajs/framework/types"
 import { SELLER_EXTENSION_MODULE } from "../../../../modules/seller-extension"
 import SellerExtensionService from "../../../../modules/seller-extension/service"
 import { VendorType } from "../../../../modules/seller-extension/models/seller-metadata"
+import {
+  deleteSellerMetadataRecord,
+  updateSellerMetadataRecord,
+} from "../../../../modules/seller-extension/metadata-service"
 
 /**
  * GET /admin/seller-metadata/:seller_id
@@ -103,7 +107,7 @@ export const PUT = async (
     updateData.service_types = JSON.stringify(body.service_types)
   }
   
-  const updated = await sellerExtensionService.updateSellerMetadatas(updateData)
+  const updated = await updateSellerMetadataRecord(sellerExtensionService, updateData)
 
   // Emit vendor.verified event if verified changed from false to true
   if (!wasVerified && body.verified === true) {
@@ -153,7 +157,7 @@ export const DELETE = async (
     })
   }
 
-  await sellerExtensionService.deleteSellerMetadatas(existingMetadata[0].id)
+  await deleteSellerMetadataRecord(sellerExtensionService, existingMetadata[0].id)
 
   return res.status(200).json({
     id: existingMetadata[0].id,

--- a/backend/src/api/admin/seller-metadata/route.ts
+++ b/backend/src/api/admin/seller-metadata/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SELLER_EXTENSION_MODULE } from "../../../modules/seller-extension"
 import SellerExtensionService from "../../../modules/seller-extension/service"
 import { VendorType } from "../../../modules/seller-extension/models/seller-metadata"
+import { createSellerMetadataRecord } from "../../../modules/seller-extension/metadata-service"
 
 /**
  * GET /admin/seller-metadata
@@ -58,7 +59,7 @@ export const POST = async (
     metadata?: Record<string, any>
   }
 
-  const sellerMetadata = await sellerExtensionService.createSellerMetadatas({
+  const sellerMetadata = await createSellerMetadataRecord(sellerExtensionService, {
     seller_id: body.seller_id,
     vendor_type: body.vendor_type || VendorType.PRODUCER,
     business_registration_number: body.business_registration_number || null,

--- a/backend/src/api/vendor/sellers/me/route.ts
+++ b/backend/src/api/vendor/sellers/me/route.ts
@@ -1,6 +1,10 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { requireSellerId } from "../../../../shared"
+import {
+  createSellerMetadataRecord,
+  updateSellerMetadataRecord,
+} from "../../../../modules/seller-extension/metadata-service"
 
 const DEFAULT_METADATA_FIELDS = [
   "vendor_type",
@@ -208,13 +212,13 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       if (metadataRecords && metadataRecords.length > 0) {
         // Update existing metadata
         const metadataId = (metadataRecords[0] as { id: string }).id
-        await sellerExtensionModule.updateSellerMetadatas([
-          { id: metadataId, ...metadataUpdate }
+        await updateSellerMetadataRecord(sellerExtensionModule, [
+          { id: metadataId, ...metadataUpdate },
         ])
       } else {
         // Create new metadata record
-        await sellerExtensionModule.createSellerMetadatas([
-          { seller_id: sellerId, ...metadataUpdate }
+        await createSellerMetadataRecord(sellerExtensionModule, [
+          { seller_id: sellerId, ...metadataUpdate },
         ])
       }
     }

--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -101,10 +101,10 @@ class RequestModuleService extends MedusaService({
       RequestStatus.ACCEPTED
     )
 
-    const request = await this.updateRequests(
-      { id },
-      { status: RequestStatus.ACCEPTED }
-    )
+    const request = await this.updateRequests({
+      id,
+      status: RequestStatus.ACCEPTED,
+    })
     return request
   }
 
@@ -120,10 +120,10 @@ class RequestModuleService extends MedusaService({
       RequestStatus.REJECTED
     )
 
-    const request = await this.updateRequests(
-      { id },
-      { status: RequestStatus.REJECTED }
-    )
+    const request = await this.updateRequests({
+      id,
+      status: RequestStatus.REJECTED,
+    })
     return request
   }
 
@@ -139,10 +139,10 @@ class RequestModuleService extends MedusaService({
       RequestStatus.CANCELLED
     )
 
-    const request = await this.updateRequests(
-      { id },
-      { status: RequestStatus.CANCELLED }
-    )
+    const request = await this.updateRequests({
+      id,
+      status: RequestStatus.CANCELLED,
+    })
     return request
   }
 
@@ -158,10 +158,10 @@ class RequestModuleService extends MedusaService({
       RequestStatus.COMPLETED
     )
 
-    const request = await this.updateRequests(
-      { id },
-      { status: RequestStatus.COMPLETED }
-    )
+    const request = await this.updateRequests({
+      id,
+      status: RequestStatus.COMPLETED,
+    })
     return request
   }
 
@@ -252,10 +252,10 @@ class RequestModuleService extends MedusaService({
 
     // Use retrieveRequest + update pattern for more reliable single-record update
     try {
-      await this.updateRequests(
-        { id },
-        updateData
-      )
+      await this.updateRequests({
+        id,
+        ...updateData,
+      })
 
       const [updatedRequest] = await this.listRequests({ id })
       if (!updatedRequest) {
@@ -309,10 +309,10 @@ class RequestModuleService extends MedusaService({
       updateData.reviewer_note = reviewerNote
     }
 
-    await this.updateRequests(
-      { id },
-      updateData
-    )
+    await this.updateRequests({
+      id,
+      ...updateData,
+    })
 
     const [updatedRequest] = await this.listRequests({ id })
     if (!updatedRequest) {

--- a/backend/src/modules/seller-extension/metadata-service.ts
+++ b/backend/src/modules/seller-extension/metadata-service.ts
@@ -1,0 +1,68 @@
+import SellerExtensionService from "./service"
+
+type MethodName =
+  | "createSellerMetadatas"
+  | "createSellerMetadata"
+  | "updateSellerMetadatas"
+  | "updateSellerMetadata"
+  | "deleteSellerMetadatas"
+  | "deleteSellerMetadata"
+  | "create"
+  | "update"
+  | "delete"
+
+type SellerExtensionServiceLike = SellerExtensionService & {
+  [key in MethodName]?: (...args: any[]) => any
+}
+
+const resolveServiceMethod = (
+  service: SellerExtensionServiceLike,
+  methodNames: MethodName[]
+) => {
+  for (const name of methodNames) {
+    const candidate = service[name]
+    if (typeof candidate === "function") {
+      return candidate.bind(service)
+    }
+  }
+
+  throw new Error(
+    `SellerExtensionService is missing expected methods: ${methodNames.join(", ")}`
+  )
+}
+
+export const createSellerMetadataRecord = async (
+  service: SellerExtensionServiceLike,
+  data: Record<string, unknown> | Record<string, unknown>[]
+) => {
+  const create = resolveServiceMethod(service, [
+    "createSellerMetadatas",
+    "createSellerMetadata",
+    "create",
+  ])
+  return create(data)
+}
+
+export const updateSellerMetadataRecord = async (
+  service: SellerExtensionServiceLike,
+  data: Record<string, unknown> | Record<string, unknown>[]
+) => {
+  const update = resolveServiceMethod(service, [
+    "updateSellerMetadatas",
+    "updateSellerMetadata",
+    "update",
+  ])
+  return update(data)
+}
+
+export const deleteSellerMetadataRecord = async (
+  service: SellerExtensionServiceLike,
+  data: string | string[]
+) => {
+  const remove = resolveServiceMethod(service, [
+    "deleteSellerMetadatas",
+    "deleteSellerMetadata",
+    "delete",
+  ])
+  return remove(data)
+}

--- a/backend/src/workflows/create-seller-metadata.ts
+++ b/backend/src/workflows/create-seller-metadata.ts
@@ -7,6 +7,10 @@ import {
 import { SELLER_EXTENSION_MODULE } from "../modules/seller-extension"
 import SellerExtensionService from "../modules/seller-extension/service"
 import { VendorType } from "../modules/seller-extension/models/seller-metadata"
+import {
+  createSellerMetadataRecord,
+  deleteSellerMetadataRecord,
+} from "../modules/seller-extension/metadata-service"
 
 type CreateSellerMetadataInput = {
   seller_id: string
@@ -38,7 +42,7 @@ const createSellerMetadataStep = createStep(
       SELLER_EXTENSION_MODULE
     )
 
-    const sellerMetadata = await sellerExtensionService.createSellerMetadatas({
+    const sellerMetadata = await createSellerMetadataRecord(sellerExtensionService, {
       seller_id: input.seller_id,
       vendor_type: input.vendor_type || VendorType.PRODUCER,
       business_registration_number: input.business_registration_number || null,
@@ -68,7 +72,7 @@ const createSellerMetadataStep = createStep(
       SELLER_EXTENSION_MODULE
     )
 
-    await sellerExtensionService.deleteSellerMetadatas(sellerMetadataId)
+    await deleteSellerMetadataRecord(sellerExtensionService, sellerMetadataId)
   }
 )
 


### PR DESCRIPTION
### Motivation
- Prevent runtime failures during seller approval where `sellerExtensionService.createSellerMetadatas` was missing and to fix non-persisting request status updates that caused `Request status update did not persist` errors.

### Description
- Add a compatibility helper `backend/src/modules/seller-extension/metadata-service.ts` that resolves `create`/`update`/`delete` method name variants on the `sellerExtension` service and expose `createSellerMetadataRecord`, `updateSellerMetadataRecord`, and `deleteSellerMetadataRecord`.
- Replace direct calls to `sellerExtensionService.createSellerMetadatas`/`updateSellerMetadatas`/`deleteSellerMetadatas` with the helper in `backend/src/workflows/create-seller-metadata.ts`, `backend/src/api/admin/seller-metadata/route.ts`, `backend/src/api/admin/seller-metadata/[seller_id]/route.ts`, and `backend/src/api/vendor/sellers/me/route.ts` to support multiple module implementations.
- Fix `updateRequests` invocation shape in `backend/src/modules/request/service.ts` to pass a single update payload object (e.g. `{ id, ...updateData }`) and update the admin PATCH route `backend/src/api/admin/requests/[id]/route.ts` to call `updateRequests` with the merged payload for reliable status persistence.

### Testing
- No automated tests were run as part of this change; changes were limited to code updates to address runtime errors observed in logs and were exercised via static inspection and local edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abb1ae5608323a3e6c26e507bc639)