### PR TITLE
Allow vendor auth middleware to accept member actor tokens

### DIFF
--- a/backend/src/api/vendor/_middlewares.ts
+++ b/backend/src/api/vendor/_middlewares.ts
@@ -118,7 +118,10 @@ export async function ensureSellerContext(
   const authContext = (req as MedusaRequest & { auth_context?: { actor_id?: string; actor_type?: string } })
     .auth_context
 
-  if (!authContext?.actor_id || authContext.actor_type !== "seller") {
+  const actorType = authContext?.actor_type
+  const isSellerActor = actorType === "seller" || actorType === "member"
+
+  if (!authContext?.actor_id || !isSellerActor) {
     res.status(401).json({
       message: "Unauthorized - seller authentication required",
       type: "unauthorized",


### PR DESCRIPTION
### Motivation
- Fix 401 `Unauthorized - seller authentication required` responses when the vendor panel supplies tokens where `auth_context.actor_type` is `member` so member-issued tokens can access `/vendor/*` routes and be resolved to a seller ID.

### Description
- Update `backend/src/api/vendor/_middlewares.ts` to accept `actor_type` of `member` in addition to `seller` by adding `actorType` and `isSellerActor` checks and keeping the existing resolution of `mem_` prefixed IDs to a `seller_id` via the database.

### Testing
- No automated tests were run; this is a small middleware change that was committed without running the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697acc077b448323be5a9bf00d3eaa30)