### PR TITLE
Improve vendor sign button visibility on mobile and all platforms

### DIFF
--- a/storefront/src/components/cells/MobileNavbar/MobileNavbar.tsx
+++ b/storefront/src/components/cells/MobileNavbar/MobileNavbar.tsx
@@ -67,6 +67,23 @@ export const MobileNavbar = ({
             </button>
           </div>
 
+          {/* Vendor CTA Banner */}
+          <a
+            href={process.env.NEXT_PUBLIC_VENDOR_URL || "https://vendor.mercurjs.com"}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={closeMenuHandler}
+            className="flex items-center justify-between mb-4 p-4 bg-green-700 hover:bg-green-600 text-white rounded-lg transition-colors"
+          >
+            <div className="flex flex-col">
+              <span className="font-bold text-base">Sell With Us</span>
+              <span className="text-green-200 text-xs">Start your vendor journey today</span>
+            </div>
+            <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+
           {/* Search Bar */}
           <form onSubmit={handleSearch} className='mb-4'>
             <div className='relative'>
@@ -124,7 +141,7 @@ export const MobileNavbar = ({
                 onClick={closeMenuHandler}
                 className="font-medium text-green-700 hover:text-green-800 flex items-center gap-2"
               >
-                <span className="text-lg">✨</span> Sell on FreeBlackMarket
+                <span className="text-lg">✨</span> Learn About Selling
               </LocalizedClientLink>
             </div>
           </div>

--- a/storefront/src/components/cells/SellNowButton/SellNowButton.tsx
+++ b/storefront/src/components/cells/SellNowButton/SellNowButton.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/atoms"
 import { ArrowRightIcon } from "@/icons"
 import Link from "next/link"
 
@@ -10,14 +9,14 @@ export const SellNowButton = () => {
       href={VENDOR_URL}
       target="_blank"
       rel="noopener noreferrer"
+      className="group inline-flex items-center gap-1.5 bg-green-700 hover:bg-green-600 active:bg-green-800 text-white font-bold text-xs lg:text-sm uppercase px-3 py-2 lg:px-4 lg:py-2 rounded-md transition-colors duration-200"
     >
-      <Button className="group uppercase !font-bold pl-12 gap-1 flex items-center">
-        Join Us
-        <ArrowRightIcon
-          color="white"
-          className="w-5 h-5 group-hover:opacity-100 opacity-0 transition-all duration-300"
-        />
-      </Button>
+      <span className="hidden sm:inline">Sell With Us</span>
+      <span className="sm:hidden">Sell</span>
+      <ArrowRightIcon
+        color="white"
+        className="w-4 h-4 lg:w-5 lg:h-5 group-hover:translate-x-0.5 transition-transform duration-200"
+      />
     </Link>
   )
 }

--- a/storefront/src/components/organisms/Header/Header.tsx
+++ b/storefront/src/components/organisms/Header/Header.tsx
@@ -43,15 +43,13 @@ export const Header = async () => {
   return (
     <header>
       <div className="flex py-2 lg:px-8 px-4">
-        <div className="flex items-center lg:w-1/3">
+        <div className="flex items-center gap-2 lg:w-1/3">
           <MobileNavbar
             parentCategories={parentCategories}
             childrenCategories={categories}
             cmsTypes={cmsTypes}
           />
-          <div className="hidden lg:block">
-            <SellNowButton />
-          </div>
+          <SellNowButton />
         </div>
         <div className="flex lg:justify-center lg:w-1/3 items-center pl-4 lg:pl-0">
           <LocalizedClientLink href="/" className="text-2xl font-bold">


### PR DESCRIPTION
- Make SellNowButton visible on all screen sizes (was hidden on mobile)
- Restyle button with green accent, responsive text ("Sell" on mobile, "Sell With Us" on larger screens), and always-visible arrow icon
- Add prominent "Sell With Us" CTA banner at top of mobile hamburger menu
- Rename buried quick link to "Learn About Selling" to differentiate from the primary CTA

https://claude.ai/code/session_01SDB6AbpWktuA9BMaitaZTX