### PR TITLE
Fix password reuse check by properly parsing provider_metadata JSON

### DIFF
--- a/backend/src/api/middlewares/password-history.ts
+++ b/backend/src/api/middlewares/password-history.ts
@@ -113,7 +113,23 @@ export async function preventPasswordReuseMiddleware(
     }
 
     const authIdentityId = providerData.auth_identity_id
-    const currentPasswordHash = providerData.provider_metadata?.password
+
+    // Parse provider_metadata - raw SQL returns it as a JSON string
+    let providerMetadata: Record<string, unknown> = {}
+    if (providerData.provider_metadata) {
+      if (typeof providerData.provider_metadata === "string") {
+        try {
+          providerMetadata = JSON.parse(providerData.provider_metadata)
+        } catch (e) {
+          console.warn("[password-history] Failed to parse provider_metadata:", e)
+        }
+      } else {
+        // Already an object (e.g., if using a different query method)
+        providerMetadata = providerData.provider_metadata as Record<string, unknown>
+      }
+    }
+
+    const currentPasswordHash = providerMetadata.password as string | undefined
 
     // Get password history for this auth identity
     let passwordHistoryService: PasswordHistoryService | null = null


### PR DESCRIPTION
The preventPasswordReuseMiddleware was failing to detect password reuse
because raw SQL queries return provider_metadata as a JSON string, not
a parsed object. Accessing .password on the string returned undefined,
causing the current password hash check to be bypassed.

This fix properly parses the JSON string before extracting the password
hash, enabling the middleware to correctly detect and prevent password
reuse in both Vendor and User portals.

Fixes #277

https://claude.ai/code/session_01Tm374WGQ4KZku65RhCzGwU