### PR TITLE
Fix password reuse prevention for customers and vendors

### DIFF
--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -277,7 +277,7 @@ export const sendResetPasswordEmail = async (email: string) => {
     })
     return { success: true, error: null }
   } catch (err) {
-    return { success: false, error: err.toString() }
+    return { success: false, error: getErrorMessage(err) }
   }
 }
 
@@ -291,6 +291,6 @@ export const updateCustomerPassword = async (
     }, token)
     return { success: true, error: null }
   } catch (err) {
-    return { success: false, error: err.toString() }
+    return { success: false, error: getErrorMessage(err) }
   }
 }


### PR DESCRIPTION
- Fix middleware to correctly decode MedusaJS password reset tokens which contain entity_id (email) instead of auth_identity_id
- Look up auth_identity_id from provider_identity table using email
- Fix storefront error handling to properly extract error messages from SDK FetchError responses using getErrorMessage helper
- Users now see clear error messages when attempting to reuse passwords

https://claude.ai/code/session_01T9vUx8xMeZC1t83qSec5u4