### PR TITLE
Send acceptance emails to customers and vendors

### DIFF
--- a/backend/src/modules/resend/emails/customer-accepted.tsx
+++ b/backend/src/modules/resend/emails/customer-accepted.tsx
@@ -1,0 +1,121 @@
+import {
+  Text,
+  Container,
+  Heading,
+  Html,
+  Section,
+  Tailwind,
+  Head,
+  Preview,
+  Body,
+  Button,
+  Link,
+} from "@react-email/components"
+
+type CustomerAcceptedEmailProps = {
+  customer_name?: string
+  storefront_url?: string
+  login_url?: string
+}
+
+function CustomerAcceptedEmailComponent({
+  customer_name,
+  storefront_url,
+  login_url,
+}: CustomerAcceptedEmailProps) {
+  const callToActionUrl = storefront_url || login_url
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Your customer account has been approved</Preview>
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[24px] max-w-[520px]">
+            <Section className="mt-[8px]">
+              <Heading className="text-black text-[24px] font-semibold text-center p-0 my-[16px] mx-0">
+                You're approved to shop!
+              </Heading>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[14px] leading-[24px]">
+                Hi{customer_name ? ` ${customer_name}` : ""},
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">
+                Your account has been accepted and you can now access the marketplace.
+              </Text>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[14px] leading-[24px] font-semibold">
+                Here’s what you can do:
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Discover local vendors and unique products</Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Place orders and track deliveries</Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Save favorites and reorder quickly</Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Contact support with any questions</Text>
+            </Section>
+
+            {callToActionUrl ? (
+              <Section className="text-center mt-[24px] mb-[24px]">
+                <Button
+                  className="bg-[#000000] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+                  href={callToActionUrl}
+                >
+                  Start exploring
+                </Button>
+              </Section>
+            ) : null}
+
+            {storefront_url ? (
+              <Section className="my-[12px]">
+                <Text className="text-black text-[14px] leading-[24px]">
+                  Marketplace link:
+                </Text>
+                <Link
+                  href={storefront_url}
+                  className="text-blue-600 no-underline text-[14px] leading-[24px] break-all"
+                >
+                  {storefront_url}
+                </Link>
+              </Section>
+            ) : null}
+
+            {login_url ? (
+              <Section className="my-[12px]">
+                <Text className="text-black text-[14px] leading-[24px]">
+                  Log in anytime:
+                </Text>
+                <Link
+                  href={login_url}
+                  className="text-blue-600 no-underline text-[14px] leading-[24px] break-all"
+                >
+                  {login_url}
+                </Link>
+              </Section>
+            ) : null}
+
+            <Section className="mt-[24px]">
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                Need help? Reply to this email and our team will support you.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  )
+}
+
+export const customerAcceptedEmail = (props: CustomerAcceptedEmailProps) => (
+  <CustomerAcceptedEmailComponent {...props} />
+)
+
+const mockCustomer: CustomerAcceptedEmailProps = {
+  customer_name: "Sam",
+  storefront_url: "https://shop.example.com",
+  login_url: "https://shop.example.com/account",
+}
+
+export default () => <CustomerAcceptedEmailComponent {...mockCustomer} />

--- a/backend/src/modules/resend/emails/vendor-accepted.tsx
+++ b/backend/src/modules/resend/emails/vendor-accepted.tsx
@@ -1,0 +1,128 @@
+import {
+  Text,
+  Container,
+  Heading,
+  Html,
+  Section,
+  Tailwind,
+  Head,
+  Preview,
+  Body,
+  Button,
+  Link,
+} from "@react-email/components"
+
+type VendorAcceptedEmailProps = {
+  seller_name: string
+  member_name?: string
+  vendor_panel_url?: string
+  onboarding_url?: string
+  login_url?: string
+}
+
+function VendorAcceptedEmailComponent({
+  seller_name,
+  member_name,
+  vendor_panel_url,
+  onboarding_url,
+  login_url,
+}: VendorAcceptedEmailProps) {
+  const callToActionUrl = onboarding_url || vendor_panel_url
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Your vendor account has been approved</Preview>
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[24px] max-w-[520px]">
+            <Section className="mt-[8px]">
+              <Heading className="text-black text-[24px] font-semibold text-center p-0 my-[16px] mx-0">
+                You're approved to sell!
+              </Heading>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[14px] leading-[24px]">
+                Hi{member_name ? ` ${member_name}` : ""},
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">
+                Great news — {seller_name} has been accepted. You now have access to the vendor toolkit so you can
+                start listing products and fulfilling orders.
+              </Text>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[14px] leading-[24px] font-semibold">
+                What you can do next:
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Publish products and manage inventory</Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Accept, pack, and fulfill orders</Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Track payouts and performance insights</Text>
+              <Text className="text-black text-[14px] leading-[24px]">• Connect with customers through messages</Text>
+            </Section>
+
+            {callToActionUrl ? (
+              <Section className="text-center mt-[24px] mb-[24px]">
+                <Button
+                  className="bg-[#000000] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+                  href={callToActionUrl}
+                >
+                  Complete onboarding
+                </Button>
+              </Section>
+            ) : null}
+
+            {vendor_panel_url ? (
+              <Section className="my-[12px]">
+                <Text className="text-black text-[14px] leading-[24px]">
+                  Vendor portal:
+                </Text>
+                <Link
+                  href={vendor_panel_url}
+                  className="text-blue-600 no-underline text-[14px] leading-[24px] break-all"
+                >
+                  {vendor_panel_url}
+                </Link>
+              </Section>
+            ) : null}
+
+            {login_url ? (
+              <Section className="my-[12px]">
+                <Text className="text-black text-[14px] leading-[24px]">
+                  Already onboarded? Log in here:
+                </Text>
+                <Link
+                  href={login_url}
+                  className="text-blue-600 no-underline text-[14px] leading-[24px] break-all"
+                >
+                  {login_url}
+                </Link>
+              </Section>
+            ) : null}
+
+            <Section className="mt-[24px]">
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                If you have questions, reply to this email and our team will help you get started.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  )
+}
+
+export const vendorAcceptedEmail = (props: VendorAcceptedEmailProps) => (
+  <VendorAcceptedEmailComponent {...props} />
+)
+
+const mockVendor: VendorAcceptedEmailProps = {
+  seller_name: "Maple Grove Farms",
+  member_name: "Jordan",
+  vendor_panel_url: "https://vendor.example.com",
+  onboarding_url: "https://vendor.example.com/onboarding",
+  login_url: "https://vendor.example.com/login",
+}
+
+export default () => <VendorAcceptedEmailComponent {...mockVendor} />

