### PR TITLE
Disable transaction for community archetype enum migration

### DIFF
--- a/backend/src/modules/product-archetype/migrations/Migration20260202000AddCommunityArchetypeEnums.ts
+++ b/backend/src/modules/product-archetype/migrations/Migration20260202000AddCommunityArchetypeEnums.ts
@@ -9,6 +9,10 @@ import { Migration } from "@mikro-orm/migrations"
  * No drop-shipping: all fulfillment is community-internal.
  */
 export class Migration20260202000AddCommunityArchetypeEnums extends Migration {
+  isTransactional(): boolean {
+    return false
+  }
+
   async up(): Promise<void> {
     // Add new enum values to product_archetype_code_enum
     // These must be committed before they can be used in INSERT statements


### PR DESCRIPTION
### Motivation
- PostgreSQL enum values must be committed in a separate transaction before they can be used in INSERTs, and applying enum changes inside a transaction caused seeding to fail with "unsafe use of new value" errors.
- The migration that adds community archetype enum values should therefore not run transactionally so the new enum labels are visible to subsequent seeding migrations.

### Description
- Added an `isTransactional()` override returning `false` to `Migration20260202000AddCommunityArchetypeEnums` to prevent the enum-change migration from running inside a transaction.
- File modified: `backend/src/modules/product-archetype/migrations/Migration20260202000AddCommunityArchetypeEnums.ts`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e95529308323ad239a9eb3281b37)