### PR TITLE
Fallback to `app_metadata.seller_id` for seller authentication

### DIFF
--- a/backend/src/shared/auth-helpers.ts
+++ b/backend/src/shared/auth-helpers.ts
@@ -38,7 +38,11 @@ export function extractSellerId(
   req: AuthenticatedRequest,
   res: MedusaResponse
 ): AuthResult<string> {
-  const sellerId = req.auth_context?.actor_id
+  const sellerId =
+    req.auth_context?.actor_id ??
+    (typeof req.auth_context?.app_metadata?.seller_id === "string"
+      ? req.auth_context?.app_metadata?.seller_id
+      : undefined)
 
   if (!sellerId) {
     res.status(401).json({ 
@@ -125,7 +129,11 @@ export function extractAdminId(
  * @returns The seller ID or null if not authenticated
  */
 export function requireSellerId(req: AuthenticatedRequest, res: MedusaResponse): string | null {
-  const sellerId = req.auth_context?.actor_id
+  const sellerId =
+    req.auth_context?.actor_id ??
+    (typeof req.auth_context?.app_metadata?.seller_id === "string"
+      ? req.auth_context?.app_metadata?.seller_id
+      : undefined)
   if (!sellerId) {
     res.status(401).json({ 
       message: "Unauthorized - seller authentication required",


### PR DESCRIPTION
### Motivation
- Vendor-facing endpoints were returning 401 for approved users when the JWT lacked `actor_id` but contained a `seller_id` in `app_metadata`.
- Provide a robust authentication fallback so vendor routes like `/vendor/sellers/me` can authenticate approved sellers even when `actor_id` is missing from the token.

### Description
- Updated `extractSellerId` in `backend/src/shared/auth-helpers.ts` to fall back to `req.auth_context?.app_metadata?.seller_id` when `actor_id` is not present and the metadata value is a string.
- Updated `requireSellerId` in the same file to apply the same fallback logic and return the `seller_id` from `app_metadata` when appropriate.
- The fallback includes a type check (`typeof ... === "string"`) to avoid treating non-string metadata as an ID.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697acea45b5c8323af834082ab837be5)