### PR TITLE
Deduplicate vendor seller and metadata field selection

### DIFF
--- a/backend/src/api/vendor/sellers/me/route.ts
+++ b/backend/src/api/vendor/sellers/me/route.ts
@@ -52,13 +52,16 @@ const parseRequestedFields = (
     .filter(field => !METADATA_FIELD_SET.has(field))
     .map(field => (field === "media" ? "photo" : field))
 
-  if (!sellerFields.includes("id")) {
-    sellerFields.unshift("id")
+  const uniqueSellerFields = Array.from(new Set(sellerFields))
+  const uniqueMetadataFields = Array.from(new Set(metadataFields))
+
+  if (!uniqueSellerFields.includes("id")) {
+    uniqueSellerFields.unshift("id")
   }
 
   return {
-    sellerFields,
-    metadataFields,
+    sellerFields: uniqueSellerFields,
+    metadataFields: uniqueMetadataFields,
     includeMediaAlias: parsedFields.includes("media"),
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate column requests and related query errors when parsing `fields` for the `/vendor/sellers/me` endpoint while preserving the existing `media` alias and ensuring `id` is always requested.

### Description
- Update `parseRequestedFields` in `backend/src/api/vendor/sellers/me/route.ts` to deduplicate seller and metadata field lists using `Set`, return the unique arrays, and ensure `id` is included; keep `media` mapped to `photo` and preserve `includeMediaAlias` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697be64b6bf083239acc93e8f1bae303)