### PR TITLE
Seed Medusa core product types and fix admin dashboard visibility

### DIFF
--- a/backend/scripts/conditional-seed.js
+++ b/backend/scripts/conditional-seed.js
@@ -72,6 +72,52 @@ async function checkDatabaseEmpty() {
       return true;
     }
 
+    // Check if product types exist (added with community architecture update)
+    try {
+      const ptResult = await pool.query(`
+        SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_name = 'product_type'
+        ) as table_exists
+      `);
+
+      if (ptResult.rows[0].table_exists) {
+        const ptCount = await pool.query('SELECT COUNT(*) as count FROM product_type');
+        const ptCountVal = parseInt(ptCount.rows[0].count, 10);
+
+        if (ptCountVal === 0) {
+          log('No product types found, seed needed to create community product types');
+          return true;
+        }
+      }
+    } catch (error) {
+      // Non-critical check, continue
+    }
+
+    // Check if product collections exist (added with community architecture update)
+    try {
+      const pcResult = await pool.query(`
+        SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_name = 'product_collection'
+        ) as table_exists
+      `);
+
+      if (pcResult.rows[0].table_exists) {
+        const pcCount = await pool.query('SELECT COUNT(*) as count FROM product_collection');
+        const pcCountVal = parseInt(pcCount.rows[0].count, 10);
+
+        if (pcCountVal === 0) {
+          log('No product collections found, seed needed to create operational collections');
+          return true;
+        }
+      }
+    } catch (error) {
+      // Non-critical check, continue
+    }
+
     log(`Found ${count} region(s), database is already seeded`);
     return false;
   } catch (error) {

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -430,6 +430,32 @@ export default async function seedDemoData({ container }: ExecArgs) {
 
   logger.info("Seeding product data...");
 
+  // Seed Medusa core product types (these show in admin dashboard Product Types page)
+  logger.info("Seeding product types...");
+  const productModuleService = container.resolve(Modules.PRODUCT);
+  try {
+    const existingTypes = await productModuleService.listProductTypes({});
+    if (!existingTypes || existingTypes.length === 0) {
+      await productModuleService.createProductTypes([
+        { value: "food", metadata: { allow_internal_fulfillment: true, community_priority: true } },
+        { value: "land_access", metadata: { allow_internal_fulfillment: true, inventory_tracking: false, reservation_required: true } },
+        { value: "tools_and_infrastructure", metadata: { allow_internal_fulfillment: true } },
+        { value: "electronics_and_networks", metadata: { allow_internal_fulfillment: true } },
+        { value: "digital_services", metadata: { allow_internal_fulfillment: true, digital: true } },
+        { value: "community_and_events", metadata: { allow_internal_fulfillment: true, capacity_based: true } },
+        { value: "mutual_aid", metadata: { allow_internal_fulfillment: true, manual_fulfillment_required: true, community_priority: true } },
+        { value: "circular_economy", metadata: { allow_internal_fulfillment: true, requires_condition_grade: true } },
+        { value: "membership", metadata: { allow_internal_fulfillment: true, digital: true } },
+        { value: "experimental", metadata: { allow_internal_fulfillment: true, requires_governance_review: true } },
+      ]);
+      logger.info("Finished seeding product types.");
+    } else {
+      logger.info("Product types already exist, skipping...");
+    }
+  } catch (error: any) {
+    logger.warn(`Warning seeding product types: ${error.message}`);
+  }
+
   // Community-aligned product categories matching the new architecture
   const categoryNames = [
     "Fresh Produce",
@@ -471,7 +497,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
   // Seed product collections (operational logic layer)
   logger.info("Seeding product collections...");
   try {
-    const productModuleService = container.resolve(Modules.PRODUCT);
     const existingCollections = await productModuleService.listProductCollections({});
     if (!existingCollections || existingCollections.length === 0) {
       await productModuleService.createProductCollections([


### PR DESCRIPTION
The admin dashboard reads from Medusa's built-in product_type, product_category, and product_collection tables — not the custom CMS Blueprint tables. The previous seed never created Medusa product types, so the Product Types page was empty.

- Add 10 canonical product types to Medusa core product_type table (food, land_access, tools_and_infrastructure, etc.) with metadata
- Update conditional-seed.js to detect missing product types and collections, triggering re-seed on existing deployments
- Remove duplicate productModuleService resolution in seed.ts

https://claude.ai/code/session_01RWE2wo88pLMGHyPJQ9EDsn