### PR TITLE
Fix vendor seller context middleware handling

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -12,6 +12,7 @@ import {
   strictAuthRateLimiter,
   vendorRegistrationRateLimiter,
 } from "../shared/rate-limiter"
+import { ensureSellerContext } from "./vendor/_middlewares"
 
 // Basic email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -332,12 +333,12 @@ export default defineMiddlewares({
     // Using "/vendor*" pattern to match all vendor routes including those from plugins
     {
       matcher: "/vendor*",
-      middlewares: [vendorCorsMiddleware],
+      middlewares: [vendorCorsMiddleware, ensureSellerContext],
     },
     // Also match the more specific pattern for local vendor routes
     {
       matcher: "/vendor/*",
-      middlewares: [vendorCorsMiddleware],
+      middlewares: [vendorCorsMiddleware, ensureSellerContext],
     },
     // CORS for auth seller registration status (uses vendor CORS since it's called by vendor panel)
     {

--- a/backend/src/api/vendor/_middlewares.ts
+++ b/backend/src/api/vendor/_middlewares.ts
@@ -92,7 +92,7 @@ async function vendorCorsMiddleware(
   next()
 }
 
-async function ensureSellerContext(
+export async function ensureSellerContext(
   req: MedusaRequest,
   res: MedusaResponse,
   next: MedusaNextFunction
@@ -103,10 +103,12 @@ async function ensureSellerContext(
     ["/vendor/sellers", new Set(["POST"])],
   ])
 
+  const rawPath = req.originalUrl || req.url || req.path || ""
+  const requestPath = rawPath.split("?")[0]
   const isPublicRoute =
-    req.path &&
-    publicRoutes.has(req.path) &&
-    publicRoutes.get(req.path)!.has(req.method.toUpperCase())
+    requestPath &&
+    publicRoutes.has(requestPath) &&
+    publicRoutes.get(requestPath)!.has(req.method.toUpperCase())
 
   if (isPublicRoute) {
     next()


### PR DESCRIPTION
### Motivation
- Requests from the vendor panel were intermittently failing with errors like `Cannot read properties of undefined (reading 'store_status')` and `Cannot read properties of undefined (reading 'id')` because the seller context middleware either wasn't applied or route path matching missed public vendor endpoints. 
- Ensure vendor routes reliably receive seller context so handlers that read `seller.store_status` or `seller.id` don't encounter undefined values.

### Description
- Exported `ensureSellerContext` from `backend/src/api/vendor/_middlewares.ts` so it can be composed with other middlewares. 
- Fixed public-route detection in `ensureSellerContext` to use the full request URL (uses `req.originalUrl || req.url || req.path` and strips query params) when checking `publicRoutes` to prevent mismatches. 
- Applied `ensureSellerContext` alongside `vendorCorsMiddleware` for the `/vendor*` and `/vendor/*` matchers in `backend/src/api/middlewares.ts` and added the necessary import. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac6504ba08323b55ed50e363664c4)