### PR TITLE
Validate password payloads in auth hooks

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -29,6 +29,14 @@ const fetchRegistrationStatus = async (token: string) => {
   }>
 }
 
+const normalizePassword = (password: unknown) => {
+  if (typeof password !== "string") {
+    throw new Error("Password should be a string.")
+  }
+
+  return password
+}
+
 /**
  * Sign in with email/password
  */
@@ -42,9 +50,11 @@ export const useSignInWithEmailPass = (
 ) => {
   return useMutation({
     mutationFn: async (payload) => {
+      const normalizedPassword = normalizePassword(payload.password)
       const result = await publicAuthSdk.auth.login("seller", "emailpass", {
         ...payload,
         email: payload.email.toLowerCase().trim(),
+        password: normalizedPassword,
       })
       if (typeof result === "string") setAuthToken(result)
       return result
@@ -71,11 +81,13 @@ export const useSignUpWithEmailPass = (
     mutationFn: async (payload) => {
       const { confirmPassword, vendor_type, ...authPayload } = payload
       const normalizedEmail = payload.email.toLowerCase().trim()
+      const normalizedPassword = normalizePassword(payload.password)
 
       try {
         const token = await sdk.auth.register("seller", "emailpass", {
           ...authPayload,
           email: normalizedEmail,
+          password: normalizedPassword,
         })
 
         if (typeof token === "string") setAuthToken(token)
@@ -90,6 +102,7 @@ export const useSignUpWithEmailPass = (
           const result = await sdk.auth.login("seller", "emailpass", {
             ...authPayload,
             email: normalizedEmail,
+            password: normalizedPassword,
           })
           if (typeof result === "string") {
             setAuthToken(result)
@@ -142,9 +155,11 @@ export const useSignUpForInvite = (
 ) => {
   return useMutation({
     mutationFn: async (payload) => {
+      const normalizedPassword = normalizePassword(payload.password)
       const token = await publicAuthSdk.auth.register("seller", "emailpass", {
         ...payload,
         email: payload.email.toLowerCase().trim(),
+        password: normalizedPassword,
       })
       if (typeof token === "string") setAuthToken(token)
       return token


### PR DESCRIPTION
### Motivation

- Prevent runtime errors like `Password should be a string` coming from the auth provider by ensuring password payloads are always strings before calling the auth SDK. 
- Normalize auth inputs (email/password) in the vendor auth hooks to reduce backend validation failures and inconsistent trimming/casing.

### Description

- Added a `normalizePassword` helper to `vendor-panel/src/hooks/api/auth.tsx` that throws if the provided password is not a string and returns the normalized value. 
- Applied the normalization in the seller auth flows: `useSignInWithEmailPass`, `useSignUpWithEmailPass`, and `useSignUpForInvite` so `password` is always a string when calling `publicAuthSdk.auth.login` and `sdk.auth.register`.
- Preserved existing behavior of lowercasing/trimming emails and storing auth tokens via `setAuthToken` when responses are strings.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697baf43ae588323820ab23df42832ea)