### PR TITLE
Add admin-to-vendor email action on seller details

### DIFF
--- a/admin-panel/src/hooks/api/sellers.tsx
+++ b/admin-panel/src/hooks/api/sellers.tsx
@@ -297,6 +297,16 @@ export const useUpdateSeller = () => {
   });
 };
 
+export const useEmailSeller = (id: string) => {
+  return useMutation({
+    mutationFn: (data: { subject: string; message: string }) =>
+      sdk.client.fetch(`/admin/sellers/${id}/email`, {
+        method: "POST",
+        body: data,
+      }),
+  });
+};
+
 export const useSellerProducts = (
   id: string,
   query?: Record<string, string | number>,

--- a/admin-panel/src/routes/sellers/common/components/seller-general-section.tsx
+++ b/admin-panel/src/routes/sellers/common/components/seller-general-section.tsx
@@ -1,5 +1,20 @@
 import { PencilSquare, User } from "@medusajs/icons";
-import { Badge, Container, Divider, Heading, Text, usePrompt } from "@medusajs/ui";
+import {
+  Badge,
+  Button,
+  Container,
+  Divider,
+  Heading,
+  Input,
+  Label,
+  Text,
+  Textarea,
+  toast,
+  usePrompt,
+} from "@medusajs/ui";
+
+import { useState } from "react";
+import type { FormEvent } from "react";
 
 import { useNavigate } from "react-router-dom";
 
@@ -9,12 +24,18 @@ import { VendorTypeLabels } from "@custom-types/domain";
 import { ActionsButton } from "@components/common/actions-button";
 import { SellerStatusBadge } from "@components/common/seller-status-badge";
 
-import { useUpdateSeller } from "@hooks/api/sellers";
+import { useEmailSeller, useUpdateSeller } from "@hooks/api/sellers";
 
 export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
   const navigate = useNavigate();
+  const [showEmailForm, setShowEmailForm] = useState(false);
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
 
   const { mutateAsync: suspendSeller } = useUpdateSeller();
+  const { mutateAsync: emailSeller, isPending: isEmailingSeller } = useEmailSeller(
+    seller.id,
+  );
 
   const dialog = usePrompt();
 
@@ -49,6 +70,32 @@ export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
     ? VendorTypeLabels[seller.seller_metadata.vendor_type as keyof typeof VendorTypeLabels] || seller.seller_metadata.vendor_type
     : "Not set";
 
+  const handleSendEmail = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!seller.email) {
+      toast.error("Vendor does not have an email address configured");
+
+      return;
+    }
+
+    if (!subject.trim() || !message.trim()) {
+      toast.error("Please add both a subject and message");
+
+      return;
+    }
+
+    try {
+      await emailSeller({ subject: subject.trim(), message: message.trim() });
+      toast.success(`Email sent to ${seller.email}`);
+      setSubject("");
+      setMessage("");
+      setShowEmailForm(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to send email");
+    }
+  };
+
   return (
     <>
       <div>
@@ -78,12 +125,47 @@ export const SellerGeneralSection = ({ seller }: { seller: VendorSeller }) => {
                     onClick: () => handleSuspend(),
                     icon: <User />,
                   },
+                  {
+                    label: showEmailForm ? "Hide email form" : "Email vendor",
+                    onClick: () => setShowEmailForm((prev) => !prev),
+                    icon: <User />,
+                  },
                 ]}
               />
             </div>
           </div>
         </Container>
       </div>
+      {showEmailForm && (
+        <Container className="mb-4">
+          <form className="flex flex-col gap-4" onSubmit={handleSendEmail}>
+            <div>
+              <Label htmlFor="vendor-email-subject">Subject</Label>
+              <Input
+                id="vendor-email-subject"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Enter email subject"
+              />
+            </div>
+            <div>
+              <Label htmlFor="vendor-email-message">Message</Label>
+              <Textarea
+                id="vendor-email-message"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="Write your message to the vendor"
+                rows={6}
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button type="submit" isLoading={isEmailingSeller}>
+                Send email
+              </Button>
+            </div>
+          </form>
+        </Container>
+      )}
       <div className="flex gap-4">
         <Container className="px-0">
           <div className="flex items-center justify-between px-8 py-4">

