### PR TITLE
Fix TS18046: cast err to Error to access message property

### DIFF
--- a/backend/src/shared/auth-helpers.ts
+++ b/backend/src/shared/auth-helpers.ts
@@ -290,7 +290,8 @@ export function decodeAuthTokenWithError(token: string): TokenDecodeResult {
       }
     }
     if (err instanceof jwt.JsonWebTokenError) {
-      if (err.message.includes("signature")) {
+      const errorMessage = (err as Error).message || ""
+      if (errorMessage.includes("signature")) {
         return {
           success: false,
           error: "invalid_signature",


### PR DESCRIPTION
The jsonwebtoken types don't properly export JsonWebTokenError type information, causing TypeScript to not narrow the type correctly after the instanceof check.

https://claude.ai/code/session_01US77jPyqvPA2Vah1Gh3RJS