### PR TITLE
Fix TS2321: cast finalTicketProduct to any to break recursive type chain

### DIFF
--- a/backend/src/workflows/create-ticket-product.ts
+++ b/backend/src/workflows/create-ticket-product.ts
@@ -252,8 +252,9 @@ export const createTicketProductWorkflow = createWorkflow(
       }
     }).config({ name: "retrieve-ticket-product" })
 
-    // Use transform to flatten the type and avoid TS2321 excessive stack depth
-    const result = transform({ finalTicketProduct }, (data) => ({
+    // Use transform with explicit any cast to break the recursive type chain
+    // and avoid TS2321 excessive stack depth errors from deeply nested MikroORM types
+    const result = transform({ finalTicketProduct: finalTicketProduct as any }, (data: any) => ({
       ticket_product: data.finalTicketProduct[0],
     }))
 


### PR DESCRIPTION
The deeply nested MikroORM entity types from useQueryGraphStep cause TypeScript to exceed its stack depth limit. Casting to any before passing into transform fully breaks the recursive type comparison.

https://claude.ai/code/session_013yQbSmhGb18YyypNzYk2sN