--- a/backend/src/api/admin/sellers/[id]/email/route.ts
+++ b/backend/src/api/admin/sellers/[id]/email/route.ts
@@ -1,0 +1,92 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { ResendService } from "../../../../../services/apprise/resend.service"
+import { requireAdminId } from "../../../../../shared/auth-helpers"
+
+type RouteParams = {
+  id: string
+}
+
+type SendVendorEmailBody = {
+  subject?: string
+  message?: string
+}
+
+/**
+ * POST /admin/sellers/:id/email
+ * Send an email to a seller/vendor from the admin panel.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest<SendVendorEmailBody, RouteParams>,
+  res: MedusaResponse
+) => {
+  const adminId = requireAdminId(req, res)
+  if (!adminId) {
+    return
+  }
+
+  const { id } = req.params
+  const { subject, message } = req.body || {}
+
+  if (!subject?.trim() || !message?.trim()) {
+    return res.status(400).json({
+      message: "subject and message are required",
+    })
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields: ["id", "name", "email"],
+    filters: { id },
+  })
+
+  const seller = sellers?.[0]
+
+  if (!seller) {
+    return res.status(404).json({ message: "Seller not found" })
+  }
+
+  if (!seller.email) {
+    return res.status(400).json({ message: "Seller has no email address" })
+  }
+
+  const resendService = new ResendService({
+    apiKey: process.env.RESEND_API_KEY || "",
+    fromEmail: process.env.RESEND_FROM_EMAIL,
+    fromName: process.env.RESEND_FROM_NAME || "Ground Up Liberation Admin",
+  })
+
+  const result = await resendService.sendEmail({
+    to: seller.email,
+    subject: subject.trim(),
+    text: message.trim(),
+    html: `<p>${message
+      .trim()
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\n/g, "<br />")}</p>`,
+    tags: [
+      { name: "channel", value: "admin" },
+      { name: "entity", value: "seller" },
+      { name: "seller_id", value: seller.id },
+      { name: "admin_id", value: adminId },
+    ],
+  })
+
+  if (!result.success) {
+    return res.status(500).json({
+      message: result.error || "Failed to send email",
+    })
+  }
+
+  return res.status(200).json({
+    success: true,
+    id: result.id,
+    seller_id: seller.id,
+    email: seller.email,
+  })
+}


### PR DESCRIPTION
### Motivation
- Provide admins the ability to send transactional or ad-hoc emails to vendors directly from the seller details page in the admin UI.

### Description
- Added backend endpoint `POST /admin/sellers/:id/email` that requires admin auth, validates `subject` and `message`, looks up the seller, and sends mail via `ResendService` with HTML-escaped content and tags containing `seller_id` and `admin_id` (`backend/src/api/admin/sellers/[id]/email/route.ts`).
- Added a new admin-panel React Query mutation hook `useEmailSeller(id)` to call the new API (`admin-panel/src/hooks/api/sellers.tsx`).
- Updated the seller details general section to add an `Email vendor` action that toggles an inline composer (subject + message), submits via `useEmailSeller`, and shows success/error toasts (`admin-panel/src/routes/sellers/common/components/seller-general-section.tsx`).
- Preserved safe HTML escaping of message bodies and attached metadata tags to outgoing emails for audit/analytics.

### Testing
- Ran targeted admin-panel ESLint for modified files (`eslint` on changed admin-panel files) which completed with warnings but no errors.
- Ran TypeScript check (`pnpm --dir admin-panel exec tsc --noEmit`) which failed due to pre-existing, project-wide type errors unrelated to these changes.
- Attempted backend ESLint for the new route which failed in this environment because ESLint configuration was not found; no backend lint errors were produced by the change itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82005120883239ae7c4d98295dd51)