### PR TITLE
Refine vendor login and registration layouts

### DIFF
--- a/vendor-panel/src/routes/login/login.tsx
+++ b/vendor-panel/src/routes/login/login.tsx
@@ -79,33 +79,33 @@ export const Login = () => {
   return (
     <div className="bg-ui-bg-subtle flex min-h-dvh w-dvw items-center justify-center px-4 py-10">
       <div className="w-full max-w-md">
-        <div className="bg-ui-bg-base shadow-elevation-card-rest border-ui-border-base flex flex-col items-center rounded-2xl border p-6 sm:p-8">
-          <div className="mb-6 flex flex-col items-center gap-4">
+        <div className="bg-ui-bg-base shadow-elevation-card-rest border-ui-border-base flex flex-col rounded-2xl border p-6 sm:p-8">
+          <div className="mb-6 flex flex-col items-center gap-4 text-center">
             <AvatarBox />
-            <div className="flex flex-col items-center">
+            <div className="flex flex-col items-center gap-1">
               <Heading>{t("login.title")}</Heading>
               <Text size="small" className="text-ui-fg-subtle text-center">
                 {t("login.hint")}
               </Text>
             </div>
           </div>
-          <div className="flex w-full flex-col gap-y-3">
+          <div className="flex w-full flex-col gap-y-4">
             {getWidgets("login.before").map((Component, i) => {
               return <Component key={i} />
             })}
             <Form {...form}>
               <form
                 onSubmit={handleSubmit}
-                className="flex w-full flex-col gap-y-6"
+                className="flex w-full flex-col gap-y-5"
               >
-                <div className="flex flex-col gap-y-2">
+                <div className="flex flex-col gap-y-3">
                   <Form.Field
                     control={form.control}
                     name="email"
                     render={({ field }) => {
                       return (
                         <Form.Item>
-                          <Form.Label className="sr-only">
+                          <Form.Label className="text-ui-fg-base text-sm font-medium">
                             {t("fields.email")}
                           </Form.Label>
                           <Form.Control>
@@ -126,7 +126,7 @@ export const Login = () => {
                     render={({ field }) => {
                       return (
                         <Form.Item>
-                          <Form.Label className="sr-only">
+                          <Form.Label className="text-ui-fg-base text-sm font-medium">
                             {t("fields.password")}
                           </Form.Label>
                           <Form.Control>
@@ -159,29 +159,31 @@ export const Login = () => {
                     {serverError}
                   </Alert>
                 )}
-                <Button className="w-full" type="submit" isLoading={isPending}>
-                  Sign In
-                </Button>
+                <div className="flex flex-col gap-3">
+                  <Button className="w-full" type="submit" isLoading={isPending}>
+                    Sign In
+                  </Button>
+                  <span className="text-ui-fg-muted txt-small text-center">
+                    <Trans
+                      i18nKey="login.forgotPassword"
+                      components={[
+                        <Link
+                          key="reset-password-link"
+                          to="/reset-password"
+                          className="text-ui-fg-interactive transition-fg hover:text-ui-fg-interactive-hover focus-visible:text-ui-fg-interactive-hover font-medium outline-none"
+                        />,
+                      ]}
+                    />
+                  </span>
+                </div>
               </form>
             </Form>
             {getWidgets("login.after").map((Component, i) => {
               return <Component key={i} />
             })}
           </div>
-          <div className="mt-6 flex flex-col items-center gap-4 text-center">
-            <span className="text-ui-fg-muted txt-small">
-              <Trans
-                i18nKey="login.forgotPassword"
-                components={[
-                  <Link
-                    key="reset-password-link"
-                    to="/reset-password"
-                    className="text-ui-fg-interactive transition-fg hover:text-ui-fg-interactive-hover focus-visible:text-ui-fg-interactive-hover font-medium outline-none"
-                  />,
-                ]}
-              />
-            </span>
-            {__DISABLE_SELLERS_REGISTRATION__ === "false" && (
+          {__DISABLE_SELLERS_REGISTRATION__ === "false" && (
+            <div className="border-ui-border-base mt-6 border-t pt-4 text-center">
               <span className="text-ui-fg-muted txt-small">
                 <Trans
                   i18nKey="login.notSellerYet"
@@ -193,8 +195,8 @@ export const Login = () => {
                   ]}
                 />
               </span>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/vendor-panel/src/routes/register/register.tsx
+++ b/vendor-panel/src/routes/register/register.tsx
@@ -143,7 +143,7 @@ export const Register = () => {
                 />
               </svg>
             </div>
-          <Heading>Thank You for registering!</Heading>
+            <Heading>Thank You for registering!</Heading>
             <Text
               size="small"
               className="text-ui-fg-subtle mt-2 max-w-[320px] text-center"
@@ -165,8 +165,18 @@ export const Register = () => {
       <div className="bg-ui-bg-subtle flex min-h-dvh w-dvw items-center justify-center px-4 py-10">
         <div className="w-full max-w-2xl">
           <div className="bg-ui-bg-base shadow-elevation-card-rest border-ui-border-base rounded-2xl border p-6 sm:p-8">
-            <div className="mb-6 flex justify-center">
+            <div className="mb-6 flex flex-col items-center gap-3 text-center">
               <AvatarBox />
+              <div className="flex flex-col items-center gap-1">
+                <Heading>{t("register.title")}</Heading>
+                <Text size="small" className="text-ui-fg-subtle max-w-md">
+                  Choose the seller profile that best matches your business.
+                  You can update details later.
+                </Text>
+              </div>
+              <div className="bg-ui-bg-component text-ui-fg-subtle inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
+                Step 1 of 2
+              </div>
             </div>
             <VendorTypeSelection
               selectedType={selectedType}
@@ -193,9 +203,9 @@ export const Register = () => {
 
   return (
     <div className="bg-ui-bg-subtle flex min-h-dvh w-dvw items-center justify-center px-4 py-10">
-      <div className="w-full max-w-lg">
+      <div className="w-full max-w-xl">
         <div className="bg-ui-bg-base shadow-elevation-card-rest border-ui-border-base flex flex-col items-center rounded-2xl border p-6 sm:p-8">
-          <div className="mb-6 flex flex-col items-center gap-4">
+          <div className="mb-6 flex w-full flex-col items-center gap-4 text-center">
             <AvatarBox />
             {selectedTypeInfo && (
               <div className="bg-ui-bg-component flex items-center gap-2 rounded-full px-3 py-1.5">
@@ -234,6 +244,9 @@ export const Register = () => {
                 {t("register.hint")}
               </Text>
             </div>
+            <div className="bg-ui-bg-component text-ui-fg-subtle inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
+              Step 2 of 2
+            </div>
           </div>
           <div className="flex w-full flex-col gap-y-3">
             <Form {...form}>
@@ -241,50 +254,95 @@ export const Register = () => {
                 onSubmit={handleSubmit}
                 className="flex w-full flex-col gap-y-6"
               >
-                <div className="flex flex-col gap-y-2">
-                  {["name", "email", "password", "confirmPassword"].map(
-                    (fieldName) => (
-                      <Form.Field
-                        key={fieldName}
-                        control={form.control}
-                        name={fieldName as any}
-                        render={({ field }) => (
-                          <Form.Item>
-                            <Form.Control>
-                              <Input
-                                {...field}
-                                type={
-                                  fieldName.includes("password")
-                                    ? "password"
-                                    : "text"
-                                }
-                                placeholder={
-                                  fieldName === "name"
-                                    ? getNamePlaceholder(
-                                        selectedType || "default"
-                                      )
-                                    : fieldName === "email"
-                                      ? t("fields.email")
-                                      : fieldName === "confirmPassword"
-                                        ? "Confirm Password"
-                                        : t("fields.password")
-                                }
-                                className="bg-ui-bg-field-component"
-                              />
-                            </Form.Control>
-                            <Form.ErrorMessage />
-                          </Form.Item>
-                        )}
-                      />
-                    )
-                  )}
+                <div className="grid gap-4">
+                  <Form.Field
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                      <Form.Item>
+                        <Form.Label className="text-ui-fg-base text-sm font-medium">
+                          Business name
+                        </Form.Label>
+                        <Form.Control>
+                          <Input
+                            {...field}
+                            placeholder={getNamePlaceholder(selectedType || "default")}
+                            className="bg-ui-bg-field-component"
+                          />
+                        </Form.Control>
+                        <Form.ErrorMessage />
+                      </Form.Item>
+                    )}
+                  />
+                  <Form.Field
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                      <Form.Item>
+                        <Form.Label className="text-ui-fg-base text-sm font-medium">
+                          {t("fields.email")}
+                        </Form.Label>
+                        <Form.Control>
+                          <Input
+                            {...field}
+                            type="email"
+                            placeholder={t("fields.email")}
+                            className="bg-ui-bg-field-component"
+                          />
+                        </Form.Control>
+                        <Form.ErrorMessage />
+                      </Form.Item>
+                    )}
+                  />
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <Form.Field
+                      control={form.control}
+                      name="password"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label className="text-ui-fg-base text-sm font-medium">
+                            {t("fields.password")}
+                          </Form.Label>
+                          <Form.Control>
+                            <Input
+                              {...field}
+                              type="password"
+                              placeholder={t("fields.password")}
+                              className="bg-ui-bg-field-component"
+                            />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="confirmPassword"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label className="text-ui-fg-base text-sm font-medium">
+                            Confirm password
+                          </Form.Label>
+                          <Form.Control>
+                            <Input
+                              {...field}
+                              type="password"
+                              placeholder="Confirm password"
+                              className="bg-ui-bg-field-component"
+                            />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                  </div>
                 </div>
 
                 <div className="border-ui-border-base mt-2 border-t pt-4">
                   <button
                     type="button"
                     onClick={() => setShowOptionalFields(!showOptionalFields)}
-                    className="text-ui-fg-interactive mx-auto flex items-center gap-1 text-sm hover:underline"
+                    className="text-ui-fg-interactive mx-auto flex items-center gap-1 text-sm font-medium hover:underline"
                   >
                     {showOptionalFields
                       ? "Hide"
@@ -312,6 +370,9 @@ export const Register = () => {
                         name={field as any}
                         render={({ field: f }) => (
                           <Form.Item>
+                            <Form.Label className="text-ui-fg-base text-sm font-medium">
+                              {field.replace("_", " ").toUpperCase()}
+                            </Form.Label>
                             <Form.Control>
                               <Input
                                 {...f}
@@ -348,6 +409,9 @@ export const Register = () => {
                 </Button>
               </form>
             </Form>
+            <div className="text-ui-fg-muted txt-small mt-4 text-center">
+              By continuing, you agree to complete onboarding once approved.
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Improve clarity and UX for the vendor authentication flows by making form fields and steps more explicit, improving spacing, and surfacing helpful copy.

### Description
- Login: replace visually-hidden labels with visible `Form.Label`s, adjust spacing and layout, group the submit button with the `forgot password` helper, and move the "not a seller yet" CTA into a bottom bordered area.
- Register: introduce step indicators for the type/details flow, restructure the details form into a labeled grid, present `password`/`confirmPassword` as a responsive two-column group, add labeled optional fields for website/social links, and increase form max width.
- Apply small copy refinements and spacing tweaks, while preserving existing validation and error handling logic.

### Testing
- Ran `pnpm --dir vendor-panel dev` to validate the vendor panel UI changes and the run failed due to a missing publishable API key environment configuration, so no automated UI/server tests completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8f0ab9c08323835556e537df46f9)