### PR TITLE
Fix vendor panel image URL conversion for localhost assets

### DIFF
--- a/vendor-panel/src/utils/images-conventer.ts
+++ b/vendor-panel/src/utils/images-conventer.ts
@@ -1,32 +1,15 @@
 import { backendUrl } from "../lib/client"
 
 export default function imagesConverter(images: string) {
-  if (typeof window === "undefined") {
+  const isLocalhost =
+    images.startsWith("http://localhost:9000") ||
+    images.startsWith("https://localhost:9000")
+
+  if (isLocalhost) {
     return images
+      .replace("http://localhost:9000", backendUrl)
+      .replace("https://localhost:9000", backendUrl)
   }
 
-  let imageUrl: URL
-  try {
-    imageUrl = new URL(images)
-  } catch {
-    return images
-  }
-
-  let backendOrigin: string
-  try {
-    backendOrigin = new URL(backendUrl, window.location.origin).origin
-  } catch {
-    return images
-  }
-
-  if (!backendOrigin || imageUrl.origin === backendOrigin) {
-    return images
-  }
-
-  if (!imageUrl.pathname.startsWith("/uploads")) {
-    return images
-  }
-
-  const updatedUrl = new URL(imageUrl.pathname + imageUrl.search + imageUrl.hash, backendOrigin)
-  return updatedUrl.toString()
+  return images
 }


### PR DESCRIPTION
### Motivation
- Prevent rewriting external image URLs and only convert local development asset URLs to the configured backend so images hosted on external storage are not broken.

### Description
- Replace complex URL parsing in `vendor-panel/src/utils/images-conventer.ts` with a targeted check that only rewrites `http://localhost:9000` and `https://localhost:9000` to `backendUrl`, and otherwise returns the original `images` value.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cfb8f9ea88323a7a1faf6d78a1dbb)