### PR TITLE
Guard vendor order/user hooks on registration-status and include seller/store_status in status response

### DIFF
--- a/backend/src/api/auth/seller/registration-status/route.ts
+++ b/backend/src/api/auth/seller/registration-status/route.ts
@@ -34,6 +34,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         return res.json({
           status: "approved",
           seller_id: sellerId,
+          seller,
+          store_status: seller.store_status ?? null,
           message: "Your seller account is approved. You can access the vendor dashboard.",
         })
       }
@@ -68,6 +70,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         return res.json({
           status: "approved",
           seller_id: appMetadata.seller_id,
+          seller,
+          store_status: seller.store_status ?? null,
           message: "Your seller account is approved. You can access the vendor dashboard.",
         })
       }
@@ -127,7 +131,7 @@ async function findSellerById(req: MedusaRequest, sellerId: string) {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data: sellers } = await query.graph({
     entity: "seller",
-    fields: ["id"],
+    fields: ["id", "store_status"],
     filters: { id: sellerId },
   })
   return sellers?.[0] ?? null
@@ -238,6 +242,8 @@ async function handleAcceptedRequest(
           return req.res!.json({
             status: "approved",
             seller_id: sellerId,
+            seller,
+            store_status: seller.store_status ?? null,
             request_id: latestRequest.id,
             message: "Your seller account is approved. You can access the vendor dashboard.",
           })


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by vendor routes reading `seller.id` when the registration/seller context is missing by ensuring the app only calls vendor order endpoints for approved sellers.
- Reduce duplicate network calls and reuse cached registration status across hooks to avoid unnecessary onboarding/profile fetches and race conditions.

### Description
- Backend: include the found `seller` object and `store_status` in all approved responses from `GET /auth/seller/registration-status` and add `store_status` to the `findSellerById` query fields, with additional diagnostic logging around token extraction and decoding.
- Frontend (users): export `usersQueryKeys` and `fetchRegistrationStatus`, extend `RegistrationStatusResponse` to include optional `seller` and `store_status`, and reuse cached registration status in `useMe` and `useOnboarding` via `queryClient.getQueryData` to avoid extra network calls; also set `enabled: Boolean(getAuthToken())` for the onboarding query and avoid spreading null `data` by using `(data ?? {})`.
- Frontend (orders): add `ensureApprovedSeller` which checks the cached or fetched registration status and gate all vendor order queries (`useOrder`, `useOrders`, `useOrderPreview`, `useOrderCommission`, `useOrderChanges`, `useOrderLineItems`) to return early when the user is not an approved seller, and import `getAuthToken` and `useQueryClient` where needed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd2f099cc83238ac3718b81a73ea1)