### PR TITLE
Increase product types list page size and fallback to returned list length

### DIFF
--- a/admin-panel/src/routes/product-types/product-type-list/components/product-type-list-table/product-type-list-table.tsx
+++ b/admin-panel/src/routes/product-types/product-type-list/components/product-type-list-table/product-type-list-table.tsx
@@ -14,7 +14,7 @@ import { useProductTypeTableQuery } from "../../../../../hooks/table/query/use-p
 import { useDataTable } from "../../../../../hooks/use-data-table"
 import { ProductTypeRowActions } from "./product-table-row-actions"
 
-const PAGE_SIZE = 20
+const PAGE_SIZE = 100
 
 export const ProductTypeListTable = () => {
   const { t } = useTranslation()
@@ -28,6 +28,7 @@ export const ProductTypeListTable = () => {
       placeholderData: keepPreviousData,
     }
   )
+  const totalCount = count ?? product_types?.length ?? 0
 
   const filters = useProductTypeTableFilters()
   const columns = useColumns()
@@ -35,7 +36,7 @@ export const ProductTypeListTable = () => {
   const { table } = useDataTable({
     columns,
     data: product_types,
-    count,
+    count: totalCount,
     getRowId: (row) => row.id,
     pageSize: PAGE_SIZE,
   })
@@ -63,7 +64,7 @@ export const ProductTypeListTable = () => {
         isLoading={isLoading}
         columns={columns}
         pageSize={PAGE_SIZE}
-        count={count}
+        count={totalCount}
         orderBy={[
           { key: "value", label: t("fields.value") },
           { key: "created_at", label: t("fields.createdAt") },


### PR DESCRIPTION
### Motivation
- The product types settings view did not surface all types by default and could show an incorrect total when the API response omitted the `count`; increase the visible page size and derive a fallback total from the returned list so the settings page reflects product types more reliably.

### Description
- Increase `PAGE_SIZE` from `20` to `100` and add `const totalCount = count ?? product_types?.length ?? 0`, then pass `totalCount` to `useDataTable` and the `_DataTable` component in `admin-panel/src/routes/product-types/product-type-list/components/product-type-list-table/product-type-list-table.tsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f36573e0832392784c35bd1a5215)