### PR TITLE
Fix buyer account loading state getting stuck

### DIFF
--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -56,9 +56,20 @@ export const retrieveCustomerContext = async (): Promise<{
     })
 
     return { customer: customer ?? null, isAuthenticated: true }
-  } catch (error) {
+  } catch (error: any) {
     console.warn("[retrieveCustomerContext] Failed to fetch customer:", error)
-    return { customer: null, isAuthenticated: true }
+
+    // Check if token is invalid/expired (401 Unauthorized)
+    const status = error?.status || error?.response?.status
+    if (status === 401) {
+      // Clear the invalid token so user can re-authenticate
+      await removeAuthToken()
+      return { customer: null, isAuthenticated: false }
+    }
+
+    // For other errors (network issues, etc.), still indicate not authenticated
+    // so user sees login form instead of being stuck on loading state
+    return { customer: null, isAuthenticated: false }
   }
 }
 


### PR DESCRIPTION
When retrieveCustomerContext failed to fetch customer data (e.g., due to invalid/expired token), it returned isAuthenticated: true, causing users to be stuck on "We're refreshing your session" indefinitely.

Now properly handles authentication errors:
- For 401 errors: clears invalid token and shows login form
- For other errors: shows login form instead of stuck loading state

https://claude.ai/code/session_01GDxwcbkH1DRPogP778UJod