### PR TITLE
Fix wishlist bugs: null safety and cache revalidation path

### DIFF
--- a/storefront/src/components/cells/WishlistButton/WishlistButton.tsx
+++ b/storefront/src/components/cells/WishlistButton/WishlistButton.tsx
@@ -46,11 +46,17 @@ export const WishlistButton = ({
   }
 
   const handleRemoveFromWishlist = async () => {
+    const wishlistId = wishlist?.[0]?.id
+    if (!wishlistId) {
+      console.error("Cannot remove from wishlist: wishlist ID not found")
+      return
+    }
+
     try {
       setIsWishlistAdding(true)
 
       await removeWishlistItem({
-        wishlist_id: wishlist?.[0].id!,
+        wishlist_id: wishlistId,
         product_id: productId,
       })
     } catch (error) {

--- a/storefront/src/lib/data/wishlist.ts
+++ b/storefront/src/lib/data/wishlist.ts
@@ -37,9 +37,11 @@ export const addWishlistItem = async ({
       reference,
       reference_id,
     },
-  }).then(() => {
-    revalidatePath("/wishlist")
   })
+
+  revalidatePath("/user/wishlist")
+
+  return response
 }
 
 export const removeWishlistItem = async ({
@@ -56,7 +58,9 @@ export const removeWishlistItem = async ({
   const response = await medusaFetch(`/store/wishlist/${wishlist_id}/product/${product_id}`, {
     headers,
     method: "DELETE",
-  }).then(() => {
-    revalidatePath("/wishlist")
   })
+
+  revalidatePath("/user/wishlist")
+
+  return response
 }


### PR DESCRIPTION
- Add null safety check in WishlistButton before removing from wishlist to prevent runtime crashes when wishlist ID is undefined
- Fix revalidatePath to use correct path "/user/wishlist" instead of "/wishlist" so cache is properly invalidated after add/remove
- Return response from addWishlistItem and removeWishlistItem functions

https://claude.ai/code/session_01LZT1Lj8yp7geL9qgzmbJHY