### PR TITLE
Broaden vendor-facing language from selling to providing

### DIFF
--- a/storefront/src/app/[locale]/(main)/how-it-works/page.tsx
+++ b/storefront/src/app/[locale]/(main)/how-it-works/page.tsx
@@ -126,7 +126,7 @@ export default function HowItWorksPage() {
     {
       icon: ShieldCheckIcon,
       title: "Verified Creators",
-      description: "Every seller is verified. See exactly where your products come from and who made them.",
+      description: "Every provider is verified. See exactly where your products come from and who made them.",
       color: "bg-blue-100 text-blue-600",
     },
     {
@@ -211,7 +211,7 @@ export default function HowItWorksPage() {
               href="/sell"
               className="px-8 py-4 bg-green-700 text-white font-semibold rounded-lg border-2 border-green-500 hover:bg-green-600 transition-colors"
             >
-              Become a Seller
+              Become a Provider
             </Link>
           </div>
         </div>
@@ -319,10 +319,10 @@ export default function HowItWorksPage() {
           <div className="text-center mb-12">
             <div className="inline-flex items-center gap-2 px-4 py-2 bg-green-800 text-green-200 rounded-full text-sm font-medium mb-4">
               <UserGroupIcon className="w-5 h-5" />
-              For Sellers
+              For Providers
             </div>
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
-              Sell on Your Terms
+              Share on Your Terms
             </h2>
             <p className="text-xl text-gray-300 max-w-2xl mx-auto">
               Whether you're a farmer, artist, baker, or service provider—
@@ -363,7 +363,7 @@ export default function HowItWorksPage() {
               href={`${VENDOR_PANEL_URL}/register`}
               className="inline-flex items-center gap-2 px-6 py-3 bg-green-500 text-white font-semibold rounded-lg hover:bg-green-400 transition-colors"
             >
-              Start Selling Free
+              Get Started Free
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
@@ -441,7 +441,7 @@ export default function HowItWorksPage() {
               Special Programs
             </h2>
             <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-              Beyond buying and selling—ways to invest in and support your community.
+              Beyond transactions—ways to invest in and support your community.
             </p>
           </div>
 
@@ -642,7 +642,7 @@ export default function HowItWorksPage() {
 
             <div className="bg-white rounded-lg p-6 shadow-sm">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                How do sellers get paid?
+                How do providers get paid?
               </h3>
               <p className="text-gray-600">
                 Through Stripe Connect. When you make a sale, 97% goes directly to your bank account
@@ -657,7 +657,7 @@ export default function HowItWorksPage() {
               <p className="text-gray-600">
                 Everything. Platform hosting, development, payment processing, customer support,
                 and community programs. There are no hidden fees, no subscriptions, no listing fees,
-                and no payment processing fees passed to sellers.
+                and no payment processing fees passed to providers.
               </p>
             </div>
 
@@ -668,13 +668,13 @@ export default function HowItWorksPage() {
               <p className="text-gray-600">
                 We have buyer protection. If your order doesn't arrive or isn't as described,
                 we'll step in to make it right. Payments are held until delivery is confirmed,
-                protecting both buyers and honest sellers.
+                protecting both buyers and honest providers.
               </p>
             </div>
 
             <div className="bg-white rounded-lg p-6 shadow-sm">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                Can I sell food or homemade products?
+                Can I offer food or homemade products?
               </h3>
               <p className="text-gray-600">
                 Yes! Many states have cottage food laws that allow home-based food production.
@@ -693,7 +693,7 @@ export default function HowItWorksPage() {
             Ready to Join the Movement?
           </h2>
           <p className="text-xl text-green-100 mb-8 max-w-2xl mx-auto">
-            Whether you're buying or selling, you're part of building a fairer economy—
+            Whether you're shopping or providing, you're part of building a fairer economy—
             one where creators keep what they earn and communities thrive.
           </p>
 
@@ -708,7 +708,7 @@ export default function HowItWorksPage() {
               href="/sell"
               className="px-8 py-4 bg-green-700 text-white font-semibold rounded-lg border-2 border-green-500 hover:bg-green-600 transition-colors"
             >
-              Become a Seller
+              Become a Provider
             </Link>
           </div>
         </div>

--- a/storefront/src/app/[locale]/(main)/sell/page.tsx
+++ b/storefront/src/app/[locale]/(main)/sell/page.tsx
@@ -78,7 +78,7 @@ export default function SellPage() {
   const benefits = [
     {
       icon: CurrencyDollarIcon,
-      title: "Keep 97% of Every Sale",
+      title: "Keep 97% of Every Transaction",
       description: "Just a 3% coalition fee—that's it. No hidden fees, no monthly charges, no listing fees, no payment processing fees passed to you.",
     },
     {
@@ -99,7 +99,7 @@ export default function SellPage() {
     {
       icon: CalendarIcon,
       title: "Standing Orders & Subscriptions",
-      description: "Build predictable income with recurring orders. Know what you're selling before you even harvest.",
+      description: "Build predictable income with recurring orders. Plan ahead with committed customers before you even harvest.",
     },
     {
       icon: ChartBarIcon,

--- a/storefront/src/app/[locale]/(main)/vendor-types/page.tsx
+++ b/storefront/src/app/[locale]/(main)/vendor-types/page.tsx
@@ -165,7 +165,7 @@ export default function VendorTypesPage() {
 
   const vendorFeatures = [
     {
-      category: "Selling & Payments",
+      category: "Revenue & Payments",
       icon: "💰",
       items: [
         { name: "97% Revenue Share", description: "Keep 97% of every sale, just 3% coalition fee" },
@@ -511,7 +511,7 @@ export default function VendorTypesPage() {
               href={`${VENDOR_PANEL_URL}/register`}
               className="inline-flex items-center gap-2 px-8 py-4 bg-green-500 text-white font-semibold rounded-lg hover:bg-green-400 transition-colors"
             >
-              Start Selling Today
+              Get Started Today
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
@@ -603,7 +603,7 @@ export default function VendorTypesPage() {
             Ready to Get Started?
           </h2>
           <p className="text-xl text-green-100 mb-8 max-w-2xl mx-auto">
-            Whether you're looking to sell or shop, you're joining a movement to build
+            Whether you're here to provide or to shop, you're joining a movement to build
             a fairer, more transparent food economy.
           </p>
 

--- a/storefront/src/components/cells/MobileNavbar/MobileNavbar.tsx
+++ b/storefront/src/components/cells/MobileNavbar/MobileNavbar.tsx
@@ -76,8 +76,8 @@ export const MobileNavbar = ({
             className="flex items-center justify-between mb-4 p-4 bg-green-700 hover:bg-green-600 text-white rounded-lg transition-colors"
           >
             <div className="flex flex-col">
-              <span className="font-bold text-base">Sell With Us</span>
-              <span className="text-green-200 text-xs">Start your vendor journey today</span>
+              <span className="font-bold text-base">Join the Market</span>
+              <span className="text-green-200 text-xs">Become a community provider</span>
             </div>
             <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -141,7 +141,7 @@ export const MobileNavbar = ({
                 onClick={closeMenuHandler}
                 className="font-medium text-green-700 hover:text-green-800 flex items-center gap-2"
               >
-                <span className="text-lg">✨</span> Learn About Selling
+                <span className="text-lg">✨</span> Learn About Joining
               </LocalizedClientLink>
             </div>
           </div>

--- a/storefront/src/components/cells/SellNowButton/SellNowButton.tsx
+++ b/storefront/src/components/cells/SellNowButton/SellNowButton.tsx
@@ -11,8 +11,8 @@ export const SellNowButton = () => {
       rel="noopener noreferrer"
       className="group inline-flex items-center gap-1.5 bg-green-700 hover:bg-green-600 active:bg-green-800 text-white font-bold text-xs lg:text-sm uppercase px-3 py-2 lg:px-4 lg:py-2 rounded-md transition-colors duration-200"
     >
-      <span className="hidden sm:inline">Sell With Us</span>
-      <span className="sm:hidden">Sell</span>
+      <span className="hidden sm:inline">Join the Market</span>
+      <span className="sm:hidden">Join</span>
       <ArrowRightIcon
         color="white"
         className="w-4 h-4 lg:w-5 lg:h-5 group-hover:translate-x-0.5 transition-transform duration-200"

--- a/storefront/src/data/footerLinks.ts
+++ b/storefront/src/data/footerLinks.ts
@@ -9,7 +9,7 @@ const links = {
     { label: 'About Us', path: 'https://www.blackmarketcoa.com' },
     { label: 'How It Works', path: '/how-it-works' },
     { label: 'Vendor Types & Features', path: '/vendor-types' },
-    { label: 'Become a Seller', path: '/sell' },
+    { label: 'Become a Provider', path: '/sell' },
     { label: 'Community Gardens', path: '/gardens' },
     { label: 'Community Kitchens', path: '/kitchens' },
     { label: 'Invest', path: '/invest' },


### PR DESCRIPTION
Replace narrow "sell/selling/seller" terminology with inclusive language that reflects the full scope of community providers: producers, gardens, kitchens, makers, restaurants, and mutual aid.

- Header/mobile: "Sell With Us" → "Join the Market"
- Mobile nav: "Learn About Selling" → "Learn About Joining"
- Footer: "Become a Seller" → "Become a Provider"
- How It Works: "For Sellers" → "For Providers", "Sell on Your Terms" → "Share on Your Terms", "Start Selling Free" → "Get Started Free", seller → provider in FAQs
- Vendor Types: "Selling & Payments" → "Revenue & Payments", "Start Selling Today" → "Get Started Today"
- Sell page: "Keep 97% of Every Sale" → "Every Transaction"

https://claude.ai/code/session_01SDB6AbpWktuA9BMaitaZTX