--- a/backend/src/modules/resend/service.ts
+++ b/backend/src/modules/resend/service.ts
@@ -14,17 +14,23 @@ import {
 import { orderPlacedEmail } from "./emails/order-placed";
 import { userInvitedEmail } from "./emails/user-invited";
 import { passwordResetEmail } from "./emails/password-reset";
+import { vendorAcceptedEmail } from "./emails/vendor-accepted";
+import { customerAcceptedEmail } from "./emails/customer-accepted";
 
 enum Templates {
   ORDER_PLACED = "order-placed",
   USER_INVITED = "user-invited",
   PASSWORD_RESET = "password-reset",
+  VENDOR_ACCEPTED = "vendor-accepted",
+  CUSTOMER_ACCEPTED = "customer-accepted",
 }
 
 const templates: {[key in Templates]?: (props: unknown) => React.ReactNode} = {
   [Templates.ORDER_PLACED]: orderPlacedEmail,
   [Templates.USER_INVITED]: userInvitedEmail,
-  [Templates.PASSWORD_RESET]: passwordResetEmail
+  [Templates.PASSWORD_RESET]: passwordResetEmail,
+  [Templates.VENDOR_ACCEPTED]: vendorAcceptedEmail,
+  [Templates.CUSTOMER_ACCEPTED]: customerAcceptedEmail,
 }
 
 type ResendOptions = {
@@ -96,6 +102,10 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
         return "You're Invited!"
       case Templates.PASSWORD_RESET:
         return "Reset Your Password"
+      case Templates.VENDOR_ACCEPTED:
+        return "Your vendor account is approved"
+      case Templates.CUSTOMER_ACCEPTED:
+        return "Your account has been approved"
       default:
         return "New Email"
     }

--- a/backend/src/modules/smtp/service.ts
+++ b/backend/src/modules/smtp/service.ts
@@ -13,17 +13,23 @@ import { render } from "@react-email/components"
 import { orderPlacedEmail } from "../resend/emails/order-placed"
 import { userInvitedEmail } from "../resend/emails/user-invited"
 import { passwordResetEmail } from "../resend/emails/password-reset"
+import { vendorAcceptedEmail } from "../resend/emails/vendor-accepted"
+import { customerAcceptedEmail } from "../resend/emails/customer-accepted"
 
 enum Templates {
   ORDER_PLACED = "order-placed",
   USER_INVITED = "user-invited",
   PASSWORD_RESET = "password-reset",
+  VENDOR_ACCEPTED = "vendor-accepted",
+  CUSTOMER_ACCEPTED = "customer-accepted",
 }
 
 const templates: {[key in Templates]?: (props: unknown) => React.ReactNode} = {
   [Templates.ORDER_PLACED]: orderPlacedEmail,
   [Templates.USER_INVITED]: userInvitedEmail,
-  [Templates.PASSWORD_RESET]: passwordResetEmail
+  [Templates.PASSWORD_RESET]: passwordResetEmail,
+  [Templates.VENDOR_ACCEPTED]: vendorAcceptedEmail,
+  [Templates.CUSTOMER_ACCEPTED]: customerAcceptedEmail,
 }
 
 type SMTPOptions = {
@@ -141,6 +147,10 @@ class SMTPNotificationProviderService extends AbstractNotificationProviderServic
         return "You're Invited!"
       case Templates.PASSWORD_RESET:
         return "Reset Your Password"
+      case Templates.VENDOR_ACCEPTED:
+        return "Your vendor account is approved"
+      case Templates.CUSTOMER_ACCEPTED:
+        return "Your account has been approved"
       default:
         return "New Email"
     }

--- a/backend/src/workflows/send-customer-accepted-notification.ts
+++ b/backend/src/workflows/send-customer-accepted-notification.ts
@@ -1,0 +1,68 @@
+import {
+  createStep,
+  StepResponse,
+  createWorkflow,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import {
+  INotificationModuleService,
+} from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+
+export type SendCustomerAcceptedNotificationInput = {
+  customer_email: string
+  customer_name?: string
+  storefront_url?: string
+  login_url?: string
+}
+
+/**
+ * Step: Send Customer Accepted Notification
+ *
+ * Sends an email notification to a customer when their account is approved.
+ */
+export const sendCustomerAcceptedNotificationStep = createStep(
+  "send-customer-accepted-notification",
+  async (input: SendCustomerAcceptedNotificationInput, { container }) => {
+    const notificationModuleService: INotificationModuleService = container
+      .resolve(Modules.NOTIFICATION)
+
+    const storefrontUrl = input.storefront_url ||
+      process.env.STOREFRONT_URL ||
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      ""
+    const loginUrl = input.login_url ||
+      (storefrontUrl ? `${storefrontUrl}/account` : "")
+
+    const notification = await notificationModuleService.createNotifications({
+      to: input.customer_email,
+      template: "customer-accepted",
+      channel: "email",
+      data: {
+        customer_name: input.customer_name,
+        storefront_url: storefrontUrl || undefined,
+        login_url: loginUrl || undefined,
+      },
+    })
+
+    return new StepResponse(notification)
+  }
+)
+
+/**
+ * Workflow: Send Customer Accepted Notification
+ *
+ * Sends an email to a customer when their account has been accepted.
+ */
+export const sendCustomerAcceptedNotificationWorkflow = createWorkflow(
+  "send-customer-accepted-notification",
+  (input: SendCustomerAcceptedNotificationInput) => {
+    const notification = sendCustomerAcceptedNotificationStep(input)
+
+    return new WorkflowResponse({
+      notification,
+    })
+  }
+)
+
+export default sendCustomerAcceptedNotificationWorkflow

--- a/backend/src/workflows/send-vendor-accepted-notification.ts
+++ b/backend/src/workflows/send-vendor-accepted-notification.ts
@@ -15,6 +15,8 @@ export type SendVendorAcceptedNotificationInput = {
   member_email: string
   member_name: string
   vendor_panel_url?: string
+  onboarding_url?: string
+  login_url?: string
 }
 
 /**
@@ -31,6 +33,10 @@ export const sendVendorAcceptedNotificationStep = createStep(
     const vendorPanelUrl = input.vendor_panel_url ||
       process.env.VENDOR_PANEL_URL ||
       ""
+    const onboardingUrl = input.onboarding_url ||
+      (vendorPanelUrl ? `${vendorPanelUrl}/onboarding` : "")
+    const loginUrl = input.login_url ||
+      (vendorPanelUrl ? `${vendorPanelUrl}/login` : "")
 
     const notification = await notificationModuleService.createNotifications({
       to: input.member_email,
@@ -40,7 +46,8 @@ export const sendVendorAcceptedNotificationStep = createStep(
         seller_name: input.seller_name,
         member_name: input.member_name,
         vendor_panel_url: vendorPanelUrl,
-        login_url: vendorPanelUrl ? `${vendorPanelUrl}/login` : undefined,
+        onboarding_url: onboardingUrl || undefined,
+        login_url: loginUrl || undefined,
       }
     })
 


### PR DESCRIPTION
### Motivation
- Automatically notify users when requests are accepted so customers and vendors receive a short overview of available features and next steps. 
- Vendors should get vendor-specific messaging that points them to onboarding and the vendor portal while customers should get a different notification directing them to the storefront. 

### Description
- Add React Email templates `vendor-accepted.tsx` and `customer-accepted.tsx` under `backend/src/modules/resend/emails` to render vendor- and customer-specific acceptance emails. 
- Add a customer notification workflow `send-customer-accepted-notification.ts` and extend the existing `send-vendor-accepted-notification` workflow to include `onboarding_url` and `login_url` inputs. 
- Wire the new templates into the notification providers by adding `VENDOR_ACCEPTED` and `CUSTOMER_ACCEPTED` to the `Templates` enum and mapping templates/subjects in `backend/src/modules/resend/service.ts` and `backend/src/modules/smtp/service.ts`. 
- Send notifications from the approval flow by updating `SellerApprovalService` to call `sendVendorAcceptedNotificationWorkflow` after seller approvals and `sendCustomerAcceptedNotificationWorkflow` after generic request approvals, with a helper `resolveCustomerContact` to locate recipient email/name from `submitter_id` or request payload and by protecting notification sends with try/catch so they are non-blocking. 

### Testing
- No automated tests were executed for this change. 
- Changes were committed and include new files: `backend/src/modules/resend/emails/vendor-accepted.tsx`, `backend/src/modules/resend/emails/customer-accepted.tsx`, and `backend/src/workflows/send-customer-accepted-notification.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f05e3e5c832391d068b3dfd7eedf)