### PR TITLE
Fix missing leading slash in Admin Panel Requests navigation link

### DIFF
--- a/admin-panel/src/components/layout/main-layout/main-layout.tsx
+++ b/admin-panel/src/components/layout/main-layout/main-layout.tsx
@@ -267,7 +267,7 @@ const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
     {
       icon: <BottomToTop />,
       label: t("requests.domain"),
-      to: "requests/seller",
+      to: "/requests/seller",
       items: [
         {
           label: t("requests.seller"),


### PR DESCRIPTION
The Requests nav item was missing a leading slash in its path (requests/seller instead of /requests/seller), which could cause navigation issues in the admin panel sidebar.

https://claude.ai/code/session_01W3EoT9CeyfNSbdub9o2NaH