### PR TITLE
Fix crash in ProductRequestsRow when request.payload is undefined

### DIFF
--- a/admin-panel/src/routes/requests/request-product-list/request-product-list.tsx
+++ b/admin-panel/src/routes/requests/request-product-list/request-product-list.tsx
@@ -113,14 +113,14 @@ const ProductRequestsRow = ({
   handleDetail: (request: AdminRequest) => void;
 }) => {
   const navigate = useNavigate();
-  const requestData = request.payload as ProductDTO;
+  const requestData = request.payload as ProductDTO | undefined;
 
   return (
     <Table.Row key={request.id}>
-      <Table.Cell>{requestData.title}</Table.Cell>
+      <Table.Cell>{requestData?.title ?? "—"}</Table.Cell>
       <Table.Cell>{request.seller?.name}</Table.Cell>
       <Table.Cell>
-        {requestData.variants?.length || 0}
+        {requestData?.variants?.length || 0}
         {" variant(s)"}
       </Table.Cell>
       <Table.Cell>


### PR DESCRIPTION
Add null safety with optional chaining for request.payload access to prevent "Cannot read properties of undefined (reading 'title')" error when a product request has no payload data.

https://claude.ai/code/session_01LUmrFpxWgrPoHgagUdipGT