### PR TITLE
Fix category card links and add redirects for legacy sales-channel handles

### DIFF
--- a/storefront/src/app/[locale]/(main)/categories/[category]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/categories/[category]/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from "react"
 import type { Metadata } from "next"
 import { Breadcrumbs } from "@/components/atoms"
 import { AlgoliaProductsListing, ProductListing } from "@/components/sections"
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import isBot from "@/lib/helpers/isBot"
 import { headers } from "next/headers"
 import Script from "next/script"
@@ -14,6 +14,19 @@ import { listProducts } from "@/lib/data/products"
 import { toHreflang } from "@/lib/helpers/hreflang"
 
 export const revalidate = 60
+
+const LEGACY_SALES_CHANNEL_HANDLES = new Set([
+  "direct-marketplace",
+  "pre-order-drops",
+  "subscriptions",
+  "wholesale",
+  "digital-downloads",
+  "services",
+  "local-pickup",
+  "custom-orders",
+  "partnerships",
+  "community-drops",
+])
 
 export async function generateMetadata({
   params,
@@ -92,6 +105,9 @@ async function Category({
   const category = await getCategoryByHandle([handle])
 
   if (!category) {
+    if (LEGACY_SALES_CHANNEL_HANDLES.has(handle)) {
+      return redirect(`/${locale}/categories`)
+    }
     return notFound()
   }
   const currency_code = (await getRegion(locale))?.currency_code || "usd"

--- a/storefront/src/app/[locale]/(main)/categories/page.tsx
+++ b/storefront/src/app/[locale]/(main)/categories/page.tsx
@@ -3,8 +3,8 @@ import { Suspense } from "react"
 
 import { Breadcrumbs } from "@/components/atoms"
 import { AlgoliaProductsListing, ProductListing } from "@/components/sections"
-import { categories as featuredCategories } from "@/components/sections/HomeCategories/HomeCategories"
 import { CategoryCard } from "@/components/organisms"
+import { listFeaturedCategories } from "@/lib/data/categories"
 import { getRegion } from "@/lib/data/regions"
 import isBot from "@/lib/helpers/isBot"
 import { headers } from "next/headers"
@@ -79,6 +79,7 @@ async function AllCategories({
 
   const ua = (await headers()).get("user-agent") || ""
   const bot = isBot(ua)
+  const featuredCategories = await listFeaturedCategories()
 
   const breadcrumbsItems = [
     {
@@ -150,9 +151,15 @@ async function AllCategories({
           Discover products from Black-owned businesses across different categories
         </p>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 gap-4 justify-items-center">
-          {featuredCategories.map((category) => (
-            <CategoryCard key={category.id} category={category} />
-          ))}
+          {featuredCategories.length > 0 ? (
+            featuredCategories.map((category) => (
+              <CategoryCard key={category.handle} category={category} />
+            ))
+          ) : (
+            <p className="text-sm text-secondary col-span-full text-center">
+              Categories are loading. Check back soon for more to explore.
+            </p>
+          )}
         </div>
       </section>
 

--- a/storefront/src/components/organisms/CartItems/EmptyCart.tsx
+++ b/storefront/src/components/organisms/CartItems/EmptyCart.tsx
@@ -2,9 +2,11 @@ import { Button } from "@/components/atoms"
 import { Carousel } from "@/components/cells"
 import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 import { CategoryCard } from "../CategoryCard/CategoryCard"
-import { categories as featuredCategories } from "@/components/sections/HomeCategories/HomeCategories"
+import { listFeaturedCategories } from "@/lib/data/categories"
 
 export const EmptyCart = async () => {
+  const featuredCategories = await listFeaturedCategories()
+
   return (
     <div>
       <div className="py-4 h-full w-full md:w-[426px] md:mx-auto flex flex-col items-center justify-center mb-16">
@@ -26,11 +28,17 @@ export const EmptyCart = async () => {
       </div>
       <div className="mb-8">
         <h3 className="heading-sm text-center mb-6 uppercase">Browse Categories</h3>
-        <Carousel
-          items={featuredCategories.map((category) => (
-            <CategoryCard key={category.id} category={category} />
-          ))}
-        />
+        {featuredCategories.length > 0 ? (
+          <Carousel
+            items={featuredCategories.map((category) => (
+              <CategoryCard key={category.handle} category={category} />
+            ))}
+          />
+        ) : (
+          <p className="text-sm text-secondary text-center">
+            Categories are loading. Check back soon for more to explore.
+          </p>
+        )}
       </div>
     </div>
   )

--- a/storefront/src/components/sections/HomeCategories/HomeCategories.tsx
+++ b/storefront/src/components/sections/HomeCategories/HomeCategories.tsx
@@ -1,78 +1,22 @@
 import { Carousel } from "@/components/cells"
 import { CategoryCard } from "@/components/organisms"
-
-export const categories: { id: number; name: string; handle: string; description?: string }[] = [
-  {
-    id: 1,
-    name: "Direct Marketplace",
-    handle: "direct-marketplace",
-    description: "Shop creator storefronts at retail pricing",
-  },
-  {
-    id: 2,
-    name: "Pre-Order Drops",
-    handle: "pre-order-drops",
-    description: "Secure limited-run releases early",
-  },
-  {
-    id: 3,
-    name: "Subscriptions",
-    handle: "subscriptions",
-    description: "Recurring boxes and creator memberships",
-  },
-  {
-    id: 4,
-    name: "Wholesale",
-    handle: "wholesale",
-    description: "Bulk pricing for retailers and teams",
-  },
-  {
-    id: 5,
-    name: "Digital Downloads",
-    handle: "digital-downloads",
-    description: "Instant access to files, courses, and tools",
-  },
-  {
-    id: 6,
-    name: "Services",
-    handle: "services",
-    description: "Book consulting, coaching, and creative help",
-  },
-  {
-    id: 7,
-    name: "Local Pickup",
-    handle: "local-pickup",
-    description: "Nearby pickup and community delivery",
-  },
-  {
-    id: 8,
-    name: "Custom Orders",
-    handle: "custom-orders",
-    description: "Made-to-order pieces and bespoke requests",
-  },
-  {
-    id: 9,
-    name: "Partnerships",
-    handle: "partnerships",
-    description: "Collaborations with brands and collectives",
-  },
-  {
-    id: 10,
-    name: "Community Drops",
-    handle: "community-drops",
-    description: "Group sales and limited community offers",
-  },
-]
+import { listFeaturedCategories } from "@/lib/data/categories"
 
 export const HomeCategories = async ({ heading }: { heading: string }) => {
+  const featuredCategories = await listFeaturedCategories()
+
+  if (featuredCategories.length === 0) {
+    return null
+  }
+
   return (
     <section className="bg-primary py-8 w-full">
       <div className="mb-6">
         <h2 className="heading-lg text-primary uppercase">{heading}</h2>
       </div>
       <Carousel
-        items={categories?.map((category) => (
-          <CategoryCard key={category.id} category={category} />
+        items={featuredCategories.map((category) => (
+          <CategoryCard key={category.handle} category={category} />
         ))}
       />
     </section>

--- a/storefront/src/components/sections/ShopByStyle/ShopByStyleSection.tsx
+++ b/storefront/src/components/sections/ShopByStyle/ShopByStyleSection.tsx
@@ -1,37 +1,21 @@
 import Image from "next/image"
 import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 import { ArrowRightIcon } from "@/icons"
+import { listFeaturedCategories } from "@/lib/data/categories"
 import { Style } from "@type/categories"
 
-export const styles: Style[] = [
-  {
-    id: 1,
-    name: "FOOD & BEVERAGE",
-    href: "/categories/food-beverage",
-  },
-  {
-    id: 2,
-    name: "ELECTRONICS",
-    href: "/categories/electronics",
-  },
-  {
-    id: 3,
-    name: "DIGITAL PRODUCTS",
-    href: "/categories/digital-products",
-  },
-  {
-    id: 4,
-    name: "SERVICES",
-    href: "/categories/services",
-  },
-  {
-    id: 5,
-    name: "BULK & WHOLESALE",
-    href: "/categories/bulk",
-  },
-]
+export async function ShopByStyleSection() {
+  const featuredCategories = await listFeaturedCategories(5)
+  const styles: Style[] = featuredCategories.map((category, index) => ({
+    id: index + 1,
+    name: category.name.toUpperCase(),
+    href: `/categories/${category.handle}`,
+  }))
 
-export function ShopByStyleSection() {
+  if (styles.length === 0) {
+    return null
+  }
+
   return (
     <section className="bg-primary container">
       <h2 className="heading-lg text-primary mb-12">SHOP BY TYPE</h2>

--- a/storefront/src/lib/data/categories.ts
+++ b/storefront/src/lib/data/categories.ts
@@ -104,3 +104,13 @@ export const getCollectionByHandle = async (handle: string) => {
     })
     .then(({ collections }) => collections?.[0] || null)
 }
+
+export const listFeaturedCategories = async (limit = 10) => {
+  try {
+    const { categories } = await listCategories({ query: { limit } })
+    return categories
+  } catch (error) {
+    console.error("Failed to fetch featured categories:", error)
+    return []
+  }
+}


### PR DESCRIPTION
### Motivation
- Hardcoded category handles (e.g. `community-drops`) caused 404s when the CMS/product categories changed, producing broken links across the site. 
- Use API-driven category data everywhere so UI cards and navigation stay in sync with the backend and avoid stale handles. 
- Provide a safe fallback for legacy sales-channel URLs so old links redirect to the category index instead of returning 404.

### Description
- Added `listFeaturedCategories` helper in `storefront/src/lib/data/categories.ts` that wraps `listCategories` with error handling. 
- Replaced hardcoded featured category arrays with API-backed calls in `HomeCategories` (`storefront/src/components/sections/HomeCategories/HomeCategories.tsx`), the categories listing page (`storefront/src/app/[locale]/(main)/categories/page.tsx`), the empty-cart carousel (`storefront/src/components/organisms/CartItems/EmptyCart.tsx`), and `ShopByStyleSection` to generate links from live `category.handle`. 
- Updated `storefront/src/app/[locale]/(main)/categories/[category]/page.tsx` to return a redirect to `/:locale/categories` for known legacy sales-channel handles (set `LEGACY_SALES_CHANNEL_HANDLES`) instead of showing a 404. 
- Normalized component keys to use `category.handle` where appropriate and added guard UI when featured categories are empty.

### Testing
- Ran a Playwright smoke script that attempted to load `http://localhost:3000`, which failed with `net::ERR_EMPTY_RESPONSE` because the local dev server was not running. 
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982a5d0a7348323a415374cd32c8a75)