### PR TITLE
Ensure consistent Rocket.Chat auto-login for vendors and customers

### DIFF
--- a/backend/src/subscribers/seller-created-rocketchat.ts
+++ b/backend/src/subscribers/seller-created-rocketchat.ts
@@ -1,0 +1,81 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { SELLER_MODULE } from "@mercurjs/b2c-core/modules/seller"
+import { getRocketChatService } from "../shared/rocketchat-service"
+import crypto from "crypto"
+
+/**
+ * Subscriber: Seller Created - RocketChat Integration
+ *
+ * Automatically creates RocketChat accounts for sellers/vendors when they are created.
+ * This ensures vendors can access the messaging system immediately after approval.
+ */
+export default async function sellerCreatedRocketChatHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const sellerId = event.data.id
+
+  if (!sellerId) {
+    console.warn("[sellerCreated RocketChat] Event received without seller ID")
+    return
+  }
+
+  console.log(`[sellerCreated RocketChat] Processing seller ${sellerId}`)
+
+  try {
+    const rocketchatService = getRocketChatService()
+
+    // Skip if RocketChat is not configured
+    if (!rocketchatService) {
+      console.log("[sellerCreated RocketChat] RocketChat not configured, skipping")
+      return
+    }
+
+    // Get seller information from MercurJS
+    const sellerService = container.resolve(SELLER_MODULE)
+    const seller = await sellerService.retrieveSeller(sellerId, {
+      relations: ["members"],
+    })
+
+    if (!seller || !seller.members || seller.members.length === 0) {
+      console.warn(`[sellerCreated RocketChat] Seller ${sellerId} not found or has no members`)
+      return
+    }
+
+    // Get the primary member (first member)
+    const member = seller.members[0]
+
+    if (!member.email) {
+      console.warn(`[sellerCreated RocketChat] Seller member has no email`)
+      return
+    }
+
+    // Create RocketChat account
+    const username = seller.handle || member.email.split("@")[0]
+    const rocketchatPassword = crypto.randomBytes(32).toString("hex")
+
+    const { userId: rocketchatUserId, username: rocketchatUsername } = await rocketchatService.createUser(
+      seller.name || member.email,
+      member.email,
+      username,
+      rocketchatPassword
+    )
+
+    // Create vendor-specific channel
+    const channelName = `vendor-${seller.handle || sellerId}`
+    await rocketchatService.createSellerChannel(channelName, `${seller.name || "Vendor"} Channel`)
+
+    // Add vendor to their channel and general channel
+    await rocketchatService.addUserToChannel(channelName, rocketchatUsername)
+    await rocketchatService.addUserToChannel("general", rocketchatUsername)
+
+    console.log(`[sellerCreated RocketChat] Created RocketChat account and channel for vendor: ${rocketchatUsername}`)
+  } catch (error: any) {
+    console.error(`[sellerCreated RocketChat] Failed to create RocketChat account for seller ${sellerId}:`, error.message)
+    // Don't throw - this is a non-critical enhancement
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "sellerCreated",
+}

--- a/vendor-panel/src/routes/messages/messages.tsx
+++ b/vendor-panel/src/routes/messages/messages.tsx
@@ -101,7 +101,7 @@ export const Messages = () => {
 
   // Quick links to common channels
   const quickLinks = [
-    { label: "My Store", channelName: seller?.id ? `vendor-${seller.id}` : null },
+    { label: "My Store", channelName: seller?.handle ? `vendor-${seller.handle}` : (seller?.id ? `vendor-${seller.id}` : null) },
     { label: "Support", channelName: "support" },
     { label: "General", channelName: "general" },
   ].filter(link => link.channelName)
@@ -111,6 +111,11 @@ export const Messages = () => {
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-3">
           <Heading>Messages</Heading>
+          {isLoggedIn && (
+            <Badge color="green" size="small">
+              Connected
+            </Badge>
+          )}
           {unreadCount > 0 && (
             <Badge color="red" size="small">
               {unreadCount} unread


### PR DESCRIPTION
Changes:
- Update vendor rocketchat endpoint to create user if not exists (matches customer endpoint behavior)
- Add seller-created subscriber to auto-create RocketChat accounts and vendor channels when sellers are approved
- Add "Connected" badge to vendor messages page (matches customer storefront)
- Update vendor quick links to use seller handle for channel names

Both vendor portal and customer storefront now have identical auto-login behavior:
1. User visits messages page
2. Backend ensures RocketChat account exists (creates if needed)
3. Backend generates auth token
4. Frontend sends token via postMessage API
5. User is auto-logged in with "Connected" badge displayed

https://claude.ai/code/session_01URp8ByRLoJxwGBiTdEE8VW