### PR TITLE
Add automatic Rocket.Chat login for customers and vendors

### DIFF
--- a/backend/src/api/store/rocketchat/route.ts
+++ b/backend/src/api/store/rocketchat/route.ts
@@ -1,0 +1,106 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { getRocketChatService } from "../../../shared/rocketchat-service"
+
+/**
+ * GET /store/rocketchat
+ * Returns Rocket.Chat configuration and login token for the authenticated customer
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) {
+  const rocketchatUrl = process.env.ROCKETCHAT_URL
+
+  if (!rocketchatUrl) {
+    res.status(200).json({
+      configured: false,
+      message: "Rocket.Chat is not configured"
+    })
+    return
+  }
+
+  // Get authenticated customer ID from auth context
+  const customerId = req.auth_context?.actor_id
+
+  if (!customerId) {
+    res.status(401).json({
+      message: "Authentication required"
+    })
+    return
+  }
+
+  try {
+    // Get customer information using query graph
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: [customer] } = await query.graph({
+      entity: "customer",
+      fields: ["id", "email", "first_name", "last_name"],
+      filters: {
+        id: customerId,
+      },
+    })
+
+    if (!customer || !customer.email) {
+      res.status(404).json({
+        message: "Customer information not found"
+      })
+      return
+    }
+
+    // Generate username from email or name
+    const username = customer.email.split("@")[0]
+
+    // Get RocketChat service and create login token
+    const rocketchatService = getRocketChatService()
+    let loginToken: string | null = null
+
+    if (rocketchatService) {
+      try {
+        // Ensure customer has a RocketChat account (creates if doesn't exist)
+        const displayName = customer.first_name && customer.last_name
+          ? `${customer.first_name} ${customer.last_name}`
+          : customer.email
+
+        // Create RocketChat user if doesn't exist (using a random secure password)
+        const crypto = await import("crypto")
+        const tempPassword = crypto.randomBytes(32).toString("hex")
+
+        await rocketchatService.createUser(
+          displayName,
+          customer.email,
+          username,
+          tempPassword
+        )
+
+        // Create login token for auto-login
+        loginToken = await rocketchatService.createUserToken(username)
+        console.log(`[RocketChat] Created login token for customer: ${username}`)
+      } catch (error: any) {
+        console.error(`[RocketChat] Failed to create login token:`, error.message)
+        // Don't fail the entire request, just don't provide auto-login
+      }
+    }
+
+    const response: any = {
+      configured: true,
+      url: rocketchatUrl,
+      iframe_url: `${rocketchatUrl}/home`,
+    }
+
+    // Only include login credentials if we successfully generated a token
+    if (loginToken) {
+      response.login = {
+        token: loginToken,
+        username: username,
+      }
+    }
+
+    res.json(response)
+  } catch (error: any) {
+    console.error("[GET /store/rocketchat] Error:", error)
+    res.status(500).json({
+      message: error.message || "Failed to retrieve RocketChat configuration"
+    })
+  }
+}

--- a/backend/src/subscribers/customer-created-rocketchat.ts
+++ b/backend/src/subscribers/customer-created-rocketchat.ts
@@ -1,0 +1,74 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { getRocketChatService } from "../shared/rocketchat-service"
+import crypto from "crypto"
+
+/**
+ * Subscriber: Customer Created - RocketChat Integration
+ *
+ * Automatically creates RocketChat accounts for customers when they register.
+ * This ensures customers can access the messaging system immediately after signup.
+ */
+export default async function customerCreatedRocketChatHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const customerId = event.data.id
+
+  if (!customerId) {
+    console.warn("[customerCreated RocketChat] Event received without customer ID")
+    return
+  }
+
+  console.log(`[customerCreated RocketChat] Processing customer ${customerId}`)
+
+  try {
+    const rocketchatService = getRocketChatService()
+
+    // Skip if RocketChat is not configured
+    if (!rocketchatService) {
+      console.log("[customerCreated RocketChat] RocketChat not configured, skipping")
+      return
+    }
+
+    // Get customer information using query graph
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: [customer] } = await query.graph({
+      entity: "customer",
+      fields: ["id", "email", "first_name", "last_name"],
+      filters: {
+        id: customerId,
+      },
+    })
+
+    if (!customer || !customer.email) {
+      console.warn(`[customerCreated RocketChat] Customer ${customerId} not found or has no email`)
+      return
+    }
+
+    // Create RocketChat account
+    const username = customer.email.split("@")[0]
+    const rocketchatPassword = crypto.randomBytes(32).toString("hex")
+
+    const { userId: rocketchatUserId, username: rocketchatUsername } = await rocketchatService.createUser(
+      customer.first_name && customer.last_name
+        ? `${customer.first_name} ${customer.last_name}`
+        : customer.email,
+      customer.email,
+      username,
+      rocketchatPassword
+    )
+
+    // Add customer to general channel
+    await rocketchatService.addUserToChannel("general", rocketchatUsername)
+
+    console.log(`[customerCreated RocketChat] Created RocketChat account for customer: ${rocketchatUsername}`)
+  } catch (error: any) {
+    console.error(`[customerCreated RocketChat] Failed to create RocketChat account for customer ${customerId}:`, error.message)
+    // Don't throw - this is a non-critical enhancement
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "customer.created",
+}

