### PR TITLE
Add explicit background to product type modal body

### DIFF
--- a/vendor-panel/src/routes/product-types/product-type-create/components/create-product-type-form/create-product-type-form.tsx
+++ b/vendor-panel/src/routes/product-types/product-type-create/components/create-product-type-form/create-product-type-form.tsx
@@ -50,7 +50,7 @@ export const CreateProductTypeForm = () => {
         onSubmit={handleSubmit}
       >
         <RouteFocusModal.Header />
-        <RouteFocusModal.Body className="flex flex-1 justify-center overflow-auto px-6 py-16">
+        <RouteFocusModal.Body className="flex flex-1 justify-center overflow-auto bg-ui-bg-base px-6 py-16">
           <div className="flex w-full max-w-[720px] flex-col gap-y-8">
             <div className="flex flex-col gap-y-1">
               <RouteFocusModal.Title asChild>


### PR DESCRIPTION
Added bg-ui-bg-base class to ensure the modal body has an opaque background that prevents the underlying table content from showing through.

https://claude.ai/code/session_01Wa2KkQwmcdD9NRQgDupNDN