### PR TITLE
Optimize vendor dashboard analytics data handling

### DIFF
--- a/vendor-panel/src/hooks/api/users.tsx
+++ b/vendor-panel/src/hooks/api/users.tsx
@@ -237,7 +237,7 @@ export const useStatistics = ({ from, to }: { from: string; to: string }) => {
           method: "GET",
         }
       ),
-    queryKey: [USERS_QUERY_KEY, "statistics"],
+    queryKey: [USERS_QUERY_KEY, "statistics", from, to],
   })
 
   return { ...data, ...rest }


### PR DESCRIPTION
### Motivation
- Prevent stale or unnecessary refetches and improve performance of the vendor dashboard analytics when users change the date range. 
- Simplify and harden chart data generation and date handling to produce consistent numeric series for charts. 
- Improve filter checks and reduce repeated work in render paths.

### Description
- Include the selected date range in the query cache key by updating `useStatistics` to `queryKey: [USERS_QUERY_KEY, "statistics", from, to]` in `vendor-panel/src/hooks/api/users.tsx` so statistics are cached/refetched per-range. 
- Replace fragile date/string manipulation and repeated `find` calls with a deterministic `generateChartData` that builds maps keyed by `yyyy-MM-dd` and iterates the day range to produce zero-filled numeric series. (Updated `vendor-panel/src/routes/dashboard/components/dashboard-charts.tsx`.)
- Use `useMemo` for parsed `from`/`to` (`parseISO`), `chartData`, `totals`, and `filterSet` to avoid recalculation on every render. 
- Normalize API inputs/outputs by formatting `from`/`to` when calling `useStatistics` and defaulting `customers`/`orders` to `[]`, and adjust the calendar `onSelect` and `updateDateRange` to work with `Date` objects.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad63eead08323ad991644ec63726f)