### PR TITLE
Fix login redirect on transient fetch errors

### DIFF
--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -76,10 +76,15 @@ export const retrieveCustomerContext = async (): Promise<{
       } catch {
         // Cookie modification not allowed in Server Components - that's OK
       }
+      // Token was invalid, user should see login form
+      return { customer: null, isAuthenticated: false }
     }
 
-    // Return not authenticated so user sees login form instead of stuck loading state
-    return { customer: null, isAuthenticated: false }
+    // For transient errors (network issues, server overload, etc.),
+    // return isAuthenticated: true so user sees loading state instead of login form.
+    // This prevents logged-in users from being redirected to login during temporary failures.
+    console.log("[retrieveCustomerContext] Transient error, showing loading state")
+    return { customer: null, isAuthenticated: true }
   }
 }
 


### PR DESCRIPTION
Previously, retrieveCustomerContext returned isAuthenticated: false for
all errors, which caused logged-in users to see the login form during
temporary network failures or server issues.

Now, only 401 errors (invalid/expired tokens) show the login form.
For other transient errors, isAuthenticated: true is returned so users
see the AccountLoadingState component instead of being unexpectedly
redirected to login.

Fixes #97

https://claude.ai/code/session_01MVCB31KqDizdGq4mQorcaw