### PR TITLE
Require seller_id before fetching vendor profile in vendor panel

### DIFF
--- a/vendor-panel/src/hooks/api/users.tsx
+++ b/vendor-panel/src/hooks/api/users.tsx
@@ -105,7 +105,7 @@ export const useMe = (
       }
 
       const status = await fetchRegistrationStatus(token)
-      if (status.status !== "approved") {
+      if (status.status !== "approved" || !status.seller_id) {
         return null
       }
 


### PR DESCRIPTION
### Motivation
- Prevent attempts to fetch the vendor "me" profile when a user is approved but the token/auth metadata does not include a `seller_id`, which was causing downstream errors reading undefined `store_status`/`id` values.

### Description
- Update the `useMe` hook in `vendor-panel/src/hooks/api/users.tsx` to only fetch `/vendor/sellers/me` when `registrationStatus.status === "approved"` AND `registrationStatus.seller_id` is present, avoiding the fetch when `seller_id` is missing.

### Testing
- No automated tests were run as part of this change; only the single-line behavioral check was implemented and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abec2d158832399f889da3d060e85)