### PR TITLE
Fix vendor portal avatar fallback asset casing

### DIFF
--- a/vendor-panel/src/components/layout/main-layout/main-layout.tsx
+++ b/vendor-panel/src/components/layout/main-layout/main-layout.tsx
@@ -92,7 +92,7 @@ const Header = () => {
       <div className="grid w-full grid-cols-[24px_1fr_15px] items-center gap-x-3">
         {fallback ? (
           <div className="w-7 h-7">
-            <ImageAvatar src={seller?.photo || "/logo.svg"} size={7} rounded />
+            <ImageAvatar src={seller?.photo || "/Logo.svg"} size={7} rounded />
           </div>
         ) : (
           <Skeleton className="h-6 w-6 rounded-md" />
@@ -230,5 +230,4 @@ const UserSection = () => {
     </div>
   )
 }
-
 

--- a/vendor-panel/src/components/layout/user-menu/user-menu.tsx
+++ b/vendor-panel/src/components/layout/user-menu/user-menu.tsx
@@ -101,7 +101,7 @@ const UserBadge = () => {
           )}
         >
           <div className="flex size-7 items-center justify-center">
-            <ImageAvatar src="/logo.svg" size={7} rounded />
+            <ImageAvatar src="/Logo.svg" size={7} rounded />
           </div>
           <div className="flex items-center overflow-hidden">
             <Text
@@ -132,7 +132,7 @@ const UserBadge = () => {
       >
         <div className="flex size-7 items-center justify-center">
           {fallback ? (
-            <ImageAvatar src={avatar || "/logo.svg"} size={7} rounded />
+            <ImageAvatar src={avatar || "/Logo.svg"} size={7} rounded />
           ) : (
             <Skeleton className="h-6 w-6 rounded-full" />
           )}
@@ -327,7 +327,7 @@ const UserItem = () => {
   return (
     <div className="flex items-center gap-x-3 overflow-hidden px-2 py-1">
       <div className="w-10">
-        <ImageAvatar src={avatar || "/logo.svg"} size={8} rounded />
+        <ImageAvatar src={avatar || "/Logo.svg"} size={8} rounded />
       </div>
       <div className="block w-full min-w-0 max-w-[187px] overflow-hidden whitespace-nowrap">
         <Text

--- a/vendor-panel/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
+++ b/vendor-panel/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
@@ -42,7 +42,7 @@ export const ProfileGeneralSection = ({ user }: ProfileGeneralSectionProps) => {
         <Text size="small" leading="compact" weight="plus">
           Photo
         </Text>
-        <ImageAvatar src={photo || "/logo.svg"} size={8} rounded />
+        <ImageAvatar src={photo || "/Logo.svg"} size={8} rounded />
       </div>
       <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
         <Text size="small" leading="compact" weight="plus">

--- a/vendor-panel/src/routes/store/store-detail/components/store-general-section/store-general-section.tsx
+++ b/vendor-panel/src/routes/store/store-detail/components/store-general-section/store-general-section.tsx
@@ -33,7 +33,7 @@ export const StoreGeneralSection = ({ seller }: { seller: StoreVendor }) => {
         <Text size="small" leading="compact" weight="plus">
           Image
         </Text>
-        <ImageAvatar src={seller.photo || "/logo.svg"} size={8} rounded />
+        <ImageAvatar src={seller.photo || "/Logo.svg"} size={8} rounded />
       </div>
       <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
         <Text size="small" leading="compact" weight="plus">


### PR DESCRIPTION
### Motivation
- The vendor portal showed broken-image markup (causing visual overlap with the username) when a user had no profile photo because the fallback referenced `"/logo.svg"` which does not match the actual `Logo.svg` asset casing in `public`.

### Description
- Updated avatar fallback references to use the correct `"/Logo.svg"` asset in `vendor-panel/src/components/layout/main-layout/main-layout.tsx`, `vendor-panel/src/components/layout/user-menu/user-menu.tsx`, `vendor-panel/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx`, and `vendor-panel/src/routes/store/store-detail/components/store-general-section/store-general-section.tsx`.
- Removed the stray local config file `.yarnrc.yml` from the repository state.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e3fecd8c832380492adf4fb71df5)