### PR TITLE
Add farm and shows feature flags and wire navigation entries (requests/orders, farm, shows)

### DIFF
--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -274,6 +274,10 @@ export function useVendorNavigation() {
       },
       items: [
         {
+          label: "Orders",
+          to: "/requests/orders",
+        },
+        {
           label: "Collections",
           to: "/requests/collections",
         },
@@ -284,6 +288,22 @@ export function useVendorNavigation() {
         {
           label: "Reviews",
           to: "/requests/reviews",
+        },
+      ],
+    },
+    {
+      icon: <Buildings />,
+      label: "Farm",
+      to: "/farm",
+      showFor: (f) => f.hasFarm,
+      items: [
+        {
+          label: "Profile",
+          to: "/farm/profile/edit",
+        },
+        {
+          label: "Harvests",
+          to: "/farm/harvests",
         },
       ],
     },
@@ -303,6 +323,12 @@ export function useVendorNavigation() {
       label: "Venues",
       to: "/venues",
       showFor: (_, type) => type === "restaurant",
+    },
+    {
+      icon: <CalendarMini />,
+      label: "Shows",
+      to: "/shows",
+      showFor: (f) => f.hasShows,
     },
   ]
 

--- a/vendor-panel/src/providers/vendor-type-provider/vendor-type-context.tsx
+++ b/vendor-panel/src/providers/vendor-type-provider/vendor-type-context.tsx
@@ -29,6 +29,8 @@ export interface VendorFeatures {
   hasHarvests: boolean
   hasPlots: boolean
   hasRequests: boolean
+  hasFarm: boolean
+  hasShows: boolean
 }
 
 /**
@@ -62,6 +64,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: true,
       hasPlots: false,
       hasRequests: false,
+      hasFarm: true,
+      hasShows: false,
     },
     garden: {
       hasProducts: true,  // Harvest shares, seedlings
@@ -76,6 +80,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: true,
       hasPlots: true,
       hasRequests: false,
+      hasFarm: true,
+      hasShows: false,
     },
     kitchen: {
       hasProducts: true,  // Prepared foods, catering items
@@ -90,6 +96,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: false,
       hasPlots: false,
       hasRequests: true,  // Kitchen time requests
+      hasFarm: false,
+      hasShows: false,
     },
     maker: {
       hasProducts: true,
@@ -104,6 +112,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: false,
       hasPlots: false,
       hasRequests: false,
+      hasFarm: false,
+      hasShows: false,
     },
     restaurant: {
       hasProducts: false,  // Uses menu items instead
@@ -118,6 +128,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: false,
       hasPlots: false,
       hasRequests: false,
+      hasFarm: false,
+      hasShows: true,
     },
     mutual_aid: {
       hasProducts: false,
@@ -132,6 +144,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: false,
       hasPlots: false,
       hasRequests: true,
+      hasFarm: false,
+      hasShows: false,
     },
     default: {
       hasProducts: true,
@@ -146,6 +160,8 @@ function getFeaturesByType(type: VendorType): VendorFeatures {
       hasHarvests: false,
       hasPlots: false,
       hasRequests: false,
+      hasFarm: false,
+      hasShows: false,
     },
   }
   


### PR DESCRIPTION
### Motivation
- Expose farm- and shows-related routes in the vendor navigation and gate their visibility by vendor type feature flags.
- Provide a Requests → Orders sublink so request-order flows are discoverable in the vendor nav.

### Description
- Added `hasFarm` and `hasShows` to the `VendorFeatures` interface and populated those flags per `VendorType` in `vendor-panel/src/providers/vendor-type-provider/vendor-type-context.tsx`.
- Wired a new `Farm` navigation item (with `Profile` and `Harvests` sublinks) into `vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx` and gated it with `hasFarm`.
- Added `Orders` under the existing `Requests` nav group at `/requests/orders` in `use-vendor-navigation.tsx`.
- Added a `Shows` extension route at `/shows` and gated it with `hasShows` in `use-vendor-navigation.tsx`.

### Testing
- No automated tests were run for this change (navigation/UI-only updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812f27f93083239e99d21b8ad8a5ce)