### PR TITLE
Extend q parameter strip middleware to additional admin routes

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -427,6 +427,57 @@ export default defineMiddlewares({
       method: "GET",
       middlewares: [stripQueryParamMiddleware],
     },
+    // Additional routes that don't support 'q' parameter
+    {
+      matcher: "/admin/collections*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/tags*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/api-keys*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/stores*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/payment-providers*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/tax-providers*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/inventory-items*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/shipping-profiles*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/payment-collections*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
+    {
+      matcher: "/admin/workflows-executions*",
+      method: "GET",
+      middlewares: [stripQueryParamMiddleware],
+    },
     // Ensure all vendor routes (including nested plugin routes) are guarded
     {
       matcher: "/vendor/**",


### PR DESCRIPTION
Added stripQueryParamMiddleware to more admin routes that don't support the 'q' search parameter:
- collections, tags, api-keys, stores
- payment-providers, tax-providers, inventory-items
- shipping-profiles, payment-collections, workflows-executions

Note: The LinkModel.q error from MikroORM is a framework-level issue in MercurJS/Medusa that occurs when expanding linked relations on product endpoints. This cannot be fully fixed with middleware since product endpoints need the 'q' parameter for search functionality.

https://claude.ai/code/session_01Ff8yw7WeQo9j9kjPWPD28m