### PR TITLE
Allow admin to reverse rejected vendor requests into accepted flow

### DIFF
--- a/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
+++ b/admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx
@@ -123,23 +123,25 @@ export function RequestSellerDetail({ request, open, close }: Props) {
           </Container>
         </Drawer.Body>
         <Drawer.Footer>
-          {request.status === "pending" && (
+          {(request.status === "pending" || request.status === "rejected") && (
             <>
               <Button
                 onClick={() => {
                   handlePrompt(request.id!, true);
                 }}
               >
-                Accept
+                {request.status === "rejected" ? "Reverse rejection" : "Accept"}
               </Button>
-              <Button
-                onClick={() => {
-                  handlePrompt(request.id!, false);
-                }}
-                variant="danger"
-              >
-                Reject
-              </Button>
+              {request.status === "pending" && (
+                <Button
+                  onClick={() => {
+                    handlePrompt(request.id!, false);
+                  }}
+                  variant="danger"
+                >
+                  Reject
+                </Button>
+              )}
               <Button variant="secondary" onClick={close}>
                 Cancel
               </Button>

--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -11,7 +11,7 @@ const VALID_TRANSITIONS: Record<RequestStatus, RequestStatus[]> = {
     RequestStatus.CANCELLED,
   ],
   [RequestStatus.ACCEPTED]: [RequestStatus.COMPLETED],
-  [RequestStatus.REJECTED]: [], // Terminal state
+  [RequestStatus.REJECTED]: [RequestStatus.ACCEPTED],
   [RequestStatus.COMPLETED]: [], // Terminal state
   [RequestStatus.CANCELLED]: [], // Terminal state
 }

--- a/backend/src/shared/seller-approval-service.ts
+++ b/backend/src/shared/seller-approval-service.ts
@@ -235,9 +235,9 @@ export class SellerApprovalService {
 
     const request = requests[0]
 
-    // Validate request is pending
-    if (request.status !== RequestStatus.PENDING) {
-      throw new Error(`Request has already been ${request.status}`)
+    // Allow approving previously rejected requests to recover accidental rejections.
+    if (request.status !== RequestStatus.PENDING && request.status !== RequestStatus.REJECTED) {
+      throw new Error(`Request cannot be approved from status ${request.status}`)
     }
 
     // Validate request type
@@ -529,9 +529,9 @@ export class SellerApprovalService {
 
     const request = requests[0]
 
-    // Validate request is pending
-    if (request.status !== RequestStatus.PENDING) {
-      throw new Error(`Request has already been ${request.status}`)
+    // Allow approving previously rejected requests to recover accidental rejections.
+    if (request.status !== RequestStatus.PENDING && request.status !== RequestStatus.REJECTED) {
+      throw new Error(`Request cannot be approved from status ${request.status}`)
     }
 
     // Use the dedicated rejectRequestWithReview method
@@ -565,9 +565,9 @@ export class SellerApprovalService {
 
     const request = requests[0]
 
-    // Validate request is pending
-    if (request.status !== RequestStatus.PENDING) {
-      throw new Error(`Request has already been ${request.status}`)
+    // Allow approving previously rejected requests to recover accidental rejections.
+    if (request.status !== RequestStatus.PENDING && request.status !== RequestStatus.REJECTED) {
+      throw new Error(`Request cannot be approved from status ${request.status}`)
     }
 
     // Build updated reviewer note


### PR DESCRIPTION
### Motivation
- Admins need a way to recover from accidental vendor rejections and run the full acceptance/onboarding flow (including notification emails) the same way as a first-time approval.

### Description
- Allow `rejected -> accepted` state transitions in the request state machine by updating `VALID_TRANSITIONS` in `backend/src/modules/request/service.ts`.
- Permit approval flows to operate when a request is `rejected` by relaxing guards in `backend/src/shared/seller-approval-service.ts` so both seller and generic approval paths accept from `pending` or `rejected` and continue with full provisioning and notification workflows.
- Update the admin UI at `admin-panel/src/routes/requests/request-seller-list/components/request-seller-detail.tsx` so rejected seller requests surface an acceptance action labeled `Reverse rejection`, while keeping the `Reject` action available only for `pending` requests.

### Testing
- Ran `pnpm --dir backend test:unit -- --runTestsByPath src/shared/__tests__/phase0-contracts.unit.spec.ts` and the unit test passed.
- Ran `pnpm -C admin-panel lint` (eslint completed; repository has existing lint warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b9528920832386273e81d31dc5a5)