### PR TITLE
Fix seller registration status typing

### DIFF
--- a/backend/src/shared/seller-registration.ts
+++ b/backend/src/shared/seller-registration.ts
@@ -26,8 +26,15 @@ export interface RegistrationStatusResponse {
   reviewer_note?: string
 }
 
-const getStoreStatus = (seller?: { store_status?: string } | null) =>
-  seller?.store_status ?? null
+const getStoreStatus = (
+  seller?: { store_status?: string | null } | null
+): RegistrationStatusResponse["store_status"] => {
+  const status = seller?.store_status ?? null
+  if (status === "ACTIVE" || status === "SUSPENDED" || status === "INACTIVE") {
+    return status
+  }
+  return null
+}
 
 const buildApprovedResponse = ({
   sellerId,
@@ -39,11 +46,11 @@ const buildApprovedResponse = ({
   seller?: Record<string, unknown> | null
   message: string
   requestId?: string
-}) => ({
+}): RegistrationStatusResponse => ({
   status: "approved",
   seller_id: sellerId,
-  seller: seller ?? null,
-  store_status: getStoreStatus(seller as { store_status?: string } | null),
+  seller: (seller as RegistrationStatusResponse["seller"]) ?? null,
+  store_status: getStoreStatus(seller as { store_status?: string | null } | null),
   message,
   ...(requestId ? { request_id: requestId } : {}),
 })
@@ -214,7 +221,7 @@ async function checkRequests(
           request_id: latestRequest.id,
           message:
             "Your registration request is pending approval. Please wait for an administrator to review your application.",
-          created_at: latestRequest.created_at,
+          created_at: latestRequest.created_at?.toISOString?.() ?? undefined,
         },
       }
 
@@ -229,7 +236,7 @@ async function checkRequests(
           request_id: latestRequest.id,
           message:
             "Your registration request was not approved. Please contact support for more information.",
-          reviewer_note: latestRequest.reviewer_note,
+          reviewer_note: latestRequest.reviewer_note ?? undefined,
         },
       }
 


### PR DESCRIPTION
### Motivation
- Resolve TypeScript build errors caused by widened string types and mismatched field shapes in the seller registration status response.
- Ensure the registration response strictly conforms to the `RegistrationStatusResponse` interface so downstream consumers get consistent values.

### Description
- Narrowed `getStoreStatus` input and return types and normalized store status values to the allowed enum set via `RegistrationStatusResponse["store_status"]`.
- Typed the `buildApprovedResponse` helper to return `RegistrationStatusResponse` and cast the `seller` payload to the exact response shape to preserve the literal `status` value.
- Serialized `created_at` using `toISOString()` when present and normalized `reviewer_note` to `undefined` instead of `null` to match the response schema.
- Updated callers to use the new helper signatures and types in `backend/src/shared/seller-registration.ts`.

### Testing
- No automated tests were run as part of this change.
- The changes were made to address TypeScript errors observed during the backend build (status typing, date and nullable field mismatches).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf65fd6c483239fc22a07675ca5b7)