### PR TITLE
Add z-50 to RouteFocusModal content for proper stacking

### DIFF
--- a/vendor-panel/src/components/modals/route-focus-modal/route-focus-modal.tsx
+++ b/vendor-panel/src/components/modals/route-focus-modal/route-focus-modal.tsx
@@ -67,7 +67,7 @@ const Content = ({ stackedModalOpen, children }: ContentProps) => {
             }
           : undefined
       }
-      className={clx({
+      className={clx("z-50", {
         "!bg-ui-bg-disabled !inset-x-5 !inset-y-3": stackedModalOpen,
       })}
     >


### PR DESCRIPTION
The sticky table header has z-10, which can appear above the modal content in certain stacking contexts. Adding z-50 ensures the modal content always appears above other elements.

https://claude.ai/code/session_01Wa2KkQwmcdD9NRQgDupNDN