### PR TITLE
Include seller store_status in registration-status and reuse cached status in vendor panel

### DIFF
--- a/backend/src/api/auth/seller/registration-status/route.ts
+++ b/backend/src/api/auth/seller/registration-status/route.ts
@@ -34,6 +34,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         return res.json({
           status: "approved",
           seller_id: sellerId,
+          seller,
+          store_status: seller.store_status ?? null,
           message: "Your seller account is approved. You can access the vendor dashboard.",
         })
       }
@@ -68,6 +70,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         return res.json({
           status: "approved",
           seller_id: appMetadata.seller_id,
+          seller,
+          store_status: seller.store_status ?? null,
           message: "Your seller account is approved. You can access the vendor dashboard.",
         })
       }
@@ -127,7 +131,7 @@ async function findSellerById(req: MedusaRequest, sellerId: string) {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data: sellers } = await query.graph({
     entity: "seller",
-    fields: ["id"],
+    fields: ["id", "store_status"],
     filters: { id: sellerId },
   })
   return sellers?.[0] ?? null
@@ -238,6 +242,8 @@ async function handleAcceptedRequest(
           return req.res!.json({
             status: "approved",
             seller_id: sellerId,
+            seller,
+            store_status: seller.store_status ?? null,
             request_id: latestRequest.id,
             message: "Your seller account is approved. You can access the vendor dashboard.",
           })


### PR DESCRIPTION
### Motivation

- The vendor panel was encountering runtime errors when it attempted to read `store_status` from a missing seller payload returned by the registration-status endpoint.
- Also reduce duplicate network calls by reusing the cached registration status when deciding whether to fetch the seller profile.

### Description

- Update `backend/src/api/auth/seller/registration-status/route.ts` to request and return the seller record (including `store_status`) when a seller is found, and to include `store_status` in approval responses.
- Update `vendor-panel/src/hooks/api/users.tsx` to extend the `RegistrationStatusResponse` type with optional `seller`/`store_status` fields and to use `queryClient.getQueryData` to reuse any cached `usersQueryKeys.registrationStatus()` before making the network call.

### Testing

- No automated tests were executed for this change (no test run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd2f099cc83238ac3718b81a73ea1)