### PR TITLE
Use readiness probe for Railway healthcheck and document health endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,6 +42,15 @@ Visit the [Quickstart Guide](https://docs.medusajs.com/learn/installation) to se
 
 Visit the [Docs](https://docs.medusajs.com/learn/installation#get-started) to learn more about our system requirements.
 
+## Railway Health Checks
+
+This backend exposes two health endpoints:
+
+- `GET /health` — liveness probe (fast, no external dependencies).
+- `GET /health/ready` — readiness probe (checks database connectivity and optional Redis).
+
+For Railway deployments that need to verify PostgreSQL connectivity, set the service health check to `/health/ready`. The default `railway.json` and `railway.staging.json` files already point to this path so Railway will only mark the service healthy when the database is reachable.
+
 ## Algolia Integration
 
 This backend includes automatic Algolia index setup via an initialization script. When you provide the following environment variables:

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -18,7 +18,7 @@
     "startCommand": "pnpm start",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
-    "healthcheckPath": "/health",
+    "healthcheckPath": "/health/ready",
     "healthcheckTimeout": 300,
     "numReplicas": 1
   }

--- a/backend/railway.staging.json
+++ b/backend/railway.staging.json
@@ -18,7 +18,7 @@
     "startCommand": "pnpm start",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
-    "healthcheckPath": "/health",
+    "healthcheckPath": "/health/ready",
     "healthcheckTimeout": 300,
     "numReplicas": 1
   }


### PR DESCRIPTION
### Motivation

- Ensure Railway only reports the service healthy when the backend can reach critical dependencies (Postgres), by pointing the deployment health check at the readiness endpoint that performs DB checks.

### Description

- Update `backend/railway.json` and `backend/railway.staging.json` to set `healthcheckPath` to `/health/ready`, and add a short `backend/README.md` section documenting the `GET /health` (liveness) and `GET /health/ready` (readiness) endpoints and recommended Railway configuration.

### Testing

- No automated tests were run because this is a configuration and documentation change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bee5ddaec8323a7d03bddddf9777a)