### PR TITLE
Apply vendor auth middleware to nested routes and include seller/store_status in registration-status

### DIFF
--- a/backend/src/api/auth/seller/registration-status/route.ts
+++ b/backend/src/api/auth/seller/registration-status/route.ts
@@ -34,6 +34,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         return res.json({
           status: "approved",
           seller_id: sellerId,
+          seller,
+          store_status: seller.store_status ?? null,
           message: "Your seller account is approved. You can access the vendor dashboard.",
         })
       }
@@ -68,6 +70,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         return res.json({
           status: "approved",
           seller_id: appMetadata.seller_id,
+          seller,
+          store_status: seller.store_status ?? null,
           message: "Your seller account is approved. You can access the vendor dashboard.",
         })
       }
@@ -127,7 +131,7 @@ async function findSellerById(req: MedusaRequest, sellerId: string) {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data: sellers } = await query.graph({
     entity: "seller",
-    fields: ["id"],
+    fields: ["id", "store_status"],
     filters: { id: sellerId },
   })
   return sellers?.[0] ?? null
@@ -238,6 +242,8 @@ async function handleAcceptedRequest(
           return req.res!.json({
             status: "approved",
             seller_id: sellerId,
+            seller,
+            store_status: seller.store_status ?? null,
             request_id: latestRequest.id,
             message: "Your seller account is approved. You can access the vendor dashboard.",
           })

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -353,6 +353,11 @@ async function securityHeadersMiddleware(
 
 export default defineMiddlewares({
   routes: [
+    // Ensure all vendor routes (including nested plugin routes) are guarded
+    {
+      matcher: "/vendor/**",
+      middlewares: [vendorCorsMiddleware, ensureSellerContext],
+    },
     // CORS for vendor routes - must be first to handle OPTIONS preflight
     // Using "/vendor*" pattern to match all vendor routes including those from plugins
     {


### PR DESCRIPTION
### Motivation
- Prevent vendor routes (including nested plugin routes) from being accessible without seller auth context and avoid runtime errors when code reads missing seller fields. 
- Surface the found `seller` object and `store_status` from the registration status endpoint to let frontend logic make safer decisions without extra lookups. 
- Reuse cached registration status on the frontend to reduce duplicate network calls and avoid races when gating vendor-only queries.

### Description
- Backend: added a `/vendor/**` route matcher in `backend/src/api/middlewares.ts` to ensure `vendorCorsMiddleware` and `ensureSellerContext` apply to nested vendor/plugin routes. 
- Backend: updated `GET /auth/seller/registration-status` in `backend/src/api/auth/seller/registration-status/route.ts` to log token extraction/decoding, include the full `seller` object and `store_status` in approved responses, and expanded `findSellerById` to request the `store_status` field. 
- Frontend (users): exported `usersQueryKeys` and `fetchRegistrationStatus`, extended `RegistrationStatusResponse` to include optional `seller` and `store_status`, and updated `useMe` and `useOnboarding` to reuse cached registration status via `queryClient.getQueryData` and set `enabled: Boolean(getAuthToken())` for onboarding. 
- Frontend (orders): added `ensureApprovedSeller` which checks cached or fetched registration status and gated vendor order hooks (`useOrder`, `useOrders`, `useOrderPreview`, `useOrderCommission`, `useOrderChanges`, `useOrderLineItems`) to return early when the user is not an approved seller.

### Testing
- No automated tests were executed for these changes. 
- Changes were committed and a PR description was created, but no CI/lint/test runs were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd2f099cc83238ac3718b81a73ea1)