### PR TITLE
Compute farm dashboard available_products/pending_orders and improve date locale resolution

### DIFF
--- a/backend/src/api/vendor/farm/stats/route.ts
+++ b/backend/src/api/vendor/farm/stats/route.ts
@@ -55,27 +55,70 @@ export async function GET(
     // OPTIMIZATION: If we have harvests, get lot counts
     // Future: add parallel queries for available_products and pending_orders
     let lotsCount = 0
+    let availableProductsCount = 0
+    let pendingOrdersCount = 0
+    let lots: Array<{ id: string; quantity_reserved?: number }> = []
     if (harvestIds.length > 0) {
-      const { data: lots } = await query.graph({
+      const { data: fetchedLots } = await query.graph({
         entity: "lot",
-        fields: ["id"],
+        fields: ["id", "quantity_reserved"],
         filters: {
           harvest_id: { $in: harvestIds },
           is_active: true,
         },
       })
-      lotsCount = lots?.length || 0
+      lots = fetchedLots || []
+      lotsCount = lots.length
     }
 
-    // TODO: Get availability windows linked to products for "available_products"
-    // TODO: Get pending orders from order service
+    const lotIds = lots.map((lot) => lot.id)
+
+    if (lotIds.length > 0) {
+      const { data: availabilityWindows } = await query.graph({
+        entity: "availability_window",
+        fields: ["product_id", "available_from", "available_until", "is_active"],
+        filters: {
+          lot_id: { $in: lotIds },
+          is_active: true,
+        },
+      })
+
+      const now = new Date()
+      const availableProductIds = new Set<string>()
+
+      for (const window of availabilityWindows || []) {
+        if (!window?.product_id) {
+          continue
+        }
+
+        const availableFrom = window.available_from
+          ? new Date(window.available_from)
+          : null
+        const availableUntil = window.available_until
+          ? new Date(window.available_until)
+          : null
+        const isWithinWindow =
+          (!availableFrom || availableFrom <= now) &&
+          (!availableUntil || availableUntil >= now)
+
+        if (isWithinWindow) {
+          availableProductIds.add(window.product_id)
+        }
+      }
+
+      availableProductsCount = availableProductIds.size
+    }
+
+    pendingOrdersCount = lots.reduce((count, lot) => {
+      return (lot.quantity_reserved ?? 0) > 0 ? count + 1 : count
+    }, 0)
 
     res.json({
       stats: {
         active_harvests: harvests?.length || 0,
         total_lots: lotsCount,
-        available_products: 0, // TODO: implement
-        pending_orders: 0, // TODO: implement
+        available_products: availableProductsCount,
+        pending_orders: pendingOrdersCount,
       }
     })
   } catch (error: any) {

--- a/vendor-panel/src/hooks/use-date.tsx
+++ b/vendor-panel/src/hooks/use-date.tsx
@@ -4,13 +4,32 @@ import { useTranslation } from "react-i18next"
 
 import { languages } from "../i18n/languages"
 
-// TODO: We rely on the current language to determine the date locale. This is not ideal, as we use en-US for the english translation.
-// We either need to also have an en-GB translation or we need to separate the date locale from the translation language.
+const resolveLocale = (language?: string) => {
+  if (!language) {
+    return enUS
+  }
+
+  const normalized = language.toLowerCase()
+  const directMatch = languages.find(
+    (entry) => entry.code.toLowerCase() === normalized
+  )
+
+  if (directMatch) {
+    return directMatch.date_locale
+  }
+
+  const baseCode = normalized.split("-")[0]
+  const baseMatch = languages.find(
+    (entry) => entry.code.toLowerCase() === baseCode
+  )
+
+  return baseMatch?.date_locale || enUS
+}
+
 export const useDate = () => {
   const { i18n } = useTranslation()
 
-  const locale =
-    languages.find((l) => l.code === i18n.language)?.date_locale || enUS
+  const locale = resolveLocale(i18n.resolvedLanguage || i18n.language)
 
   const getFullDate = ({
     date,


### PR DESCRIPTION
### Motivation
- Provide real counts for farm dashboard metrics so vendor UI reflects linked products and pending orders instead of zeros.
- Make date formatting robust across language variants by resolving locale codes (e.g. `en-GB`, `en`) to the correct `date-fns` locale.

### Description
- Backend: enhanced `/vendor/farm/stats` handler to fetch lots with `quantity_reserved`, query `availability_window` records for those lots, and compute `available_products` by counting unique active product links that are currently within their availability window; compute `pending_orders` by counting lots with `quantity_reserved > 0` and return these values in the `stats` payload (file: `backend/src/api/vendor/farm/stats/route.ts`).
- Frontend: added `resolveLocale` helper and switched `useDate` to use `i18n.resolvedLanguage || i18n.language`, normalizing codes and falling back to base language codes before defaulting to `enUS` (file: `vendor-panel/src/hooks/use-date.tsx`).
- Minor: fetched `quantity_reserved` from `lot` and included date window checks (`available_from`/`available_until`) when counting available products.

### Testing
- No automated tests were run for these changes.
- Manual validation is expected by exercising the vendor farm dashboard (not performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698139eca33c832381b24f12730e30e3)