### PR TITLE
Add solar-punk theme to collections, categories and category cards

### DIFF
--- a/storefront/src/app/[locale]/(main)/categories/page.tsx
+++ b/storefront/src/app/[locale]/(main)/categories/page.tsx
@@ -146,8 +146,14 @@ async function AllCategories({
 
       {/* Category Grid Section */}
       <section className="mb-12">
-        <h1 className="heading-xl uppercase mb-2">Shop by Category</h1>
-        <p className="text-secondary mb-6">
+        <div className="inline-flex items-center gap-3 rounded-full border border-emerald-200/80 bg-emerald-50/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-900 mb-4">
+          <span className="text-lg">🌾</span>
+          Solar Punk Market
+        </div>
+        <h1 className="heading-xl uppercase mb-2 text-emerald-950">
+          Shop by Category
+        </h1>
+        <p className="text-emerald-900/80 mb-6">
           Discover products from Black-owned businesses across different categories
         </p>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 gap-4 justify-items-center">

--- a/storefront/src/components/organisms/CategoryCard/CategoryCard.tsx
+++ b/storefront/src/components/organisms/CategoryCard/CategoryCard.tsx
@@ -2,7 +2,7 @@ import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedL
 
 // Category emoji mapping for visual appeal
 const categoryEmojis: Record<string, string> = {
-  "direct-marketplace": "🌞",
+  "direct-marketplace": "☀️",
   "pre-order-drops": "🌱",
   "subscriptions": "🍃",
   "wholesale": "🌾",
@@ -20,20 +20,21 @@ export function CategoryCard({
   category: { name: string; handle: string; description?: string }
 }) {
   const emoji = categoryEmojis[category.handle] || "🛍️"
-  
+
   return (
     <LocalizedClientLink
       href={`/categories/${category.handle}`}
-      className="relative flex flex-col items-center justify-center border border-border rounded-xl bg-component transition-all hover:shadow-lg hover:scale-105 hover:border-primary w-[200px] min-h-[200px] p-4 group text-center"
+      className="relative flex flex-col items-center justify-center border border-emerald-200/80 rounded-2xl bg-gradient-to-br from-emerald-50 via-lime-50 to-amber-50 transition-all hover:shadow-xl hover:-translate-y-1 hover:border-emerald-400 w-[200px] min-h-[200px] p-4 group text-center"
     >
-      <div className="flex items-center justify-center w-14 h-14 mb-3 text-3xl bg-primary/10 rounded-full group-hover:bg-primary/20 transition-colors">
-        {emoji}
+      <div className="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.7),transparent_65%)]" />
+      <div className="relative flex items-center justify-center w-16 h-16 mb-3 text-3xl rounded-full bg-white/70 border border-emerald-200 shadow-sm group-hover:bg-white">
+        <span aria-hidden="true">{emoji}</span>
       </div>
-      <h3 className="w-full font-semibold text-primary text-sm leading-tight">
+      <h3 className="relative w-full font-semibold text-emerald-950 text-sm leading-tight">
         {category.name}
       </h3>
       {category.description && (
-        <p className="w-full text-xs text-secondary mt-1 leading-snug line-clamp-2">
+        <p className="relative w-full text-xs text-emerald-900/80 mt-1 leading-snug line-clamp-2">
           {category.description}
         </p>
       )}

--- a/storefront/src/components/sections/CollectionsPage/CollectionsPage.tsx
+++ b/storefront/src/components/sections/CollectionsPage/CollectionsPage.tsx
@@ -14,16 +14,16 @@ interface CollectionsPageProps {
   collections: Collection[]
 }
 
-// Color palette for collection cards
-const CARD_COLORS = [
-  { bg: "from-green-400 to-emerald-500", text: "text-white" },
-  { bg: "from-teal-400 to-cyan-500", text: "text-white" },
-  { bg: "from-blue-400 to-indigo-500", text: "text-white" },
-  { bg: "from-purple-400 to-violet-500", text: "text-white" },
-  { bg: "from-orange-400 to-red-500", text: "text-white" },
-  { bg: "from-amber-400 to-orange-500", text: "text-white" },
-  { bg: "from-rose-400 to-pink-500", text: "text-white" },
-  { bg: "from-cyan-400 to-blue-500", text: "text-white" },
+// Solar punk palette for collection cards
+const CARD_STYLES = [
+  { bg: "from-emerald-500 via-green-500 to-lime-400", text: "text-white", icon: "🌞" },
+  { bg: "from-teal-500 via-cyan-500 to-sky-400", text: "text-white", icon: "🌿" },
+  { bg: "from-amber-500 via-orange-400 to-yellow-300", text: "text-white", icon: "🌻" },
+  { bg: "from-lime-500 via-emerald-500 to-teal-400", text: "text-white", icon: "🍃" },
+  { bg: "from-rose-500 via-pink-500 to-fuchsia-400", text: "text-white", icon: "🦋" },
+  { bg: "from-cyan-500 via-sky-500 to-indigo-400", text: "text-white", icon: "💧" },
+  { bg: "from-amber-400 via-lime-400 to-emerald-300", text: "text-white", icon: "⚡" },
+  { bg: "from-green-600 via-emerald-500 to-teal-400", text: "text-white", icon: "🌱" },
 ]
 
 export function CollectionsPage({ collections }: CollectionsPageProps) {
@@ -38,8 +38,8 @@ export function CollectionsPage({ collections }: CollectionsPageProps) {
             Browse curated collections of products from our marketplace vendors.
           </p>
         </div>
-        <div className="text-center py-16 bg-gray-50 rounded-lg">
-          <p className="text-gray-600">
+        <div className="text-center py-16 bg-gradient-to-br from-emerald-50 via-lime-50 to-amber-50 rounded-2xl border border-emerald-100">
+          <p className="text-emerald-900">
             No collections available yet. Check back soon for curated product collections.
           </p>
         </div>
@@ -50,10 +50,14 @@ export function CollectionsPage({ collections }: CollectionsPageProps) {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        <div className="inline-flex items-center gap-3 rounded-full border border-emerald-200/80 bg-emerald-50/70 px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-emerald-900 mb-4">
+          <span className="text-xl">☀️</span>
+          Solar Punk Collections
+        </div>
+        <h1 className="text-3xl font-bold text-emerald-950 mb-2">
           Shop by Collection
         </h1>
-        <p className="text-gray-600 max-w-2xl">
+        <p className="text-emerald-900/80 max-w-2xl">
           Browse curated collections of products from our marketplace vendors.
           Each collection is hand-picked to help you discover quality products.
         </p>
@@ -61,16 +65,25 @@ export function CollectionsPage({ collections }: CollectionsPageProps) {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
         {collections.map((collection, index) => {
-          const colorScheme = CARD_COLORS[index % CARD_COLORS.length]
+          const colorScheme = CARD_STYLES[index % CARD_STYLES.length]
           return (
             <Link
               key={collection.id}
               href={`/collections/${collection.handle}`}
-              className="group relative overflow-hidden rounded-xl shadow-sm hover:shadow-lg transition-all duration-300"
+              className="group relative overflow-hidden rounded-2xl border border-emerald-200/70 bg-gradient-to-br from-emerald-50 via-lime-50 to-amber-50 shadow-sm hover:shadow-xl transition-all duration-300"
             >
+              <div className="absolute inset-0 opacity-30 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.55),transparent_65%)]" />
               <div
-                className={`bg-gradient-to-br ${colorScheme.bg} p-6 h-40 flex flex-col justify-between`}
+                className={`relative bg-gradient-to-br ${colorScheme.bg} p-6 h-44 flex flex-col justify-between`}
               >
+                <div className="flex items-center justify-between">
+                  <span className="text-2xl" aria-hidden="true">
+                    {colorScheme.icon}
+                  </span>
+                  <span className="text-xs uppercase tracking-[0.3em] text-white/70">
+                    Collection
+                  </span>
+                </div>
                 <div>
                   <h3
                     className={`text-lg font-semibold ${colorScheme.text} group-hover:underline`}


### PR DESCRIPTION
### Motivation
- Refresh the Collections and Categories pages and their icons with a solar-punk visual style to provide a warmer, nature-forward theme for the storefront.

### Description
- Replace the Collections page palette with a solar-punk gradient set, add icon badges, a radial overlay, adjusted card sizing and softer rounded corners in `storefront/src/components/sections/CollectionsPage/CollectionsPage.tsx`.
- Add a solar-punk header badge and update heading and paragraph colors on the Categories page in `storefront/src/app/[locale]/(main)/categories/page.tsx` to better match the new theme.
- Restyle category cards in `storefront/src/components/organisms/CategoryCard/CategoryCard.tsx` with gradient backgrounds, softened borders, an emoji badge, updated typography and subtle overlay effects while preserving existing links and behavior.
- Include small accessibility improvements by marking decorative emoji spans as `aria-hidden` and keeping text content unchanged.

### Testing
- Ran `pnpm --version` successfully to verify the package manager environment. 
- Attempted to start the dev server with `pnpm run launcher dev -- --port 3000` for visual verification, but the run failed due to a missing Medusa publishable key/backend connectivity so UI rendering could not be validated.
- No automated unit or integration tests were present for these UI-only changes, so none were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982af5f4b7c832396d8f317b856941a)