### PR TITLE
Validate password payloads and improve seller auth context handling

### DIFF
--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -29,6 +29,14 @@ const fetchRegistrationStatus = async (token: string) => {
   }>
 }
 
+const normalizePassword = (password: unknown) => {
+  if (typeof password !== "string") {
+    throw new Error("Password should be a string.")
+  }
+
+  return password
+}
+
 /**
  * Sign in with email/password
  */
@@ -42,9 +50,11 @@ export const useSignInWithEmailPass = (
 ) => {
   return useMutation({
     mutationFn: async (payload) => {
+      const normalizedPassword = normalizePassword(payload.password)
       const result = await publicAuthSdk.auth.login("seller", "emailpass", {
         ...payload,
         email: payload.email.toLowerCase().trim(),
+        password: normalizedPassword,
       })
       if (typeof result === "string") setAuthToken(result)
       return result
@@ -71,11 +81,13 @@ export const useSignUpWithEmailPass = (
     mutationFn: async (payload) => {
       const { confirmPassword, vendor_type, ...authPayload } = payload
       const normalizedEmail = payload.email.toLowerCase().trim()
+      const normalizedPassword = normalizePassword(payload.password)
 
       try {
         const token = await sdk.auth.register("seller", "emailpass", {
           ...authPayload,
           email: normalizedEmail,
+          password: normalizedPassword,
         })
 
         if (typeof token === "string") setAuthToken(token)
@@ -90,6 +102,7 @@ export const useSignUpWithEmailPass = (
           const result = await sdk.auth.login("seller", "emailpass", {
             ...authPayload,
             email: normalizedEmail,
+            password: normalizedPassword,
           })
           if (typeof result === "string") {
             setAuthToken(result)
@@ -142,9 +155,11 @@ export const useSignUpForInvite = (
 ) => {
   return useMutation({
     mutationFn: async (payload) => {
+      const normalizedPassword = normalizePassword(payload.password)
       const token = await publicAuthSdk.auth.register("seller", "emailpass", {
         ...payload,
         email: payload.email.toLowerCase().trim(),
+        password: normalizedPassword,
       })
       if (typeof token === "string") setAuthToken(token)
       return token


### PR DESCRIPTION
### Motivation
- Prevent runtime errors from the auth provider by ensuring `password` payloads are always strings before reaching vendor auth endpoints. 
- Normalize and validate client inputs so the auth SDK is called with consistent types. 
- Improve seller authentication resolution so middleware can reliably populate seller context from bearer tokens or linked `auth_identity` records.

### Description
- Add `validatePasswordMiddleware` in `backend/src/api/middlewares.ts` and register it for `POST /auth/seller/emailpass` to return `400` when `password` is not a string. 
- Enhance `ensureSellerContext` in `backend/src/api/vendor/_middlewares.ts` to decode bearer tokens, populate `auth_context` (including `auth_identity_id`), and resolve seller ids via member lookups or the `auth` module, and add a `decodeAuthToken` helper. 
- Update `backend/src/shared/auth-helpers.ts` with `extractBearerToken` and `decodeAuthToken` helpers and change `requireSellerId` to resolve seller ids from tokens or linked `auth_identity` records. 
- Add `normalizePassword` in `vendor-panel/src/hooks/api/auth.tsx` and apply it in `useSignInWithEmailPass`, `useSignUpWithEmailPass`, and `useSignUpForInvite` so client code throws early if `password` is not a string.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697baf43ae588323820ab23df42832ea)