### PR TITLE
Harden auth token handling and protect admin routes

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -390,11 +390,11 @@ export default defineMiddlewares({
     },
     {
       matcher: "/admin/backfill-seller-auth",
-      middlewares: [adminCorsMiddleware],
+      middlewares: [adminCorsMiddleware, authenticate("user", ["bearer", "session"])],
     },
     {
       matcher: "/admin/auth-debug",
-      middlewares: [adminCorsMiddleware],
+      middlewares: [adminCorsMiddleware, authenticate("user", ["bearer", "session"])],
     },
     // Apply security headers to all routes
     {

--- a/backend/src/shared/config.ts
+++ b/backend/src/shared/config.ts
@@ -119,13 +119,15 @@ function loadConfig(): Config {
   
   // Production warnings
   if (result.data.NODE_ENV === "production") {
+    if (!result.data.JWT_SECRET) {
+      logger.error("JWT_SECRET is required in production.")
+      throw new Error("JWT_SECRET is required in production.")
+    }
+
     const warnings: string[] = []
     
     if (!result.data.REDIS_URL) {
       warnings.push("REDIS_URL not set - rate limiting and caching will use in-memory storage")
-    }
-    if (!result.data.JWT_SECRET) {
-      warnings.push("JWT_SECRET not set - using default (INSECURE)")
     }
     if (!result.data.COOKIE_SECRET) {
       warnings.push("COOKIE_SECRET not set - using default (INSECURE)")

--- a/storefront/src/lib/hooks/useHawalaWallet.ts
+++ b/storefront/src/lib/hooks/useHawalaWallet.ts
@@ -76,10 +76,8 @@ export interface InvestmentPool {
 const API_BASE = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || "http://localhost:9000"
 
 async function fetchWithAuth(url: string, options: RequestInit = {}) {
-  const token = localStorage.getItem("medusa_auth_token")
   const headers = {
     "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...options.headers,
   }
 


### PR DESCRIPTION
### Motivation
- Prevent unsigned JWTs from being trusted by requiring verified token parsing and making `JWT_SECRET` mandatory in production.
- Centralize token decoding to avoid inconsistent/unsafe decode fallbacks across vendor and seller flows.
- Protect sensitive admin diagnostic/backfill endpoints and remove insecure client-side token usage in Hawala flows.

### Description
- Require `JWT_SECRET` in production by throwing in `backend/src/shared/config.ts` when it is not set.
- Centralize verified JWT parsing in `backend/src/shared/auth-helpers.ts` and expose `decodeAuthToken` and `decodeAuthTokenFromAuthorization` to ensure tokens are only accepted when `JWT_SECRET` is present.
- Update `backend/src/api/vendor/_middlewares.ts` and `backend/src/api/auth/seller/registration-status/route.ts` to use the shared decoder and avoid decoding tokens without verification.
- Add `authenticate("user", ["bearer", "session"])` to the admin routes for `/admin/backfill-seller-auth` and `/admin/auth-debug` in `backend/src/api/middlewares.ts`.
- Remove `localStorage.getItem("medusa_auth_token")` usage from `storefront/src/lib/hooks/useHawalaWallet.ts` so Hawala requests rely on cookie-based auth (`credentials: "include"`).

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf212a08083239b91246d33cdffa0)