--- a/storefront/src/components/sections/UserMessagesSection/UserMessagesSection.tsx
+++ b/storefront/src/components/sections/UserMessagesSection/UserMessagesSection.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import { useState } from "react"
-
-const ROCKETCHAT_URL = process.env.NEXT_PUBLIC_ROCKETCHAT_URL || ""
+import { useState, useRef, useEffect, useCallback } from "react"
+import { useRocketChat } from "@/providers/RocketChatProvider"
 
 interface UserMessagesSectionProps {
   // Optional: specific channel to open (e.g., for vendor or order messaging)
@@ -11,13 +10,131 @@ interface UserMessagesSectionProps {
   directMessageUser?: string
 }
 
-export const UserMessagesSection = ({ 
-  channelName, 
-  directMessageUser 
+export const UserMessagesSection = ({
+  channelName,
+  directMessageUser
 }: UserMessagesSectionProps = {}) => {
-  const [isFullscreen, setIsFullscreen] = useState(false)
+  const {
+    isConfigured,
+    isLoading,
+    rocketChatUrl,
+    iframeUrl: defaultIframeUrl,
+    loginToken,
+    getChannelUrl,
+    getDirectMessageUrl,
+  } = useRocketChat()
 
-  if (!ROCKETCHAT_URL) {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const loginAttemptedRef = useRef(false)
+
+  // Build the appropriate URL based on props
+  let iframeUrl = defaultIframeUrl
+  if (directMessageUser && rocketChatUrl) {
+    iframeUrl = getDirectMessageUrl(directMessageUser)
+  } else if (channelName && rocketChatUrl) {
+    iframeUrl = getChannelUrl(channelName)
+  }
+
+  // Auto-login to RocketChat via postMessage when iframe loads
+  const handleIframeLogin = useCallback(() => {
+    if (!iframeRef.current || !loginToken || !rocketChatUrl || loginAttemptedRef.current) return
+
+    try {
+      const iframe = iframeRef.current
+      const targetOrigin = new URL(rocketChatUrl).origin
+
+      // Send login-with-token message to RocketChat iframe
+      iframe.contentWindow?.postMessage({
+        externalCommand: "login-with-token",
+        token: loginToken
+      }, targetOrigin)
+
+      loginAttemptedRef.current = true
+      console.log("[RocketChat] Sent auto-login token to iframe")
+    } catch (error) {
+      console.error("[RocketChat] Failed to send login token:", error)
+    }
+  }, [loginToken, rocketChatUrl])
+
+  // Listen for messages from RocketChat iframe
+  useEffect(() => {
+    if (!rocketChatUrl) return
+
+    const handleMessage = (event: MessageEvent) => {
+      try {
+        const targetOrigin = new URL(rocketChatUrl).origin
+        if (event.origin !== targetOrigin) return
+
+        // Handle RocketChat ready event
+        if (event.data?.eventName === "startup") {
+          console.log("[RocketChat] Iframe ready, attempting auto-login")
+          handleIframeLogin()
+        }
+
+        // Handle successful login
+        if (event.data?.eventName === "login") {
+          setIsLoggedIn(true)
+          console.log("[RocketChat] Auto-login successful")
+        }
+      } catch (error) {
+        // Ignore origin parsing errors
+      }
+    }
+
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
+  }, [rocketChatUrl, handleIframeLogin])
+
+  // Reset login state when token changes
+  useEffect(() => {
+    loginAttemptedRef.current = false
+    setIsLoggedIn(false)
+  }, [loginToken])
+
+  // Handle iframe load event as fallback
+  const handleIframeLoad = useCallback(() => {
+    // Small delay to ensure RocketChat is fully loaded
+    setTimeout(() => {
+      if (!loginAttemptedRef.current) {
+        handleIframeLogin()
+      }
+    }, 1000)
+  }, [handleIframeLogin])
+
+  // Navigate to a channel using postMessage (preserves login state)
+  const navigateToChannel = useCallback((targetChannelName: string) => {
+    if (!iframeRef.current || !rocketChatUrl) return
+
+    try {
+      const targetOrigin = new URL(rocketChatUrl).origin
+      iframeRef.current.contentWindow?.postMessage({
+        externalCommand: "go",
+        path: `/channel/${targetChannelName}`
+      }, targetOrigin)
+    } catch (error) {
+      // Fallback to direct URL change
+      const url = getChannelUrl(targetChannelName)
+      if (iframeRef.current && url) {
+        iframeRef.current.src = url
+      }
+    }
+  }, [rocketChatUrl, getChannelUrl])
+
+  // Show loading state
+  if (isLoading) {
+    return (
+      <div className="max-w-full h-[655px] flex items-center justify-center text-gray-500">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+          <p className="text-sm mt-4">Loading chat...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isConfigured || !rocketChatUrl) {
     return (
       <div className="max-w-full h-[655px] flex items-center justify-center text-gray-500">
         <div className="text-center">
@@ -28,29 +145,44 @@ export const UserMessagesSection = ({
     )
   }
 
-  // Build the appropriate URL based on props
-  let iframeUrl = ROCKETCHAT_URL
-  if (directMessageUser) {
-    iframeUrl = `${ROCKETCHAT_URL}/direct/${directMessageUser}`
-  } else if (channelName) {
-    iframeUrl = `${ROCKETCHAT_URL}/channel/${channelName}`
-  } else {
-    iframeUrl = `${ROCKETCHAT_URL}/home`
-  }
+  // Quick links to common channels
+  const quickLinks = [
+    { label: "Support", channelName: "support" },
+    { label: "General", channelName: "general" },
+  ]
 
   return (
-    <div className={`max-w-full ${isFullscreen ? 'fixed inset-0 z-50 bg-white' : 'h-[655px]'}`}>
+    <div className={`max-w-full ${isFullscreen ? "fixed inset-0 z-50 bg-white" : "h-[655px]"}`}>
       <div className="flex justify-between items-center mb-2">
-        <h2 className="text-xl font-semibold">Messages</h2>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold">Messages</h2>
+          {isLoggedIn && (
+            <span className="text-xs text-green-600 bg-green-100 px-2 py-1 rounded">
+              Connected
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-4">
+          {/* Quick channel links */}
+          <div className="flex items-center gap-2 text-sm">
+            {quickLinks.map((link, idx) => (
+              <button
+                key={idx}
+                onClick={() => navigateToChannel(link.channelName)}
+                className="text-gray-500 hover:text-primary transition-colors"
+              >
+                {link.label}
+              </button>
+            ))}
+          </div>
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
             className="text-sm text-primary hover:underline"
           >
-            {isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
+            {isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
           </button>
           <a
-            href={ROCKETCHAT_URL}
+            href={rocketChatUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-primary hover:underline"
@@ -60,24 +192,28 @@ export const UserMessagesSection = ({
         </div>
       </div>
       <iframe
-        src={iframeUrl}
+        ref={iframeRef}
+        src={iframeUrl || `${rocketChatUrl}/home`}
         title="Messages"
-        className={`w-full border-0 rounded-lg ${isFullscreen ? 'h-[calc(100vh-60px)]' : 'h-[600px]'}`}
-        allow="camera; microphone; fullscreen; display-capture"
+        className={`w-full border-0 rounded-lg ${isFullscreen ? "h-[calc(100vh-60px)]" : "h-[600px]"}`}
+        allow="camera; microphone; fullscreen; display-capture; autoplay"
+        onLoad={handleIframeLoad}
       />
     </div>
   )
 }
 
-// Helper function to get vendor channel URL
+// Helper function to get vendor channel URL (for use outside the component)
 export const getVendorChannelUrl = (vendorHandle: string) => {
-  if (!ROCKETCHAT_URL) return null
-  return `${ROCKETCHAT_URL}/channel/vendor-${vendorHandle}`
+  const rocketChatUrl = process.env.NEXT_PUBLIC_ROCKETCHAT_URL
+  if (!rocketChatUrl) return null
+  return `${rocketChatUrl}/channel/vendor-${vendorHandle}`
 }
 
-// Helper function to get order channel URL
+// Helper function to get order channel URL (for use outside the component)
 export const getOrderChannelUrl = (orderId: string) => {
-  if (!ROCKETCHAT_URL) return null
-  const cleanOrderId = orderId.replace('order_', '')
-  return `${ROCKETCHAT_URL}/channel/order-${cleanOrderId}`
+  const rocketChatUrl = process.env.NEXT_PUBLIC_ROCKETCHAT_URL
+  if (!rocketChatUrl) return null
+  const cleanOrderId = orderId.replace("order_", "")
+  return `${rocketChatUrl}/channel/order-${cleanOrderId}`
 }

--- a/storefront/src/lib/data/rocketchat.ts
+++ b/storefront/src/lib/data/rocketchat.ts
@@ -1,0 +1,39 @@
+"use server"
+
+import { medusaFetch } from "../config"
+import { getAuthHeaders } from "./cookies"
+
+interface RocketChatConfig {
+  configured: boolean
+  url?: string
+  iframe_url?: string
+  login?: {
+    token: string
+    username: string
+  }
+  message?: string
+}
+
+/**
+ * Fetch Rocket.Chat configuration for the authenticated customer
+ * Returns config with login token for auto-login
+ */
+export async function getRocketChatConfig(): Promise<RocketChatConfig | null> {
+  try {
+    const authHeaders = await getAuthHeaders()
+    if (!authHeaders) {
+      return null
+    }
+
+    const config = await medusaFetch<RocketChatConfig>("/store/rocketchat", {
+      method: "GET",
+      headers: authHeaders,
+      cache: "no-store", // Never cache auth-related data
+    })
+
+    return config
+  } catch (error) {
+    console.error("[getRocketChatConfig] Error:", error)
+    return null
+  }
+}

--- a/storefront/src/providers/RocketChatProvider.tsx
+++ b/storefront/src/providers/RocketChatProvider.tsx
@@ -1,17 +1,48 @@
 "use client"
 
-import { createContext, useContext, useState, useEffect, ReactNode } from "react"
+import { createContext, useContext, useState, useEffect, ReactNode, useCallback } from "react"
+import { getRocketChatConfig } from "@/lib/data/rocketchat"
+
+interface RocketChatConfig {
+  configured: boolean
+  url?: string
+  iframe_url?: string
+  login?: {
+    token: string
+    username: string
+  }
+}
 
 interface RocketChatContextType {
   isConfigured: boolean
+  isLoading: boolean
   rocketChatUrl: string | null
+  iframeUrl: string | null
+  loginToken: string | null
+  username: string | null
   unreadCount: number
+  // Helper functions for messaging
+  getChannelUrl: (channelName: string) => string | null
+  getDirectMessageUrl: (username: string) => string | null
+  getOrderChannelUrl: (orderId: string) => string | null
+  getVendorChannelUrl: (vendorHandle: string) => string | null
+  // Refresh config (e.g., after login)
+  refreshConfig: () => Promise<void>
 }
 
 const RocketChatContext = createContext<RocketChatContextType>({
   isConfigured: false,
+  isLoading: true,
   rocketChatUrl: null,
+  iframeUrl: null,
+  loginToken: null,
+  username: null,
   unreadCount: 0,
+  getChannelUrl: () => null,
+  getDirectMessageUrl: () => null,
+  getOrderChannelUrl: () => null,
+  getVendorChannelUrl: () => null,
+  refreshConfig: async () => {},
 })
 
 export const useRocketChat = () => {
@@ -24,25 +55,74 @@ export const useRocketChat = () => {
 
 interface RocketChatProviderProps {
   children: ReactNode
+  // Optional: pre-fetched config from server component
+  initialConfig?: RocketChatConfig | null
 }
 
-export const RocketChatProvider = ({ children }: RocketChatProviderProps) => {
+export const RocketChatProvider = ({ children, initialConfig }: RocketChatProviderProps) => {
+  const [isLoading, setIsLoading] = useState(!initialConfig)
+  const [isConfigured, setIsConfigured] = useState(initialConfig?.configured ?? false)
+  const [rocketChatUrl, setRocketChatUrl] = useState<string | null>(initialConfig?.url ?? null)
+  const [iframeUrl, setIframeUrl] = useState<string | null>(initialConfig?.iframe_url ?? null)
+  const [loginToken, setLoginToken] = useState<string | null>(initialConfig?.login?.token ?? null)
+  const [username, setUsername] = useState<string | null>(initialConfig?.login?.username ?? null)
   const [unreadCount, setUnreadCount] = useState(0)
 
-  // NEXT_PUBLIC_ env vars are available on both server and client
-  const rocketChatUrl = process.env.NEXT_PUBLIC_ROCKETCHAT_URL || null
-  const isConfigured = Boolean(rocketChatUrl)
+  // Function to fetch/refresh config
+  const fetchConfig = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      const config = await getRocketChatConfig()
+
+      if (config && config.configured && config.url) {
+        setIsConfigured(true)
+        setRocketChatUrl(config.url)
+        setIframeUrl(config.iframe_url || `${config.url}/home`)
+
+        if (config.login) {
+          setLoginToken(config.login.token)
+          setUsername(config.login.username)
+        }
+      } else {
+        // Fallback to env var if server fetch fails
+        const fallbackUrl = process.env.NEXT_PUBLIC_ROCKETCHAT_URL || null
+        setIsConfigured(Boolean(fallbackUrl))
+        setRocketChatUrl(fallbackUrl)
+        setIframeUrl(fallbackUrl ? `${fallbackUrl}/home` : null)
+      }
+    } catch (error) {
+      console.error("[RocketChatProvider] Failed to fetch config:", error)
+      // Fallback to env var
+      const fallbackUrl = process.env.NEXT_PUBLIC_ROCKETCHAT_URL || null
+      setIsConfigured(Boolean(fallbackUrl))
+      setRocketChatUrl(fallbackUrl)
+      setIframeUrl(fallbackUrl ? `${fallbackUrl}/home` : null)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Fetch config on mount if not provided
+  useEffect(() => {
+    if (!initialConfig) {
+      fetchConfig()
+    }
+  }, [initialConfig, fetchConfig])
 
   // Listen for messages from Rocket.Chat iframe for unread counts
   useEffect(() => {
     if (!rocketChatUrl) return
 
     const handleMessage = (event: MessageEvent) => {
-      // Verify the origin matches our Rocket.Chat URL
-      if (rocketChatUrl && event.origin === new URL(rocketChatUrl).origin) {
-        if (event.data?.type === "unread-count") {
-          setUnreadCount(event.data.count || 0)
+      try {
+        // Verify the origin matches our Rocket.Chat URL
+        if (rocketChatUrl && event.origin === new URL(rocketChatUrl).origin) {
+          if (event.data?.type === "unread-count") {
+            setUnreadCount(event.data.count || 0)
+          }
         }
+      } catch (error) {
+        // Ignore origin parsing errors
       }
     }
 
@@ -50,12 +130,46 @@ export const RocketChatProvider = ({ children }: RocketChatProviderProps) => {
     return () => window.removeEventListener("message", handleMessage)
   }, [rocketChatUrl])
 
+  // Helper function to get a specific channel URL
+  const getChannelUrl = useCallback((channelName: string) => {
+    if (!rocketChatUrl) return null
+    return `${rocketChatUrl}/channel/${channelName}`
+  }, [rocketChatUrl])
+
+  // Helper function to get direct message URL
+  const getDirectMessageUrl = useCallback((targetUsername: string) => {
+    if (!rocketChatUrl) return null
+    return `${rocketChatUrl}/direct/${targetUsername}`
+  }, [rocketChatUrl])
+
+  // Helper function to get order-specific channel URL
+  const getOrderChannelUrl = useCallback((orderId: string) => {
+    if (!rocketChatUrl) return null
+    const cleanOrderId = orderId.replace("order_", "")
+    return `${rocketChatUrl}/channel/order-${cleanOrderId}`
+  }, [rocketChatUrl])
+
+  // Helper function to get vendor channel URL
+  const getVendorChannelUrl = useCallback((vendorHandle: string) => {
+    if (!rocketChatUrl) return null
+    return `${rocketChatUrl}/channel/vendor-${vendorHandle}`
+  }, [rocketChatUrl])
+
   return (
     <RocketChatContext.Provider
       value={{
         isConfigured,
+        isLoading,
         rocketChatUrl,
+        iframeUrl,
+        loginToken,
+        username,
         unreadCount,
+        getChannelUrl,
+        getDirectMessageUrl,
+        getOrderChannelUrl,
+        getVendorChannelUrl,
+        refreshConfig: fetchConfig,
       }}
     >
       {children}


### PR DESCRIPTION
This implements auto-login to Rocket.Chat when customers log into their profile on the storefront, similar to the existing vendor panel feature.

Changes:
- Add GET /store/rocketchat endpoint for customer authentication tokens
- Update RocketChatProvider to fetch config from backend with login token
- Update UserMessagesSection to use postMessage API for auto-login
- Add customer.created subscriber for automatic RocketChat account creation
- Add helper functions for channel navigation (support, vendor, order channels)

The auto-login flow:
1. When a logged-in customer visits the messages page, the provider fetches their Rocket.Chat credentials from the backend
2. The backend creates/retrieves their RC account and generates an auth token
3. The iframe receives the token via postMessage and auto-logs the user in
4. Users see a "Connected" badge when successfully authenticated

https://claude.ai/code/session_01URp8ByRLoJxwGBiTdEE8VW