### PR TITLE
Avoid showing login prompts during authenticated profile navigation

### DIFF
--- a/storefront/src/app/[locale]/(main)/user/addresses/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/addresses/page.tsx
@@ -1,22 +1,25 @@
-import { UserNavigation } from "@/components/molecules"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { AccountLoadingState, UserNavigation } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { redirect } from "next/navigation"
 import { Addresses } from "@/components/organisms"
 import { listRegions } from "@/lib/data/regions"
 
 export default async function Page() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
   const regions = await listRegions()
 
-  if (!user) {
-    redirect("/user")
+  if (!customer) {
+    if (!isAuthenticated) {
+      redirect("/user")
+    }
+    return <AccountLoadingState title="Addresses" />
   }
 
   return (
     <main className="container">
       <div className="grid grid-cols-1 md:grid-cols-4 mt-6 gap-5 md:gap-8">
         <UserNavigation />
-        <Addresses {...{ user, regions }} />
+        <Addresses {...{ user: customer, regions }} />
       </div>
     </main>
   )

--- a/storefront/src/app/[locale]/(main)/user/messages/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/messages/page.tsx
@@ -1,12 +1,14 @@
-import { LoginForm } from "@/components/molecules/LoginForm/LoginForm"
-import { UserNavigation } from "@/components/molecules/UserNavigation/UserNavigation"
+import { AccountLoadingState, LoginForm, UserNavigation } from "@/components/molecules"
 import { UserMessagesSection } from "@/components/sections/UserMessagesSection/UserMessagesSection"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 
 export default async function MessagesPage() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return <LoginForm />
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Messages" />
+  }
 
   return (
     <main className="container">

--- a/storefront/src/app/[locale]/(main)/user/orders/[id]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/orders/[id]/page.tsx
@@ -1,5 +1,5 @@
-import { UserNavigation } from "@/components/molecules"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { AccountLoadingState, UserNavigation } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { Button } from "@/components/atoms"
 import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 import { ArrowLeftIcon } from "@/icons"
@@ -15,10 +15,14 @@ export default async function UserPage({
 }) {
   const { id } = await params
 
-  const user = await retrieveCustomer()
-  const orderSet = await retrieveOrderSet(id)
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return redirect("/user")
+  if (!customer) {
+    if (!isAuthenticated) return redirect("/user")
+    return <AccountLoadingState title="Orders" />
+  }
+
+  const orderSet = await retrieveOrderSet(id)
 
   return (
     <main className="container">

--- a/storefront/src/app/[locale]/(main)/user/orders/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/orders/page.tsx
@@ -1,6 +1,6 @@
-import { LoginForm, ParcelAccordion } from "@/components/molecules"
+import { AccountLoadingState, LoginForm, ParcelAccordion } from "@/components/molecules"
 import { UserNavigation } from "@/components/molecules"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { OrdersPagination } from "@/components/sections"
 import { isEmpty } from "lodash"
 import { listOrders } from "@/lib/data/orders"
@@ -12,9 +12,12 @@ export default async function UserPage({
 }: {
   searchParams: Promise<{ page: string }>
 }) {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return <LoginForm />
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Orders" />
+  }
 
   const orders = await listOrders()
 

--- a/storefront/src/app/[locale]/(main)/user/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/page.tsx
@@ -1,18 +1,20 @@
-import { LoginForm } from "@/components/molecules"
-import { UserNavigation } from "@/components/molecules"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { AccountLoadingState, LoginForm, UserNavigation } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 
 export default async function UserPage() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return <LoginForm />
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Account" />
+  }
 
   return (
     <main className="container">
       <div className="grid grid-cols-1 md:grid-cols-4 mt-6 gap-5 md:gap-8">
         <UserNavigation />
         <div className="md:col-span-3">
-          <h1 className="heading-xl uppercase">Welcome {user.first_name}</h1>
+          <h1 className="heading-xl uppercase">Welcome {customer.first_name}</h1>
           <p className="label-md">Your account is ready to go!</p>
         </div>
       </div>

--- a/storefront/src/app/[locale]/(main)/user/register/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/register/page.tsx
@@ -1,12 +1,16 @@
-import { RegisterForm } from "@/components/molecules"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { AccountLoadingState, RegisterForm } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { redirect } from "next/navigation"
 
 export default async function Page() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (user) {
+  if (customer) {
     redirect("/user")
+  }
+
+  if (isAuthenticated) {
+    return <AccountLoadingState title="Account" />
   }
 
   return <RegisterForm />

--- a/storefront/src/app/[locale]/(main)/user/returns/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/returns/page.tsx
@@ -1,7 +1,6 @@
-import { LoginForm } from "@/components/molecules"
-import { UserNavigation } from "@/components/molecules/UserNavigation/UserNavigation"
+import { AccountLoadingState, LoginForm, UserNavigation } from "@/components/molecules"
 import { OrderReturnRequests } from "@/components/sections/OrderReturnRequests/OrderReturnRequests"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { getReturns, retrieveReturnReasons } from "@/lib/data/orders"
 
 export default async function ReturnsPage({
@@ -10,9 +9,12 @@ export default async function ReturnsPage({
   searchParams: Promise<{ page: string; return: string }>
 }) {
   // Check authentication first
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return <LoginForm />
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Returns" />
+  }
 
   // Fetch returns data with error handling
   const returnsData = await getReturns()
@@ -36,7 +38,7 @@ export default async function ReturnsPage({
                 new Date(a.line_items[0].created_at).getTime()
               )
             })}
-            user={user}
+            user={customer}
             page={page}
             currentReturn={returnId || ""}
             returnReasons={returnReasons}

--- a/storefront/src/app/[locale]/(main)/user/reviews/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/reviews/page.tsx
@@ -1,12 +1,15 @@
-import { LoginForm, UserNavigation } from "@/components/molecules"
+import { AccountLoadingState, LoginForm, UserNavigation } from "@/components/molecules"
 import { ReviewsToWrite } from "@/components/organisms"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { listOrders } from "@/lib/data/orders"
 
 export default async function Page() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return <LoginForm />
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Reviews" />
+  }
 
   const orders = await listOrders()
 

--- a/storefront/src/app/[locale]/(main)/user/reviews/written/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/reviews/written/page.tsx
@@ -1,16 +1,18 @@
-import { LoginForm, UserNavigation } from "@/components/molecules"
+import { AccountLoadingState, LoginForm, UserNavigation } from "@/components/molecules"
 import { ReviewsWritten } from "@/components/organisms"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { listOrders } from "@/lib/data/orders"
 import { getReviews } from "@/lib/data/reviews"
 
 export default async function Page() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Reviews" />
+  }
 
   const reviewsRes = await getReviews()
   const orders = await listOrders()
-
-  if (!user) return <LoginForm />
 
   return (
     <main className="container">

--- a/storefront/src/app/[locale]/(main)/user/settings/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/settings/page.tsx
@@ -1,12 +1,14 @@
-import { LoginForm, ProfileDetails } from "@/components/molecules"
-import { UserNavigation } from "@/components/molecules"
+import { AccountLoadingState, LoginForm, ProfileDetails, UserNavigation } from "@/components/molecules"
 import { ProfilePassword } from "@/components/molecules/ProfileDetails/ProfilePassword"
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 
 export default async function ReviewsPage() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  if (!user) return <LoginForm />
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Settings" />
+  }
 
   return (
     <main className="container">
@@ -14,8 +16,8 @@ export default async function ReviewsPage() {
         <UserNavigation />
         <div className="md:col-span-3">
           <h1 className="heading-md uppercase mb-8">Settings</h1>
-          <ProfileDetails user={user} />
-          <ProfilePassword user={user} />
+          <ProfileDetails user={customer} />
+          <ProfilePassword user={customer} />
         </div>
       </div>
     </main>

--- a/storefront/src/app/[locale]/(main)/user/wishlist/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/wishlist/page.tsx
@@ -1,4 +1,4 @@
-import { retrieveCustomer } from "@/lib/data/customer"
+import { retrieveCustomerContext } from "@/lib/data/customer"
 import { redirect } from "next/navigation"
 import { isEmpty } from "lodash"
 import { Wishlist as WishlistType } from "@/types/wishlist"
@@ -7,22 +7,21 @@ import { Button } from "@/components/atoms"
 import { WishlistItem } from "@/components/cells"
 import { getUserWishlists } from "@/lib/data/wishlist"
 import { HttpTypes } from "@medusajs/types"
-import { UserNavigation } from "@/components/molecules"
+import { AccountLoadingState, UserNavigation } from "@/components/molecules"
 
 export default async function Wishlist() {
-  const user = await retrieveCustomer()
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
 
-  let wishlist: WishlistType[] = []
-  if (user) {
-    const response = await getUserWishlists()
-    wishlist = response.wishlists
+  if (!customer) {
+    if (!isAuthenticated) {
+      redirect("/user")
+    }
+    return <AccountLoadingState title="Wishlist" />
   }
 
+  const response = await getUserWishlists()
+  const wishlist: WishlistType[] = response.wishlists
   const count = wishlist?.[0]?.products?.length || 0
-
-  if (!user) {
-    redirect("/user")
-  }
 
   return (
     <main className="container">
@@ -58,7 +57,7 @@ export default async function Wishlist() {
                       }
                     }
                     wishlist={wishlist}
-                    user={user}
+                    user={customer}
                   />
                 ))}
               </div>

--- a/storefront/src/components/molecules/AccountLoadingState/AccountLoadingState.tsx
+++ b/storefront/src/components/molecules/AccountLoadingState/AccountLoadingState.tsx
@@ -1,0 +1,23 @@
+import { UserNavigation } from "@/components/molecules"
+
+type AccountLoadingStateProps = {
+  title?: string
+  description?: string
+}
+
+export const AccountLoadingState = ({
+  title = "Account",
+  description = "We’re refreshing your session. Please try again in a moment.",
+}: AccountLoadingStateProps) => {
+  return (
+    <main className="container">
+      <div className="grid grid-cols-1 md:grid-cols-4 mt-6 gap-5 md:gap-8">
+        <UserNavigation />
+        <div className="md:col-span-3 space-y-4">
+          <h1 className="heading-md uppercase">{title}</h1>
+          <p className="text-secondary">{description}</p>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/storefront/src/components/molecules/index.ts
+++ b/storefront/src/components/molecules/index.ts
@@ -29,6 +29,7 @@ import { CartDropdownItem } from "./CartDropdownItem/CartDropdownItem"
 import { LoginForm } from "./LoginForm/LoginForm"
 import { RegisterForm } from "./RegisterForm/RegisterForm"
 import { UserNavigation } from "./UserNavigation/UserNavigation"
+import { AccountLoadingState } from "./AccountLoadingState/AccountLoadingState"
 import { ParcelAccordion } from "./ParcelAccordion/ParcelAccordion"
 import { AddressForm } from "./AddressForm/AddressForm"
 import { ReviewForm } from "./ReviewForm/ReviewForm"
@@ -78,6 +79,7 @@ export {
   LoginForm,
   RegisterForm,
   UserNavigation,
+  AccountLoadingState,
   ParcelAccordion,
   AddressForm,
   ReviewForm,

--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -37,6 +37,31 @@ export const retrieveCustomer =
     }
   }
 
+export const retrieveCustomerContext = async (): Promise<{
+  customer: HttpTypes.StoreCustomer | null
+  isAuthenticated: boolean
+}> => {
+  const authHeaders = await getAuthHeaders()
+  if (!authHeaders) {
+    return { customer: null, isAuthenticated: false }
+  }
+
+  try {
+    const { customer } = await medusaFetch<{
+      customer: HttpTypes.StoreCustomer
+    }>(`/store/customers/me`, {
+      method: "GET",
+      headers: authHeaders,
+      cache: "no-store",
+    })
+
+    return { customer: customer ?? null, isAuthenticated: true }
+  } catch (error) {
+    console.warn("[retrieveCustomerContext] Failed to fetch customer:", error)
+    return { customer: null, isAuthenticated: true }
+  }
+}
+
 /* ---------------------------------------------
  * UPDATE CUSTOMER
  * -------------------------------------------- */


### PR DESCRIPTION
### Motivation

- Users with a valid session were intermittently being forced to the login page while navigating account tabs due to transient failures when fetching the customer record. 
- The change prevents showing login/register UI when an auth token exists and the customer fetch temporarily fails, improving UX during navigation.

### Description

- Added an auth-aware helper `retrieveCustomerContext` that returns `{ customer, isAuthenticated }` so callers can distinguish missing tokens from transient fetch errors (`storefront/src/lib/data/customer.ts`).
- Introduced a shared `AccountLoadingState` component to present a non-blocking loading message when a session exists but customer data is not yet available (`storefront/src/components/molecules/AccountLoadingState/AccountLoadingState.tsx`).
- Replaced direct `retrieveCustomer` checks in account routes with `retrieveCustomerContext` and updated routes to show `AccountLoadingState` instead of immediately redirecting or rendering the login form (user pages under `storefront/src/app/[locale]/(main)/user/*`).
- Exported the new component from the molecules barrel file (`storefront/src/components/molecules/index.ts`).

### Testing

- No automated unit or integration tests were executed as part of this change.
- A Playwright attempt to capture a screenshot of the running site failed with `net::ERR_EMPTY_RESPONSE` because no dev server was reachable, so no end-to-end validation could be performed automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e68375bc8323a15e7de9bcc4da37)