### PR TITLE
Fix vendor auth context for dashboard requests

### DIFF
--- a/backend/src/api/vendor/_middlewares.ts
+++ b/backend/src/api/vendor/_middlewares.ts
@@ -132,7 +132,12 @@ export async function ensureSellerContext(
   }
 
   const requestWithAuth = req as MedusaRequest & {
-    auth_context?: { actor_id?: string; actor_type?: string; auth_identity_id?: string }
+    auth_context?: {
+      actor_id?: string
+      actor_type?: string
+      auth_identity_id?: string
+      member_id?: string
+    }
   }
   const authContext = requestWithAuth.auth_context ?? {}
   const decodedToken = decodeAuthTokenFromAuthorization(req.headers.authorization)
@@ -182,8 +187,7 @@ export async function ensureSellerContext(
     )
     const memberId = memberResult.rows?.[0]?.id
     if (memberId) {
-      authContext.actor_id = memberId
-      authContext.actor_type = authContext.actor_type ?? "member"
+      authContext.member_id = memberId
     } else {
       res.status(401).json({
         message: "Seller membership not found for authenticated user",


### PR DESCRIPTION
### Motivation
- Dashboard requests were failing with `Cannot read properties of undefined (reading 'store_status' | 'id')` because vendor middleware overwrote the seller `actor_id` with a member id, breaking downstream vendor APIs that expect a seller id.
- Preserve the original seller authentication context so vendor endpoints (like the dashboard) can correctly look up seller data.

### Description
- Added `member_id` to the `auth_context` typing in `backend/src/api/vendor/_middlewares.ts` to hold a resolved member id without mutating `actor_id`.
- When the incoming `actor_id` starts with `sel_`, resolve the corresponding `member.id` and assign it to `auth_context.member_id` instead of overwriting `auth_context.actor_id` or `actor_type`.
- Kept the existing seller validation flow intact so downstream code still receives the seller `actor_id` as before.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c21d2fe788323b9167be99f05d677)