### PR TITLE
Harden seller request approval and registration lookups

### DIFF
--- a/backend/src/api/admin/requests/[id]/approve/route.ts
+++ b/backend/src/api/admin/requests/[id]/approve/route.ts
@@ -3,6 +3,7 @@ import { REQUEST_MODULE } from "../../../../../modules/request"
 import RequestModuleService from "../../../../../modules/request/service"
 import { isSellerRequestType } from "../../../../../modules/request/validators"
 import { getSellerApprovalService } from "../../../../../shared/seller-approval-service"
+import { requireAdminId } from "../../../../../shared/auth-helpers"
 
 /**
  * POST /admin/requests/:id/approve
@@ -21,7 +22,10 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
 
   try {
     // Get reviewer ID from authenticated user
-    const reviewerId = req.auth_context?.actor_id || "unknown"
+    const reviewerId = requireAdminId(req, res)
+    if (!reviewerId) {
+      return
+    }
 
     const approvalService = getSellerApprovalService(req.scope)
 

--- a/backend/src/api/admin/requests/[id]/reject/route.ts
+++ b/backend/src/api/admin/requests/[id]/reject/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { RequestStatus } from "../../../../../modules/request/models"
 import { getSellerApprovalService } from "../../../../../shared/seller-approval-service"
+import { requireAdminId } from "../../../../../shared/auth-helpers"
 
 const rejectSchema = z.object({
   reason: z.string().optional(),
@@ -20,7 +21,10 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     const { reason } = rejectSchema.parse(req.body || {})
 
     // Get reviewer ID from authenticated user
-    const reviewerId = req.auth_context?.actor_id || "unknown"
+    const reviewerId = requireAdminId(req, res)
+    if (!reviewerId) {
+      return
+    }
 
     const approvalService = getSellerApprovalService(req.scope)
 

--- a/backend/src/api/admin/requests/route.ts
+++ b/backend/src/api/admin/requests/route.ts
@@ -4,6 +4,7 @@ import { REQUEST_MODULE } from "../../../modules/request"
 import RequestModuleService from "../../../modules/request/service"
 import { RequestStatus } from "../../../modules/request/models"
 import { sanitizeInput } from "../../../shared/seller-approval-service"
+import { requireAdminId } from "../../../shared/auth-helpers"
 
 // ===========================================
 // VALIDATION SCHEMAS
@@ -71,6 +72,10 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
 export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
   try {
     const body = createRequestSchema.parse(req.body)
+    const adminId = requireAdminId(req, res)
+    if (!adminId) {
+      return
+    }
 
     const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
 
@@ -85,8 +90,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     })
 
     // Get actor info for audit logging
-    const actorId = req.auth_context?.actor_id || "unknown"
-    console.log(`[POST /admin/requests] Request ${request.id} created by admin ${actorId}. Type: ${body.type}`)
+    console.log(`[POST /admin/requests] Request ${request.id} created by admin ${adminId}. Type: ${body.type}`)
 
     res.status(201).json({
       request,

--- a/backend/src/api/shared/seller-registration.ts
+++ b/backend/src/api/shared/seller-registration.ts
@@ -2,6 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { REQUEST_MODULE } from "../../modules/request"
 import RequestModuleService from "../../modules/request/service"
+import { RequestStatus } from "../../modules/request/models"
 import { REQUEST_TYPES } from "../../modules/request/validators"
 import {
   createSellerRegistrationSchema,
@@ -56,12 +57,11 @@ export const handleSellerRegistration = async (
     const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
     const existingRequests = await requestService.listRequests({
       type: REQUEST_TYPES.SELLER,
+      submitter_id: authIdentity.id,
+      status: RequestStatus.PENDING,
     })
 
-    const userExistingRequest = existingRequests.find((request) => {
-      const data = request.data as Record<string, unknown> | undefined
-      return data?.auth_identity_id === authIdentity.id && request.status === "pending"
-    })
+    const userExistingRequest = existingRequests[0]
 
     if (userExistingRequest) {
       console.log(


### PR DESCRIPTION
### Motivation
- Reduce expensive full-table scans and fragile matching in the seller registration/approval workflow by using targeted queries and PG lookups. 
- Verify registration tokens using a configured JWT secret when available to avoid trusting unverified JWTs. 
- Ensure admin actions are audited and only executed when an authenticated admin reviewer is present. 

### Description
- Updated `GET /auth/seller/registration-status` to use `config.JWT_SECRET` and `jwt.verify` when present, falling back to `jwt.decode` only when no secret is configured, and added warnings when decoding without verification. 
- Changed pending-request lookups to scope by `submitter_id` and `status` (most notably in `backend/src/api/auth/seller/registration-status/route.ts` and `backend/src/api/shared/seller-registration.ts`) so we return targeted results instead of scanning all seller requests. 
- When linking approved requests to sellers, added direct Postgres lookups on the `member` table and a `findSellerById` check to reliably resolve `seller_id` before updating `auth_identity` (in `registration-status` handler and `seller-approval-service`). 
- Hardened fallback handling in `backend/src/shared/seller-approval-service.ts` to look up existing sellers by `member.email` via `PG_CONNECTION` and by `handle` with a tuned `LIKE` query rather than fetching entire seller graphs. 
- Enforced authenticated admin reviewer identity across admin request endpoints by calling `requireAdminId(req, res)` in `backend/src/api/admin/requests/*` routes and using the returned admin id for audit logs and action attribution. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were validated via static inspection and local code checks (file diffs and targeted greps) and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba6f402288323b9bedf161f1b2e77)