### PR TITLE
Add /v1/* marketplace API for the Creator Studio contract

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -185,6 +185,9 @@ const marketplaceModules = [
   { resolve: './src/modules/vendor-rules' },
   { resolve: './src/modules/supplier-forwarding' },
   { resolve: './src/modules/vendor-hype-operations-prediction' },
+  { resolve: './src/modules/marketplace-listing' },
+  { resolve: './src/modules/marketplace-signing' },
+  { resolve: './src/modules/marketplace-webhooks' },
 ]
 
 // Community infrastructure modules

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -3706,66 +3706,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -4215,24 +4228,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.7':
     resolution: {integrity: sha512-/OOp9UZBg4v2q9+x/U21Jtld0Wb8ghzBScwhscI7YvoSh4E8RALaJ1msV8V8AKkBkZH7FUAFB7Vbv0oVzZsezA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.7':
     resolution: {integrity: sha512-VBbs4gtD4XQxrHuQ2/2+TDZpPQQgrOHYRnS6SyJW+dw0Nj/OomRqH+n5Z4e/TgKRRbieufipeIGvADYC/90PYQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.7':
     resolution: {integrity: sha512-kVuy2unodso6p0rMauS2zby8/bhzoGRYxBDyD6i2tls/fEYAE74oP0VPFzxIyHaIjK1SN6u5TgvV9MpyJ5xVug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.7':
     resolution: {integrity: sha512-uddYoo5Xmo1XKLhAnh4NBIyy5d0xk33x1sX3nIJboFySLNz878ksCFCZ3IBqrt1Za0gaoIWoOSSSk0eNhAc/sw==}

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -20,6 +20,7 @@ import {
 } from "../shared/rate-limiter";
 import { preventPasswordReuseMiddleware } from "./middlewares/password-history";
 import { ensureSellerContext } from "./vendor/_middlewares";
+import { requireSellerContextV1 } from "./middlewares/seller-context-v1";
 import { CreateVenueSchema } from "./admin/venues/route";
 import { CreateTicketProductSchema } from "./admin/ticket-products/route";
 import { GetTicketProductSeatsSchema } from "./store/ticket-products/[id]/seats/route";
@@ -600,6 +601,27 @@ export default defineMiddlewares({
         authenticate("user", ["bearer", "session"]),
       ],
     },
+    // ============================================================
+    // /v1/** — Marketplace plugins / Creator Studio API
+    // ============================================================
+    // CORS for all /v1 routes (covers seller, public marketplace, checkout, admin)
+    {
+      matcher: "/v1/**",
+      middlewares: [vendorCorsMiddleware],
+    },
+    // Seller routes — require seller bearer auth and resolved seller context
+    {
+      matcher: "/v1/seller/**",
+      middlewares: [authenticate("seller", "bearer"), requireSellerContextV1],
+    },
+    // Admin marketplace routes — require platform admin auth
+    {
+      matcher: "/v1/admin/**",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    // /v1/marketplace/** and /v1/checkout/** are intentionally unauthenticated
+    // (public listings + cart-token-based checkout). CORS above is sufficient.
+
     // Apply security headers to all routes
     {
       matcher: "/*",

--- a/backend/src/api/middlewares/seller-context-v1.ts
+++ b/backend/src/api/middlewares/seller-context-v1.ts
@@ -1,0 +1,106 @@
+import type {
+  MedusaRequest,
+  MedusaResponse,
+  MedusaNextFunction,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { decodeAuthTokenFromAuthorization } from "../../shared/auth-helpers"
+
+/**
+ * Resolves the authenticated seller for /v1/seller/** routes and attaches
+ * { seller_id } to the request. Designed to run AFTER `authenticate("seller", "bearer")`.
+ *
+ * Differs from ./vendor/_middlewares.ts:ensureSellerContext in that it:
+ *   - Has no /vendor/* public-route whitelist (all /v1/seller/* require auth).
+ *   - Skips MercurJS-specific actor_id rewriting; /v1/seller/* routes don't
+ *     touch MercurJS internals.
+ *   - Exposes the canonical `sel_*` seller id as `req.seller_id` for handlers.
+ */
+export interface SellerAuthRequest extends MedusaRequest {
+  seller_id?: string
+}
+
+export async function requireSellerContextV1(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+): Promise<void> {
+  const requestWithAuth = req as MedusaRequest & {
+    auth_context?: {
+      actor_id?: string
+      actor_type?: string
+      auth_identity_id?: string
+    }
+  }
+  const authContext = requestWithAuth.auth_context ?? {}
+  const decoded = decodeAuthTokenFromAuthorization(req.headers.authorization)
+
+  if (!authContext.actor_id && decoded?.actorId) {
+    authContext.actor_id = decoded.actorId
+  }
+  if (!authContext.actor_type && decoded?.actorType) {
+    authContext.actor_type = decoded.actorType
+  }
+  if (!authContext.auth_identity_id && decoded?.authIdentityId) {
+    authContext.auth_identity_id = decoded.authIdentityId
+  }
+  if (!authContext.actor_id && decoded?.sellerId) {
+    authContext.actor_id = decoded.sellerId
+    authContext.actor_type = authContext.actor_type ?? "seller"
+  }
+
+  let sellerId: string | null = null
+
+  if (authContext.actor_id?.startsWith("sel_")) {
+    sellerId = authContext.actor_id
+  } else if (authContext.actor_id?.startsWith("mem_")) {
+    try {
+      const pgConnection = req.scope.resolve(
+        ContainerRegistrationKeys.PG_CONNECTION
+      )
+      const result = await pgConnection.raw(
+        `SELECT seller_id FROM member WHERE id = ? LIMIT 1`,
+        [authContext.actor_id]
+      )
+      sellerId = result.rows?.[0]?.seller_id ?? null
+    } catch (err) {
+      console.error("[v1 seller context] member lookup failed", err)
+    }
+  } else if (authContext.auth_identity_id) {
+    try {
+      const authModule = req.scope.resolve(Modules.AUTH)
+      const identities = await authModule.listAuthIdentities({
+        id: [authContext.auth_identity_id],
+      })
+      const appMetadata = identities?.[0]?.app_metadata as
+        | { seller_id?: string }
+        | undefined
+      const linked = appMetadata?.seller_id
+      if (linked?.startsWith("sel_")) {
+        sellerId = linked
+      } else if (linked?.startsWith("mem_")) {
+        const pgConnection = req.scope.resolve(
+          ContainerRegistrationKeys.PG_CONNECTION
+        )
+        const result = await pgConnection.raw(
+          `SELECT seller_id FROM member WHERE id = ? LIMIT 1`,
+          [linked]
+        )
+        sellerId = result.rows?.[0]?.seller_id ?? null
+      }
+    } catch (err) {
+      console.error("[v1 seller context] auth identity lookup failed", err)
+    }
+  }
+
+  if (!sellerId) {
+    res.status(401).json({
+      message: "Unauthorized - seller authentication required",
+      type: "unauthorized",
+    })
+    return
+  }
+
+  ;(req as SellerAuthRequest).seller_id = sellerId
+  next()
+}

--- a/backend/src/api/v1/admin/marketplace/creators/[seller_id]/suspend/route.ts
+++ b/backend/src/api/v1/admin/marketplace/creators/[seller_id]/suspend/route.ts
@@ -1,0 +1,83 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../../../modules/marketplace-listing/service"
+import {
+  CreatorListingStatus,
+} from "../../../../../../../modules/marketplace-listing/models/creator-listing"
+import {
+  CreatorPayoutProvider,
+  CreatorPayoutStatus,
+} from "../../../../../../../modules/marketplace-listing/models/creator-payout-account"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const BodySchema = z
+  .object({
+    reason: z.string().max(500).optional(),
+  })
+  .strict()
+  .partial()
+
+/**
+ * Admin suspends a creator's marketplace account: marks payout account
+ * suspended, suspends all of their listings, and emits the
+ * `creator.account.suspended` webhook.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const parsed = BodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid suspension payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const sellerId = String(req.params.seller_id || "")
+  if (!sellerId) {
+    return res
+      .status(400)
+      .json({ message: "seller_id required", type: "invalid_request" })
+  }
+
+  const listingService = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const webhooksService = req.scope.resolve<MarketplaceWebhooksService>(
+    MARKETPLACE_WEBHOOKS_MODULE
+  )
+
+  await listingService.upsertPayoutAccount(sellerId, {
+    provider: CreatorPayoutProvider.MANUAL,
+    status: CreatorPayoutStatus.SUSPENDED,
+  })
+
+  const listings = await listingService.listCreatorListings({
+    seller_id: sellerId,
+  })
+  let suspendedCount = 0
+  for (const l of listings) {
+    if (l.status !== CreatorListingStatus.ARCHIVED) {
+      await listingService.suspendListing(l.id)
+      suspendedCount++
+    }
+  }
+
+  const dispatched = await webhooksService.dispatch(
+    "creator.account.suspended",
+    sellerId,
+    {
+      seller_id: sellerId,
+      reason: parsed.data.reason ?? null,
+      suspended_listing_count: suspendedCount,
+      suspended_at: new Date().toISOString(),
+    }
+  )
+
+  return res.json({
+    seller_id: sellerId,
+    suspended_listing_count: suspendedCount,
+    dispatched_count: dispatched.length,
+  })
+}

--- a/backend/src/api/v1/admin/marketplace/payouts/route.ts
+++ b/backend/src/api/v1/admin/marketplace/payouts/route.ts
@@ -1,0 +1,87 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../modules/marketplace-listing/service"
+import {
+  CreatorPayoutProvider,
+  CreatorPayoutStatus,
+} from "../../../../../modules/marketplace-listing/models/creator-payout-account"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../modules/marketplace-webhooks/service"
+
+const BodySchema = z
+  .object({
+    seller_id: z.string().min(1),
+    amount: z.number().nonnegative(),
+    currency: z.string().min(3).max(8),
+    external_payout_id: z.string().min(1).max(120).optional(),
+    period_id: z.string().min(1).max(120).optional(),
+    provider: z
+      .enum([
+        CreatorPayoutProvider.STRIPE_CONNECT,
+        CreatorPayoutProvider.HAWALA,
+        CreatorPayoutProvider.MANUAL,
+      ])
+      .optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .strict()
+
+/**
+ * Admin records that a creator payout has been completed and emits the
+ * `creator.payout.completed` outbound webhook.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const parsed = BodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid payout payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const listingService = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const webhooksService = req.scope.resolve<MarketplaceWebhooksService>(
+    MARKETPLACE_WEBHOOKS_MODULE
+  )
+
+  const now = new Date()
+  await listingService.upsertPayoutAccount(parsed.data.seller_id, {
+    provider: parsed.data.provider ?? CreatorPayoutProvider.MANUAL,
+    status: CreatorPayoutStatus.ACTIVE,
+    provider_metadata: parsed.data.metadata ?? null,
+  })
+
+  const [account] = await listingService.listCreatorPayoutAccounts({
+    seller_id: parsed.data.seller_id,
+  })
+  if (account) {
+    await listingService.updateCreatorPayoutAccounts({
+      id: account.id,
+      last_payout_at: now,
+    })
+  }
+
+  const dispatched = await webhooksService.dispatch(
+    "creator.payout.completed",
+    parsed.data.seller_id,
+    {
+      seller_id: parsed.data.seller_id,
+      amount: parsed.data.amount,
+      currency: parsed.data.currency.toUpperCase(),
+      external_payout_id: parsed.data.external_payout_id ?? null,
+      period_id: parsed.data.period_id ?? null,
+      provider: parsed.data.provider ?? CreatorPayoutProvider.MANUAL,
+      paid_at: now.toISOString(),
+    }
+  )
+
+  return res.json({
+    seller_id: parsed.data.seller_id,
+    paid_at: now.toISOString(),
+    dispatched_count: dispatched.length,
+  })
+}

--- a/backend/src/api/v1/checkout/sessions/[id]/page/route.ts
+++ b/backend/src/api/v1/checkout/sessions/[id]/page/route.ts
@@ -1,0 +1,297 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import jwt from "jsonwebtoken"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { config } from "../../../../../../shared/config"
+import createDigitalProductOrderWorkflow from "../../../../../../workflows/create-digital-product-order"
+
+interface SessionTokenPayload {
+  cart_id: string
+  embed: boolean
+  embed_origin?: string
+  return_url?: string
+}
+
+function decodeSession(token: string): SessionTokenPayload | null {
+  if (!config.JWT_SECRET) return null
+  try {
+    const decoded = (jwt.verify as any)(token, config.JWT_SECRET, {
+      audience: "fbm-checkout",
+    })
+    if (typeof decoded !== "object" || !decoded || !("cart_id" in decoded)) {
+      return null
+    }
+    return decoded as unknown as SessionTokenPayload
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Render the embed-checkout page. When ?embed=1, the rendered HTML emits
+ * `postMessage(... , embedOrigin)` events for `checkout.ready`,
+ * `checkout.completed`, `checkout.cancelled`, and `checkout.error`. The
+ * postMessage target is the origin captured at session creation, never `*`,
+ * so a malicious top frame on a different origin cannot intercept the events.
+ *
+ * GET serves the page (and triggers cart completion when called with
+ * ?action=complete). For non-embed callers the page is still useful as a
+ * lightweight redirect/loading shell.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const token = String(req.params.id || "")
+  const session = decodeSession(token)
+  if (!session) {
+    res.status(401).type("text/html").send(renderError("Invalid or expired session"))
+    return
+  }
+
+  const action = String(req.query.action || "")
+  const embed = req.query.embed === "1" || session.embed
+  const embedOrigin = session.embed_origin
+
+  // The global securityHeadersMiddleware sets X-Frame-Options: SAMEORIGIN.
+  // For embed sessions we explicitly allow framing only from the
+  // origin captured at session creation (signed into the JWT), and remove
+  // the legacy X-Frame-Options header which lacks an allow-list form.
+  if (embed && embedOrigin) {
+    res.removeHeader("X-Frame-Options")
+    res.setHeader(
+      "Content-Security-Policy",
+      `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors ${embedOrigin}`
+    )
+  }
+
+  if (action === "complete") {
+    try {
+      const { result } = await createDigitalProductOrderWorkflow(req.scope).run({
+        input: { cart_id: session.cart_id },
+      })
+      const orderId =
+        (result as { order?: { id?: string } } | undefined)?.order?.id ??
+        (result as { id?: string } | undefined)?.id ??
+        null
+
+      const returnTarget = session.return_url
+      res
+        .status(200)
+        .type("text/html")
+        .send(
+          renderResult({
+            embed,
+            embedOrigin,
+            event: "checkout.completed",
+            payload: { order_id: orderId, cart_id: session.cart_id },
+            returnTarget,
+          })
+        )
+      return
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Checkout failed"
+      res
+        .status(500)
+        .type("text/html")
+        .send(
+          renderResult({
+            embed,
+            embedOrigin,
+            event: "checkout.error",
+            payload: { message },
+          })
+        )
+      return
+    }
+  }
+
+  if (action === "cancel") {
+    res
+      .status(200)
+      .type("text/html")
+      .send(
+        renderResult({
+          embed,
+          embedOrigin,
+          event: "checkout.cancelled",
+          payload: { cart_id: session.cart_id },
+        })
+      )
+    return
+  }
+
+  // Default: render the loading/ready shell. Caller can submit the form
+  // (or call POST) to complete the cart.
+  const cartSummary = await summarizeCart(req, session.cart_id)
+  res
+    .status(200)
+    .type("text/html")
+    .send(
+      renderShell({
+        embed,
+        embedOrigin,
+        token,
+        cart: cartSummary,
+      })
+    )
+}
+
+/**
+ * Programmatic completion endpoint for non-iframe consumers.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const token = String(req.params.id || "")
+  const session = decodeSession(token)
+  if (!session) {
+    return res
+      .status(401)
+      .json({ message: "Invalid or expired session", type: "unauthorized" })
+  }
+
+  try {
+    const { result } = await createDigitalProductOrderWorkflow(req.scope).run({
+      input: { cart_id: session.cart_id },
+    })
+    return res.json({ type: "order", ...result })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Checkout failed"
+    return res.status(500).json({ message, type: "checkout_failed" })
+  }
+}
+
+async function summarizeCart(req: MedusaRequest, cartId: string) {
+  try {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "cart",
+      fields: ["id", "currency_code", "total"],
+      filters: { id: cartId },
+    })
+    return data?.[0] ?? { id: cartId }
+  } catch {
+    return { id: cartId }
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+function renderError(message: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Checkout error</title></head><body><h1>Checkout error</h1><p>${escapeHtml(
+    message
+  )}</p></body></html>`
+}
+
+function renderShell(args: {
+  embed: boolean
+  embedOrigin?: string
+  token: string
+  cart: { id: string; currency_code?: string; total?: number | string }
+}): string {
+  const targetOrigin = args.embedOrigin ?? ""
+  const safeOrigin = JSON.stringify(targetOrigin)
+  const completeUrl = `?action=complete${args.embed ? "&embed=1" : ""}`
+  const cancelUrl = `?action=cancel${args.embed ? "&embed=1" : ""}`
+  const total =
+    args.cart.total !== undefined ? String(args.cart.total) : "—"
+  const currency = args.cart.currency_code
+    ? args.cart.currency_code.toUpperCase()
+    : ""
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'">
+  <title>Free Black Market — Checkout</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 16px; max-width: 480px; margin: 0 auto; }
+    .row { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #eee; }
+    button { padding: 12px 20px; border-radius: 6px; border: 0; cursor: pointer; font-size: 16px; }
+    .pay { background: #111; color: #fff; }
+    .cancel { background: #f4f4f4; color: #111; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Checkout</h1>
+  <div class="row"><span>Cart</span><span>${escapeHtml(args.cart.id)}</span></div>
+  <div class="row"><span>Total</span><span>${escapeHtml(total)} ${escapeHtml(
+    currency
+  )}</span></div>
+  <form method="GET" action="${escapeHtml(completeUrl)}">
+    <button class="pay" type="submit">Confirm and pay</button>
+  </form>
+  <form method="GET" action="${escapeHtml(cancelUrl)}">
+    <button class="cancel" type="submit">Cancel</button>
+  </form>
+  <script>
+    (function () {
+      var embed = ${args.embed ? "true" : "false"};
+      var origin = ${safeOrigin};
+      if (embed && origin && window.parent && window.parent !== window) {
+        window.parent.postMessage(
+          { source: "fbm-checkout", type: "checkout.ready", payload: { cart_id: ${JSON.stringify(
+            args.cart.id
+          )} } },
+          origin
+        );
+      }
+    })();
+  </script>
+</body>
+</html>`
+}
+
+function renderResult(args: {
+  embed: boolean
+  embedOrigin?: string
+  event:
+    | "checkout.completed"
+    | "checkout.cancelled"
+    | "checkout.error"
+  payload: Record<string, unknown>
+  returnTarget?: string
+}): string {
+  const target = args.embedOrigin ?? ""
+  const safeOrigin = JSON.stringify(target)
+  const safeEvent = JSON.stringify(args.event)
+  const safePayload = JSON.stringify(args.payload)
+  const safeReturnTarget = JSON.stringify(args.returnTarget ?? null)
+  const heading =
+    args.event === "checkout.completed"
+      ? "Order placed"
+      : args.event === "checkout.cancelled"
+      ? "Checkout cancelled"
+      : "Checkout error"
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'">
+  <title>${escapeHtml(heading)}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 24px; max-width: 480px; margin: 0 auto; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(heading)}</h1>
+  <script>
+    (function () {
+      var embed = ${args.embed ? "true" : "false"};
+      var origin = ${safeOrigin};
+      var returnTarget = ${safeReturnTarget};
+      if (embed && origin && window.parent && window.parent !== window) {
+        window.parent.postMessage(
+          { source: "fbm-checkout", type: ${safeEvent}, payload: ${safePayload} },
+          origin
+        );
+      } else if (returnTarget) {
+        try { window.location.href = returnTarget; } catch (e) {}
+      }
+    })();
+  </script>
+</body>
+</html>`
+}

--- a/backend/src/api/v1/checkout/sessions/route.ts
+++ b/backend/src/api/v1/checkout/sessions/route.ts
@@ -1,0 +1,80 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import jwt from "jsonwebtoken"
+import { config } from "../../../../shared/config"
+
+const httpsUrl = z.string().url().refine((u) => /^https:\/\//.test(u), {
+  message: "url must use https://",
+})
+
+const BodySchema = z
+  .object({
+    cart_id: z.string().min(1).max(80),
+    return_url: httpsUrl.optional(),
+    embed: z.boolean().optional(),
+    embed_origin: httpsUrl.optional(),
+  })
+  .strict()
+  .refine((d) => !d.embed || !!d.embed_origin, {
+    message: "embed_origin is required when embed=true",
+    path: ["embed_origin"],
+  })
+
+const SESSION_TTL_SECONDS = 30 * 60 // 30 minutes
+
+interface SessionTokenPayload {
+  cart_id: string
+  embed: boolean
+  embed_origin?: string
+  return_url?: string
+}
+
+function getJwtSecret(): string {
+  const secret = config.JWT_SECRET
+  if (!secret) {
+    throw new Error("JWT_SECRET is required to issue checkout session tokens")
+  }
+  return secret
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const parsed = BodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid checkout session payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const payload: SessionTokenPayload = {
+    cart_id: parsed.data.cart_id,
+    embed: parsed.data.embed === true,
+    embed_origin: parsed.data.embed_origin,
+    return_url: parsed.data.return_url,
+  }
+
+  const token = (jwt.sign as any)(payload, getJwtSecret(), {
+    expiresIn: SESSION_TTL_SECONDS,
+    audience: "fbm-checkout",
+  })
+
+  const protocol =
+    (req.headers["x-forwarded-proto"] as string) || req.protocol || "https"
+  const host = req.headers["x-forwarded-host"] || req.headers.host
+  const baseUrl = (process.env.BACKEND_URL || `${protocol}://${host}`).replace(
+    /\/$/,
+    ""
+  )
+
+  const url = `${baseUrl}/v1/checkout/sessions/${encodeURIComponent(token)}/page${
+    parsed.data.embed ? "?embed=1" : ""
+  }`
+
+  return res.status(201).json({
+    session_id: token,
+    url,
+    expires_in: SESSION_TTL_SECONDS,
+    embed: payload.embed,
+  })
+}

--- a/backend/src/api/v1/marketplace/listings/[id]/route.ts
+++ b/backend/src/api/v1/marketplace/listings/[id]/route.ts
@@ -1,0 +1,32 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../modules/marketplace-listing/service"
+import { CreatorListingStatus } from "../../../../../modules/marketplace-listing/models/creator-listing"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const [listing] = await service.listCreatorListings({
+    id: req.params.id,
+    status: CreatorListingStatus.PUBLISHED,
+  })
+  if (!listing) {
+    return res.status(404).json({ message: "Listing not found", type: "not_found" })
+  }
+  return res.json({
+    listing: {
+      id: listing.id,
+      seller_id: listing.seller_id,
+      slug: listing.slug,
+      title: listing.title,
+      description: listing.description,
+      version: listing.version,
+      manifest: listing.manifest,
+      signed_bundle_url: listing.signed_bundle_url,
+      signature_envelope: listing.signature_envelope,
+      signed_at: listing.signed_at,
+      embed_origins: listing.embed_origins,
+    },
+  })
+}

--- a/backend/src/api/v1/marketplace/listings/route.ts
+++ b/backend/src/api/v1/marketplace/listings/route.ts
@@ -1,0 +1,55 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../modules/marketplace-listing/service"
+import { CreatorListingStatus } from "../../../../modules/marketplace-listing/models/creator-listing"
+
+const MAX_LIMIT = 100
+
+function parseInt32(raw: unknown, fallback: number, max: number): number {
+  if (typeof raw !== "string") return fallback
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n < 0) return fallback
+  return Math.min(n, max)
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = parseInt32(req.query.limit, 25, MAX_LIMIT)
+  const offset = parseInt32(req.query.offset, 0, 10_000)
+  const seller_id =
+    typeof req.query.seller_id === "string" ? req.query.seller_id : undefined
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+
+  const filters: Record<string, unknown> = { status: CreatorListingStatus.PUBLISHED }
+  if (seller_id) filters.seller_id = seller_id
+
+  const listings = await service.listCreatorListings(filters, {
+    take: limit,
+    skip: offset,
+    order: { signed_at: "DESC" },
+  })
+
+  return res.json({
+    listings: listings.map(toPublicListing),
+    limit,
+    offset,
+  })
+}
+
+function toPublicListing(listing: any) {
+  return {
+    id: listing.id,
+    seller_id: listing.seller_id,
+    slug: listing.slug,
+    title: listing.title,
+    description: listing.description,
+    version: listing.version,
+    manifest: listing.manifest,
+    signed_bundle_url: listing.signed_bundle_url,
+    signature_envelope: listing.signature_envelope,
+    signed_at: listing.signed_at,
+    embed_origins: listing.embed_origins,
+  }
+}

--- a/backend/src/api/v1/marketplace/signing-keys/route.ts
+++ b/backend/src/api/v1/marketplace/signing-keys/route.ts
@@ -1,0 +1,25 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MARKETPLACE_SIGNING_MODULE } from "../../../../modules/marketplace-signing"
+import type PluginSigningService from "../../../../modules/marketplace-signing/service"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const service = req.scope.resolve<PluginSigningService>(
+    MARKETPLACE_SIGNING_MODULE
+  )
+
+  try {
+    const { keyId, pem } = service.getPublicKeyPem()
+    return res.json({
+      keys: [
+        {
+          keyId,
+          alg: "ed25519",
+          publicKeyPem: pem,
+        },
+      ],
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    return res.status(503).json({ message, type: "signing_unavailable" })
+  }
+}

--- a/backend/src/api/v1/seller/listings/[id]/publish/route.ts
+++ b/backend/src/api/v1/seller/listings/[id]/publish/route.ts
@@ -1,0 +1,95 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../../modules/marketplace-listing/service"
+import { CreatorListingStatus } from "../../../../../../modules/marketplace-listing/models/creator-listing"
+import { MARKETPLACE_SIGNING_MODULE } from "../../../../../../modules/marketplace-signing"
+import type PluginSigningService from "../../../../../../modules/marketplace-signing/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../modules/marketplace-webhooks/service"
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const listingService = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const signingService = req.scope.resolve<PluginSigningService>(
+    MARKETPLACE_SIGNING_MODULE
+  )
+  const webhooksService = req.scope.resolve<MarketplaceWebhooksService>(
+    MARKETPLACE_WEBHOOKS_MODULE
+  )
+
+  const [listing] = await listingService.listCreatorListings({
+    id: req.params.id,
+    seller_id: sellerId,
+  })
+  if (!listing) {
+    return res.status(404).json({ message: "Listing not found", type: "not_found" })
+  }
+
+  if (listing.status === CreatorListingStatus.SUSPENDED) {
+    return res.status(409).json({
+      message: "Suspended listings cannot be published",
+      type: "invalid_state",
+    })
+  }
+
+  if (!listing.code_blob_url || !listing.code_blob_sha256) {
+    return res.status(400).json({
+      message: "Cannot publish: code_blob_url and code_blob_sha256 are required",
+      type: "missing_code_blob",
+    })
+  }
+
+  const manifest = (listing.manifest ?? {}) as Record<string, unknown>
+  const assets = (listing.assets as Array<{ path: string; sha256: string }> | null) ?? []
+  const assetHashes: Record<string, string> = {}
+  for (const a of assets) {
+    assetHashes[a.path] = a.sha256
+  }
+
+  await listingService.beginPublish(listing.id)
+
+  let envelope
+  try {
+    envelope = signingService.sign({
+      manifest: {
+        id: typeof manifest.id === "string" ? manifest.id : listing.slug,
+        version: listing.version,
+        ...manifest,
+      },
+      codeSha256: listing.code_blob_sha256,
+      assetHashes,
+    })
+  } catch (err) {
+    await listingService.updateCreatorListings({
+      id: listing.id,
+      status: CreatorListingStatus.DRAFT,
+    })
+    const message = err instanceof Error ? err.message : "Signing failed"
+    return res.status(500).json({ message, type: "signing_failed" })
+  }
+
+  const signedBundleUrl = listing.code_blob_url
+
+  const updated = await listingService.markPublished(listing.id, {
+    signed_bundle_url: signedBundleUrl,
+    signature_envelope: envelope as unknown as Record<string, unknown>,
+    signing_key_id: envelope.keyId,
+  })
+
+  await webhooksService.dispatch("listing.signed_bundle.published", sellerId, {
+    listing_id: listing.id,
+    slug: listing.slug,
+    version: listing.version,
+    signed_bundle_url: signedBundleUrl,
+    signature_envelope: envelope,
+  })
+
+  return res.json({ listing: updated, envelope })
+}

--- a/backend/src/api/v1/seller/listings/[id]/route.ts
+++ b/backend/src/api/v1/seller/listings/[id]/route.ts
@@ -1,0 +1,119 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../modules/marketplace-listing/service"
+import { CreatorListingStatus } from "../../../../../modules/marketplace-listing/models/creator-listing"
+
+const semverRegex = /^\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?$/i
+const httpsUrl = z.string().url().refine((u) => /^https:\/\//.test(u), {
+  message: "url must use https://",
+})
+
+const PatchSchema = z
+  .object({
+    title: z.string().min(1).max(120).optional(),
+    description: z.string().max(2000).nullable().optional(),
+    manifest: z.record(z.unknown()).optional(),
+    code_blob_url: httpsUrl.nullable().optional(),
+    code_blob_sha256: z.string().regex(/^[a-f0-9]{64}$/i).nullable().optional(),
+    assets: z
+      .array(
+        z.object({
+          path: z.string().min(1).max(256),
+          url: httpsUrl,
+          sha256: z.string().regex(/^[a-f0-9]{64}$/i),
+        })
+      )
+      .max(64)
+      .nullable()
+      .optional(),
+    version: z.string().regex(semverRegex).optional(),
+    embed_origins: z.array(httpsUrl).max(16).nullable().optional(),
+  })
+  .strict()
+
+async function getOwnedListing(
+  req: MedusaRequest,
+  id: string,
+  sellerId: string
+) {
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const [listing] = await service.listCreatorListings({ id, seller_id: sellerId })
+  return listing ?? null
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const listing = await getOwnedListing(req, req.params.id, sellerId)
+  if (!listing) {
+    return res.status(404).json({ message: "Listing not found", type: "not_found" })
+  }
+  return res.json({ listing })
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const listing = await getOwnedListing(req, req.params.id, sellerId)
+  if (!listing) {
+    return res.status(404).json({ message: "Listing not found", type: "not_found" })
+  }
+
+  if (
+    listing.status === CreatorListingStatus.PUBLISHED ||
+    listing.status === CreatorListingStatus.SUSPENDED
+  ) {
+    return res.status(409).json({
+      message:
+        "Published or suspended listings cannot be edited. Bump the version and create a new draft.",
+      type: "invalid_state",
+    })
+  }
+
+  const parsed = PatchSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid update payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const updated = await (service as any).updateCreatorListings({
+    id: listing.id,
+    ...parsed.data,
+  })
+
+  return res.json({ listing: updated })
+}
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const listing = await getOwnedListing(req, req.params.id, sellerId)
+  if (!listing) {
+    return res.status(404).json({ message: "Listing not found", type: "not_found" })
+  }
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  await service.archiveListing(listing.id)
+  return res.json({ id: listing.id, status: CreatorListingStatus.ARCHIVED })
+}

--- a/backend/src/api/v1/seller/listings/mine/route.ts
+++ b/backend/src/api/v1/seller/listings/mine/route.ts
@@ -1,0 +1,22 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../modules/marketplace-listing/service"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+
+  const listings = await service.listCreatorListings(
+    { seller_id: sellerId },
+    { order: { created_at: "DESC" } }
+  )
+
+  return res.json({ listings })
+}

--- a/backend/src/api/v1/seller/listings/route.ts
+++ b/backend/src/api/v1/seller/listings/route.ts
@@ -1,0 +1,75 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../middlewares/seller-context-v1"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../modules/marketplace-listing/service"
+
+const slugRegex = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/
+const semverRegex = /^\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?$/i
+const httpsUrl = z.string().url().refine((u) => /^https:\/\//.test(u), {
+  message: "url must use https://",
+})
+
+const AssetSchema = z.object({
+  path: z.string().min(1).max(256),
+  url: httpsUrl,
+  sha256: z.string().regex(/^[a-f0-9]{64}$/i),
+})
+
+const CreateListingSchema = z.object({
+  slug: z.string().regex(slugRegex),
+  title: z.string().min(1).max(120),
+  description: z.string().max(2000).nullish(),
+  manifest: z.record(z.unknown()),
+  code_blob_url: httpsUrl.nullish(),
+  code_blob_sha256: z.string().regex(/^[a-f0-9]{64}$/i).nullish(),
+  assets: z.array(AssetSchema).max(64).nullish(),
+  version: z.string().regex(semverRegex),
+  embed_origins: z.array(httpsUrl).max(16).nullish(),
+})
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const parsed = CreateListingSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid listing payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+
+  const existing = await service.listCreatorListings({
+    seller_id: sellerId,
+    slug: parsed.data.slug,
+  })
+  if (existing.length > 0) {
+    return res.status(409).json({
+      message: "A listing with that slug already exists for this seller",
+      type: "duplicate_slug",
+    })
+  }
+
+  const listing = await (service as any).createCreatorListings({
+    seller_id: sellerId,
+    slug: parsed.data.slug,
+    title: parsed.data.title,
+    description: parsed.data.description ?? null,
+    manifest: parsed.data.manifest,
+    code_blob_url: parsed.data.code_blob_url ?? null,
+    code_blob_sha256: parsed.data.code_blob_sha256 ?? null,
+    assets: parsed.data.assets ?? null,
+    version: parsed.data.version,
+    embed_origins: parsed.data.embed_origins ?? null,
+  })
+
+  return res.status(201).json({ listing })
+}

--- a/backend/src/api/v1/seller/payouts/onboarding/route.ts
+++ b/backend/src/api/v1/seller/payouts/onboarding/route.ts
@@ -1,0 +1,73 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../modules/marketplace-listing/service"
+import {
+  CreatorPayoutProvider,
+  CreatorPayoutStatus,
+} from "../../../../../modules/marketplace-listing/models/creator-payout-account"
+
+const BodySchema = z
+  .object({
+    provider: z
+      .enum([
+        CreatorPayoutProvider.STRIPE_CONNECT,
+        CreatorPayoutProvider.HAWALA,
+        CreatorPayoutProvider.MANUAL,
+      ])
+      .optional(),
+    return_url: z.string().url().optional(),
+  })
+  .strict()
+
+/**
+ * Start (or resume) creator payout onboarding.
+ *
+ * Stripe Connect wiring is intentionally out of scope for this PR (see
+ * THREAT_MODEL.md and the marketplace plan): we mark the account `pending`
+ * and return a placeholder onboarding URL pointing at the vendor panel,
+ * giving the BlackOut client a stable contract while the real provider
+ * integration lands separately.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const parsed = BodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid onboarding payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const provider = parsed.data.provider ?? CreatorPayoutProvider.MANUAL
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+
+  const baseUrl =
+    process.env.VENDOR_PANEL_URL ||
+    process.env.BACKEND_URL ||
+    "https://vendor.freeblackmarket.com"
+  const onboardingUrl = `${baseUrl.replace(/\/$/, "")}/payouts/onboarding?seller=${encodeURIComponent(
+    sellerId
+  )}&provider=${provider}`
+
+  await service.upsertPayoutAccount(sellerId, {
+    provider,
+    onboarding_url: onboardingUrl,
+    status: CreatorPayoutStatus.PENDING,
+  })
+
+  return res.json({
+    url: onboardingUrl,
+    status: CreatorPayoutStatus.PENDING,
+    provider,
+  })
+}

--- a/backend/src/api/v1/seller/payouts/status/route.ts
+++ b/backend/src/api/v1/seller/payouts/status/route.ts
@@ -1,0 +1,34 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { MARKETPLACE_LISTING_MODULE } from "../../../../../modules/marketplace-listing"
+import type MarketplaceListingService from "../../../../../modules/marketplace-listing/service"
+import {
+  CreatorPayoutProvider,
+  CreatorPayoutStatus,
+} from "../../../../../modules/marketplace-listing/models/creator-payout-account"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<MarketplaceListingService>(
+    MARKETPLACE_LISTING_MODULE
+  )
+  const [account] = await service.listCreatorPayoutAccounts({ seller_id: sellerId })
+
+  if (!account) {
+    return res.json({
+      account: {
+        seller_id: sellerId,
+        provider: CreatorPayoutProvider.MANUAL,
+        status: CreatorPayoutStatus.PENDING,
+        onboarding_url: null,
+        last_payout_at: null,
+      },
+    })
+  }
+
+  return res.json({ account })
+}

--- a/backend/src/api/v1/seller/webhooks/[id]/route.ts
+++ b/backend/src/api/v1/seller/webhooks/[id]/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../modules/marketplace-webhooks/service"
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<MarketplaceWebhooksService>(
+    MARKETPLACE_WEBHOOKS_MODULE
+  )
+
+  const [sub] = await service.listWebhookSubscriptions({
+    id: req.params.id,
+    seller_id: sellerId,
+  })
+  if (!sub) {
+    return res.status(404).json({ message: "Subscription not found", type: "not_found" })
+  }
+
+  await service.deleteWebhookSubscriptions(sub.id)
+  return res.json({ id: sub.id, deleted: true })
+}

--- a/backend/src/api/v1/seller/webhooks/route.ts
+++ b/backend/src/api/v1/seller/webhooks/route.ts
@@ -1,0 +1,87 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../middlewares/seller-context-v1"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../modules/marketplace-webhooks/service"
+import { MARKETPLACE_WEBHOOK_EVENTS } from "../../../../modules/marketplace-webhooks/models/webhook-subscription"
+
+const httpsUrl = z.string().url().refine((u) => /^https:\/\//.test(u), {
+  message: "url must use https://",
+})
+
+const CreateSchema = z.object({
+  url: httpsUrl,
+  events: z
+    .array(z.enum(MARKETPLACE_WEBHOOK_EVENTS))
+    .min(1)
+    .max(MARKETPLACE_WEBHOOK_EVENTS.length),
+})
+
+function redact(secret: string): string {
+  if (!secret) return ""
+  return `${secret.slice(0, 12)}...${secret.slice(-4)}`
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<MarketplaceWebhooksService>(
+    MARKETPLACE_WEBHOOKS_MODULE
+  )
+  const subs = await service.listWebhookSubscriptions(
+    { seller_id: sellerId },
+    { order: { created_at: "DESC" } }
+  )
+
+  return res.json({
+    subscriptions: subs.map((s) => ({
+      id: s.id,
+      url: s.url,
+      events: s.events,
+      status: s.status,
+      failure_count: s.failure_count,
+      last_attempt_at: s.last_attempt_at,
+      secret_preview: redact(s.secret),
+    })),
+  })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const parsed = CreateSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid webhook payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<MarketplaceWebhooksService>(
+    MARKETPLACE_WEBHOOKS_MODULE
+  )
+  const created = await service.createSubscription({
+    seller_id: sellerId,
+    url: parsed.data.url,
+    events: parsed.data.events,
+  })
+  const sub = Array.isArray(created) ? created[0] : created
+
+  // Return the full secret ONCE on creation; subsequent reads are redacted.
+  return res.status(201).json({
+    subscription: {
+      id: sub.id,
+      url: sub.url,
+      events: sub.events,
+      status: sub.status,
+      secret: sub.secret,
+    },
+  })
+}

--- a/backend/src/modules/marketplace-listing/index.ts
+++ b/backend/src/modules/marketplace-listing/index.ts
@@ -1,0 +1,10 @@
+import { Module } from "@medusajs/framework/utils"
+import MarketplaceListingService from "./service"
+
+export const MARKETPLACE_LISTING_MODULE = "marketplaceListing"
+
+export default Module(MARKETPLACE_LISTING_MODULE, {
+  service: MarketplaceListingService,
+})
+
+export * from "./models"

--- a/backend/src/modules/marketplace-listing/migrations/Migration20260505CreateMarketplaceListing.ts
+++ b/backend/src/modules/marketplace-listing/migrations/Migration20260505CreateMarketplaceListing.ts
@@ -1,0 +1,99 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260505CreateMarketplaceListing extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_listing_status_enum" AS ENUM (
+          'draft', 'signing', 'published', 'archived', 'suspended'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_payout_provider_enum" AS ENUM (
+          'stripe_connect', 'hawala', 'manual'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_payout_status_enum" AS ENUM (
+          'pending', 'active', 'restricted', 'suspended'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "creator_listing" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "slug" TEXT NOT NULL,
+        "title" TEXT NOT NULL,
+        "description" TEXT NULL,
+        "manifest" JSONB NOT NULL,
+        "code_blob_url" TEXT NULL,
+        "code_blob_sha256" TEXT NULL,
+        "assets" JSONB NULL,
+        "version" TEXT NOT NULL,
+        "status" creator_listing_status_enum NOT NULL DEFAULT 'draft',
+        "signed_bundle_url" TEXT NULL,
+        "signature_envelope" JSONB NULL,
+        "signed_at" TIMESTAMPTZ NULL,
+        "signing_key_id" TEXT NULL,
+        "embed_origins" JSONB NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "creator_listing_pkey" PRIMARY KEY ("id")
+      );
+    `)
+
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_listing_seller_id"
+        ON "creator_listing" ("seller_id");
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_listing_status"
+        ON "creator_listing" ("status");
+    `)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_creator_listing_seller_slug"
+        ON "creator_listing" ("seller_id", "slug")
+        WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "creator_payout_account" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL UNIQUE,
+        "provider" creator_payout_provider_enum NOT NULL DEFAULT 'manual',
+        "external_account_id" TEXT NULL,
+        "onboarding_url" TEXT NULL,
+        "status" creator_payout_status_enum NOT NULL DEFAULT 'pending',
+        "last_payout_at" TIMESTAMPTZ NULL,
+        "provider_metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "creator_payout_account_pkey" PRIMARY KEY ("id")
+      );
+    `)
+
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_payout_account_status"
+        ON "creator_payout_account" ("status");
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "creator_payout_account" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "creator_listing" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_payout_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_payout_provider_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_listing_status_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/marketplace-listing/models/creator-listing.ts
+++ b/backend/src/modules/marketplace-listing/models/creator-listing.ts
@@ -1,0 +1,71 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum CreatorListingStatus {
+  DRAFT = "draft",
+  SIGNING = "signing",
+  PUBLISHED = "published",
+  ARCHIVED = "archived",
+  SUSPENDED = "suspended",
+}
+
+export interface CreatorListingAsset {
+  path: string
+  url: string
+  sha256: string
+}
+
+export interface CreatorListingSignatureEnvelope {
+  keyId: string
+  alg: "ed25519"
+  manifestHash: string
+  codeHash: string
+  assetHashes: Record<string, string>
+  signedAt: string
+  signature: string
+}
+
+const CreatorListing = model
+  .define("creator_listing", {
+    id: model.id().primaryKey(),
+
+    seller_id: model.text(),
+    slug: model.text(),
+    title: model.text(),
+    description: model.text().nullable(),
+
+    manifest: model.json(),
+    code_blob_url: model.text().nullable(),
+    code_blob_sha256: model.text().nullable(),
+    assets: model.json().nullable(),
+
+    version: model.text(),
+    status: model
+      .enum(Object.values(CreatorListingStatus))
+      .default(CreatorListingStatus.DRAFT),
+
+    signed_bundle_url: model.text().nullable(),
+    signature_envelope: model.json().nullable(),
+    signed_at: model.dateTime().nullable(),
+    signing_key_id: model.text().nullable(),
+
+    embed_origins: model.json().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["seller_id"],
+      name: "IDX_creator_listing_seller_id",
+    },
+    {
+      on: ["status"],
+      name: "IDX_creator_listing_status",
+    },
+    {
+      on: ["seller_id", "slug"],
+      name: "UQ_creator_listing_seller_slug",
+      unique: true,
+    },
+  ])
+
+export default CreatorListing

--- a/backend/src/modules/marketplace-listing/models/creator-payout-account.ts
+++ b/backend/src/modules/marketplace-listing/models/creator-payout-account.ts
@@ -1,0 +1,41 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum CreatorPayoutProvider {
+  STRIPE_CONNECT = "stripe_connect",
+  HAWALA = "hawala",
+  MANUAL = "manual",
+}
+
+export enum CreatorPayoutStatus {
+  PENDING = "pending",
+  ACTIVE = "active",
+  RESTRICTED = "restricted",
+  SUSPENDED = "suspended",
+}
+
+const CreatorPayoutAccount = model
+  .define("creator_payout_account", {
+    id: model.id().primaryKey(),
+
+    seller_id: model.text().unique(),
+    provider: model
+      .enum(Object.values(CreatorPayoutProvider))
+      .default(CreatorPayoutProvider.MANUAL),
+
+    external_account_id: model.text().nullable(),
+    onboarding_url: model.text().nullable(),
+    status: model
+      .enum(Object.values(CreatorPayoutStatus))
+      .default(CreatorPayoutStatus.PENDING),
+
+    last_payout_at: model.dateTime().nullable(),
+    provider_metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["status"],
+      name: "IDX_creator_payout_account_status",
+    },
+  ])
+
+export default CreatorPayoutAccount

--- a/backend/src/modules/marketplace-listing/models/index.ts
+++ b/backend/src/modules/marketplace-listing/models/index.ts
@@ -1,0 +1,13 @@
+export { default as CreatorListing } from "./creator-listing"
+export { default as CreatorPayoutAccount } from "./creator-payout-account"
+
+export {
+  CreatorListingStatus,
+  type CreatorListingAsset,
+  type CreatorListingSignatureEnvelope,
+} from "./creator-listing"
+
+export {
+  CreatorPayoutProvider,
+  CreatorPayoutStatus,
+} from "./creator-payout-account"

--- a/backend/src/modules/marketplace-listing/service.ts
+++ b/backend/src/modules/marketplace-listing/service.ts
@@ -1,0 +1,82 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import CreatorListing, { CreatorListingStatus } from "./models/creator-listing"
+import CreatorPayoutAccount, {
+  CreatorPayoutProvider,
+  CreatorPayoutStatus,
+} from "./models/creator-payout-account"
+
+class MarketplaceListingService extends MedusaService({
+  CreatorListing,
+  CreatorPayoutAccount,
+}) {
+  /**
+   * Mark a listing as `signing` before invoking the signing service.
+   * Idempotent: callers should treat repeated calls as a retry.
+   */
+  async beginPublish(listingId: string) {
+    return (this as any).updateCreatorListings({
+      id: listingId,
+      status: CreatorListingStatus.SIGNING,
+    })
+  }
+
+  async markPublished(
+    listingId: string,
+    fields: {
+      signed_bundle_url: string
+      signature_envelope: Record<string, unknown>
+      signing_key_id: string
+    }
+  ) {
+    return (this as any).updateCreatorListings({
+      id: listingId,
+      status: CreatorListingStatus.PUBLISHED,
+      signed_at: new Date(),
+      ...fields,
+    })
+  }
+
+  async archiveListing(listingId: string) {
+    return (this as any).updateCreatorListings({
+      id: listingId,
+      status: CreatorListingStatus.ARCHIVED,
+    })
+  }
+
+  async suspendListing(listingId: string) {
+    return (this as any).updateCreatorListings({
+      id: listingId,
+      status: CreatorListingStatus.SUSPENDED,
+    })
+  }
+
+  async upsertPayoutAccount(
+    sellerId: string,
+    fields: {
+      provider?: CreatorPayoutProvider
+      external_account_id?: string | null
+      onboarding_url?: string | null
+      status?: CreatorPayoutStatus
+      provider_metadata?: Record<string, unknown> | null
+    }
+  ) {
+    const existing = await this.listCreatorPayoutAccounts({ seller_id: sellerId })
+    if (existing.length > 0) {
+      return (this as any).updateCreatorPayoutAccounts({
+        id: existing[0].id,
+        ...fields,
+      })
+    }
+
+    return (this as any).createCreatorPayoutAccounts({
+      seller_id: sellerId,
+      provider: fields.provider ?? CreatorPayoutProvider.MANUAL,
+      status: fields.status ?? CreatorPayoutStatus.PENDING,
+      external_account_id: fields.external_account_id ?? null,
+      onboarding_url: fields.onboarding_url ?? null,
+      provider_metadata: fields.provider_metadata ?? null,
+    })
+  }
+}
+
+export default MarketplaceListingService

--- a/backend/src/modules/marketplace-signing/__tests__/plugin-signing-service.unit.spec.ts
+++ b/backend/src/modules/marketplace-signing/__tests__/plugin-signing-service.unit.spec.ts
@@ -1,0 +1,94 @@
+import { generateKeyPairSync, verify as cryptoVerify, createPublicKey } from "crypto"
+import PluginSigningService, {
+  canonicalJson,
+  sha256,
+} from "../service"
+
+function withSigningKey<T>(fn: () => T): T {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519")
+  const previousPem = process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM
+  const previousKid = process.env.MARKETPLACE_SIGNING_KEY_ID
+  process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM = privateKey
+    .export({ type: "pkcs8", format: "pem" })
+    .toString()
+  process.env.MARKETPLACE_SIGNING_KEY_ID = "test-key-1"
+  ;(global as any).__test_public_key = publicKey
+  try {
+    return fn()
+  } finally {
+    if (previousPem === undefined) delete process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM
+    else process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM = previousPem
+    if (previousKid === undefined) delete process.env.MARKETPLACE_SIGNING_KEY_ID
+    else process.env.MARKETPLACE_SIGNING_KEY_ID = previousKid
+    delete (global as any).__test_public_key
+  }
+}
+
+describe("PluginSigningService.sign", () => {
+  it("produces an envelope that verifies against the configured public key", () => {
+    withSigningKey(() => {
+      const service = new PluginSigningService()
+      const manifest = { id: "com.example.test", version: "1.0.0", title: "T" }
+      const envelope = service.sign({
+        manifest,
+        codeSha256: "a".repeat(64),
+        assetHashes: { "img/icon.png": "b".repeat(64) },
+        signedAt: new Date("2026-05-05T00:00:00Z"),
+      })
+
+      expect(envelope.alg).toBe("ed25519")
+      expect(envelope.keyId).toBe("test-key-1")
+      expect(envelope.codeHash).toBe("a".repeat(64))
+      expect(envelope.assetHashes["img/icon.png"]).toBe("b".repeat(64))
+
+      const publicKey = (global as any).__test_public_key
+      const payload = [
+        "1",
+        envelope.manifestHash,
+        envelope.codeHash,
+        sha256(canonicalJson(envelope.assetHashes)),
+        envelope.signedAt,
+      ].join("|")
+
+      const ok = cryptoVerify(
+        null,
+        Buffer.from(payload, "utf8"),
+        publicKey,
+        Buffer.from(envelope.signature, "base64")
+      )
+      expect(ok).toBe(true)
+    })
+  })
+
+  it("getPublicKeyPem returns a valid SPKI public key", () => {
+    withSigningKey(() => {
+      const service = new PluginSigningService()
+      const { keyId, pem } = service.getPublicKeyPem()
+      expect(keyId).toBe("test-key-1")
+      const parsed = createPublicKey({ key: pem, format: "pem" })
+      expect(parsed.asymmetricKeyType).toBe("ed25519")
+    })
+  })
+
+  it("manifest canonicalization is order-independent", () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe(canonicalJson({ a: 2, b: 1 }))
+    expect(canonicalJson([{ b: 1, a: 2 }])).toBe(canonicalJson([{ a: 2, b: 1 }]))
+  })
+
+  it("throws if signing key env vars are missing", () => {
+    const prev = process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM
+    delete process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM
+    try {
+      const service = new PluginSigningService()
+      expect(() =>
+        service.sign({
+          manifest: { id: "x", version: "1.0.0" },
+          codeSha256: "a".repeat(64),
+          assetHashes: {},
+        })
+      ).toThrow(/MARKETPLACE_SIGNING_PRIVATE_KEY_PEM/)
+    } finally {
+      if (prev !== undefined) process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM = prev
+    }
+  })
+})

--- a/backend/src/modules/marketplace-signing/index.ts
+++ b/backend/src/modules/marketplace-signing/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import PluginSigningService from "./service"
+
+export const MARKETPLACE_SIGNING_MODULE = "marketplaceSigning"
+
+export default Module(MARKETPLACE_SIGNING_MODULE, {
+  service: PluginSigningService,
+})
+
+export { default as PluginSigningService } from "./service"
+export type { PluginSignedBundle, PluginManifestLike } from "./service"

--- a/backend/src/modules/marketplace-signing/service.ts
+++ b/backend/src/modules/marketplace-signing/service.ts
@@ -1,0 +1,125 @@
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  KeyObject,
+  sign as cryptoSign,
+} from "crypto"
+
+export interface PluginManifestLike {
+  id: string
+  version: string
+  [key: string]: unknown
+}
+
+export interface PluginSignedBundle {
+  keyId: string
+  alg: "ed25519"
+  manifestHash: string
+  codeHash: string
+  assetHashes: Record<string, string>
+  signedAt: string
+  signature: string
+}
+
+const SIGNING_PROTOCOL_VERSION = "1"
+
+/**
+ * PluginSigningService
+ *
+ * Produces an Ed25519 signature envelope over a manifest + code blob + asset
+ * hashes. The envelope shape mirrors `@blackout/protocol`'s
+ * `PluginSignatureEnvelope`, so the BlackOut client's `pluginSignature.ts`
+ * verifier can validate bundles signed here against the pinned public key.
+ *
+ * Canonicalization: all hashed inputs are SHA-256(JSON-with-sorted-keys);
+ * the signed payload concatenates `${PROTOCOL_VERSION}|${manifestHash}|${codeHash}|${assetHashesHash}|${signedAt}`.
+ */
+class PluginSigningService {
+  private getPrivateKey(): { keyId: string; key: KeyObject } {
+    const pem = process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM
+    const keyId = process.env.MARKETPLACE_SIGNING_KEY_ID
+
+    if (!pem || !keyId) {
+      throw new Error(
+        "[marketplace-signing] MARKETPLACE_SIGNING_PRIVATE_KEY_PEM and MARKETPLACE_SIGNING_KEY_ID must be set"
+      )
+    }
+
+    return {
+      keyId,
+      key: createPrivateKey({ key: pem, format: "pem" }),
+    }
+  }
+
+  /**
+   * Returns the configured public key in PEM form for verification by the
+   * BlackOut client (the client pins this value at build time).
+   */
+  getPublicKeyPem(): { keyId: string; pem: string } {
+    const { keyId, key } = this.getPrivateKey()
+    const pub = createPublicKey(key)
+    return {
+      keyId,
+      pem: pub.export({ type: "spki", format: "pem" }).toString(),
+    }
+  }
+
+  sign(args: {
+    manifest: PluginManifestLike
+    codeSha256: string
+    assetHashes: Record<string, string>
+    signedAt?: Date
+  }): PluginSignedBundle {
+    const { keyId, key } = this.getPrivateKey()
+    const signedAt = (args.signedAt ?? new Date()).toISOString()
+
+    const manifestHash = sha256(canonicalJson(args.manifest))
+    const assetHashesHash = sha256(canonicalJson(args.assetHashes))
+
+    const payload = [
+      SIGNING_PROTOCOL_VERSION,
+      manifestHash,
+      args.codeSha256,
+      assetHashesHash,
+      signedAt,
+    ].join("|")
+
+    const signature = cryptoSign(null, Buffer.from(payload, "utf8"), key)
+      .toString("base64")
+
+    return {
+      keyId,
+      alg: "ed25519",
+      manifestHash,
+      codeHash: args.codeSha256,
+      assetHashes: { ...args.assetHashes },
+      signedAt,
+      signature,
+    }
+  }
+}
+
+export function sha256(input: string | Buffer): string {
+  return createHash("sha256").update(input).digest("hex")
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeys(value))
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys)
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = sortKeys((value as Record<string, unknown>)[k])
+    }
+    return out
+  }
+  return value
+}
+
+export default PluginSigningService

--- a/backend/src/modules/marketplace-webhooks/__tests__/marketplace-webhooks-service.unit.spec.ts
+++ b/backend/src/modules/marketplace-webhooks/__tests__/marketplace-webhooks-service.unit.spec.ts
@@ -1,0 +1,24 @@
+import { createHmac } from "crypto"
+import { signWithSecret } from "../service"
+import { MARKETPLACE_WEBHOOK_EVENTS } from "../models/webhook-subscription"
+
+describe("marketplace-webhooks service helpers", () => {
+  it("signWithSecret produces an HMAC-SHA256 hex digest matching crypto.createHmac", () => {
+    const body = JSON.stringify({ id: "evt_1", event: "creator.payout.completed" })
+    const secret = "fbm_whsec_abcdef0123456789"
+
+    const expected = createHmac("sha256", secret).update(body).digest("hex")
+    expect(signWithSecret(secret, body)).toBe(expected)
+  })
+
+  it("exports the three contract events", () => {
+    expect(MARKETPLACE_WEBHOOK_EVENTS).toEqual(
+      expect.arrayContaining([
+        "creator.payout.completed",
+        "listing.signed_bundle.published",
+        "creator.account.suspended",
+      ])
+    )
+    expect(MARKETPLACE_WEBHOOK_EVENTS.length).toBe(3)
+  })
+})

--- a/backend/src/modules/marketplace-webhooks/index.ts
+++ b/backend/src/modules/marketplace-webhooks/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import MarketplaceWebhooksService from "./service"
+
+export const MARKETPLACE_WEBHOOKS_MODULE = "marketplaceWebhooks"
+
+export default Module(MARKETPLACE_WEBHOOKS_MODULE, {
+  service: MarketplaceWebhooksService,
+})
+
+export * from "./models"
+export { signWithSecret } from "./service"

--- a/backend/src/modules/marketplace-webhooks/migrations/Migration20260505CreateMarketplaceWebhooks.ts
+++ b/backend/src/modules/marketplace-webhooks/migrations/Migration20260505CreateMarketplaceWebhooks.ts
@@ -1,0 +1,80 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260505CreateMarketplaceWebhooks extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "marketplace_webhook_subscription_status_enum" AS ENUM (
+          'active', 'disabled'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "marketplace_webhook_delivery_status_enum" AS ENUM (
+          'pending', 'succeeded', 'failed', 'dead'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "marketplace_webhook_subscription" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "url" TEXT NOT NULL,
+        "secret" TEXT NOT NULL,
+        "events" JSONB NOT NULL,
+        "status" marketplace_webhook_subscription_status_enum NOT NULL DEFAULT 'active',
+        "failure_count" INTEGER NOT NULL DEFAULT 0,
+        "last_attempt_at" TIMESTAMPTZ NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "marketplace_webhook_subscription_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_marketplace_webhook_subscription_seller_id"
+        ON "marketplace_webhook_subscription" ("seller_id");
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_marketplace_webhook_subscription_status"
+        ON "marketplace_webhook_subscription" ("status");
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "marketplace_webhook_delivery" (
+        "id" TEXT NOT NULL,
+        "subscription_id" TEXT NOT NULL,
+        "event" TEXT NOT NULL,
+        "payload" JSONB NOT NULL,
+        "attempt" INTEGER NOT NULL DEFAULT 0,
+        "status" marketplace_webhook_delivery_status_enum NOT NULL DEFAULT 'pending',
+        "response_code" INTEGER NULL,
+        "response_body" TEXT NULL,
+        "next_attempt_at" TIMESTAMPTZ NULL,
+        "delivered_at" TIMESTAMPTZ NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "marketplace_webhook_delivery_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_marketplace_webhook_delivery_subscription_id"
+        ON "marketplace_webhook_delivery" ("subscription_id");
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_marketplace_webhook_delivery_status_next"
+        ON "marketplace_webhook_delivery" ("status", "next_attempt_at");
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "marketplace_webhook_delivery" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "marketplace_webhook_subscription" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "marketplace_webhook_delivery_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "marketplace_webhook_subscription_status_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/marketplace-webhooks/models/index.ts
+++ b/backend/src/modules/marketplace-webhooks/models/index.ts
@@ -1,0 +1,10 @@
+export { default as WebhookSubscription } from "./webhook-subscription"
+export { default as WebhookDelivery } from "./webhook-delivery"
+
+export {
+  WebhookSubscriptionStatus,
+  MARKETPLACE_WEBHOOK_EVENTS,
+  type MarketplaceWebhookEvent,
+} from "./webhook-subscription"
+
+export { WebhookDeliveryStatus } from "./webhook-delivery"

--- a/backend/src/modules/marketplace-webhooks/models/webhook-delivery.ts
+++ b/backend/src/modules/marketplace-webhooks/models/webhook-delivery.ts
@@ -1,0 +1,40 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum WebhookDeliveryStatus {
+  PENDING = "pending",
+  SUCCEEDED = "succeeded",
+  FAILED = "failed",
+  DEAD = "dead",
+}
+
+const WebhookDelivery = model
+  .define("marketplace_webhook_delivery", {
+    id: model.id().primaryKey(),
+
+    subscription_id: model.text(),
+    event: model.text(),
+    payload: model.json(),
+
+    attempt: model.number().default(0),
+    status: model
+      .enum(Object.values(WebhookDeliveryStatus))
+      .default(WebhookDeliveryStatus.PENDING),
+
+    response_code: model.number().nullable(),
+    response_body: model.text().nullable(),
+
+    next_attempt_at: model.dateTime().nullable(),
+    delivered_at: model.dateTime().nullable(),
+  })
+  .indexes([
+    {
+      on: ["subscription_id"],
+      name: "IDX_marketplace_webhook_delivery_subscription_id",
+    },
+    {
+      on: ["status", "next_attempt_at"],
+      name: "IDX_marketplace_webhook_delivery_status_next",
+    },
+  ])
+
+export default WebhookDelivery

--- a/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
+++ b/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
@@ -1,0 +1,43 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum WebhookSubscriptionStatus {
+  ACTIVE = "active",
+  DISABLED = "disabled",
+}
+
+export const MARKETPLACE_WEBHOOK_EVENTS = [
+  "creator.payout.completed",
+  "listing.signed_bundle.published",
+  "creator.account.suspended",
+] as const
+
+export type MarketplaceWebhookEvent = (typeof MARKETPLACE_WEBHOOK_EVENTS)[number]
+
+const WebhookSubscription = model
+  .define("marketplace_webhook_subscription", {
+    id: model.id().primaryKey(),
+
+    seller_id: model.text(),
+    url: model.text(),
+    secret: model.text(),
+    events: model.json(),
+
+    status: model
+      .enum(Object.values(WebhookSubscriptionStatus))
+      .default(WebhookSubscriptionStatus.ACTIVE),
+
+    failure_count: model.number().default(0),
+    last_attempt_at: model.dateTime().nullable(),
+  })
+  .indexes([
+    {
+      on: ["seller_id"],
+      name: "IDX_marketplace_webhook_subscription_seller_id",
+    },
+    {
+      on: ["status"],
+      name: "IDX_marketplace_webhook_subscription_status",
+    },
+  ])
+
+export default WebhookSubscription

--- a/backend/src/modules/marketplace-webhooks/service.ts
+++ b/backend/src/modules/marketplace-webhooks/service.ts
@@ -1,0 +1,223 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { createHmac, randomBytes } from "crypto"
+import WebhookSubscription, {
+  MARKETPLACE_WEBHOOK_EVENTS,
+  MarketplaceWebhookEvent,
+  WebhookSubscriptionStatus,
+} from "./models/webhook-subscription"
+import WebhookDelivery, {
+  WebhookDeliveryStatus,
+} from "./models/webhook-delivery"
+
+const RETRY_BACKOFF_MINUTES = [1, 5, 30] as const
+const MAX_ATTEMPTS = RETRY_BACKOFF_MINUTES.length + 1
+
+export interface DispatchedDelivery {
+  id: string
+  subscription_id: string
+}
+
+class MarketplaceWebhooksService extends MedusaService({
+  WebhookSubscription,
+  WebhookDelivery,
+}) {
+  isKnownEvent(event: string): event is MarketplaceWebhookEvent {
+    return (MARKETPLACE_WEBHOOK_EVENTS as readonly string[]).includes(event)
+  }
+
+  generateSecret(): string {
+    return `fbm_whsec_${randomBytes(24).toString("hex")}`
+  }
+
+  async createSubscription(args: {
+    seller_id: string
+    url: string
+    events: string[]
+    secret?: string
+  }) {
+    const secret = args.secret ?? this.generateSecret()
+    return (this as any).createWebhookSubscriptions({
+      seller_id: args.seller_id,
+      url: args.url,
+      events: args.events,
+      secret,
+      status: WebhookSubscriptionStatus.ACTIVE,
+      failure_count: 0,
+    })
+  }
+
+  /**
+   * Enqueue a delivery for every subscription on the given seller that
+   * subscribes to `event`. Caller is responsible for supplying the payload —
+   * the dispatcher signs it with the per-subscription secret at delivery time.
+   */
+  async dispatch(
+    event: MarketplaceWebhookEvent | string,
+    sellerId: string,
+    payload: Record<string, unknown>
+  ): Promise<DispatchedDelivery[]> {
+    const subscriptions = await this.listWebhookSubscriptions({
+      seller_id: sellerId,
+      status: WebhookSubscriptionStatus.ACTIVE,
+    })
+
+    const matching = subscriptions.filter((s) => {
+      const events = (s.events as unknown as string[] | null) ?? []
+      return Array.isArray(events) && (events.includes(event) || events.includes("*"))
+    })
+
+    if (matching.length === 0) return []
+
+    const created = await Promise.all(
+      matching.map(async (s) => {
+        const delivery = await (this as any).createWebhookDeliveries({
+          subscription_id: s.id,
+          event,
+          payload,
+          attempt: 0,
+          status: WebhookDeliveryStatus.PENDING,
+          next_attempt_at: new Date(),
+        })
+        const single = Array.isArray(delivery) ? delivery[0] : delivery
+        return { id: single.id, subscription_id: s.id }
+      })
+    )
+
+    return created
+  }
+
+  /**
+   * Attempt one delivery. Returns true on 2xx, false otherwise (and schedules
+   * retry or marks dead).
+   */
+  async attemptDelivery(deliveryId: string): Promise<boolean> {
+    const [delivery] = await this.listWebhookDeliveries({ id: deliveryId })
+    if (!delivery) return false
+
+    const [subscription] = await this.listWebhookSubscriptions({
+      id: delivery.subscription_id,
+    })
+    if (!subscription) {
+      await (this as any).updateWebhookDeliveries({
+        id: delivery.id,
+        status: WebhookDeliveryStatus.DEAD,
+      })
+      return false
+    }
+
+    const body = JSON.stringify({
+      id: delivery.id,
+      event: delivery.event,
+      seller_id: subscription.seller_id,
+      payload: delivery.payload,
+      created_at: new Date().toISOString(),
+    })
+
+    const signature = signWithSecret(subscription.secret, body)
+    const attempt = (delivery.attempt ?? 0) + 1
+
+    let responseCode: number | null = null
+    let responseBody: string | null = null
+    let succeeded = false
+
+    try {
+      const res = await fetch(subscription.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-FBM-Event": delivery.event,
+          "X-FBM-Delivery": delivery.id,
+          "X-FBM-Signature": `sha256=${signature}`,
+        },
+        body,
+      })
+      responseCode = res.status
+      responseBody = (await res.text()).slice(0, 2000)
+      succeeded = res.ok
+    } catch (err) {
+      responseBody = err instanceof Error ? err.message.slice(0, 2000) : "fetch_error"
+    }
+
+    if (succeeded) {
+      await (this as any).updateWebhookDeliveries({
+        id: delivery.id,
+        attempt,
+        status: WebhookDeliveryStatus.SUCCEEDED,
+        response_code: responseCode,
+        response_body: responseBody,
+        delivered_at: new Date(),
+        next_attempt_at: null,
+      })
+      await (this as any).updateWebhookSubscriptions({
+        id: subscription.id,
+        failure_count: 0,
+        last_attempt_at: new Date(),
+      })
+      return true
+    }
+
+    const isFinalAttempt = attempt >= MAX_ATTEMPTS
+    if (isFinalAttempt) {
+      await (this as any).updateWebhookDeliveries({
+        id: delivery.id,
+        attempt,
+        status: WebhookDeliveryStatus.DEAD,
+        response_code: responseCode,
+        response_body: responseBody,
+        next_attempt_at: null,
+      })
+    } else {
+      const backoffMinutes = RETRY_BACKOFF_MINUTES[attempt - 1] ?? 30
+      const next = new Date(Date.now() + backoffMinutes * 60_000)
+      await (this as any).updateWebhookDeliveries({
+        id: delivery.id,
+        attempt,
+        status: WebhookDeliveryStatus.FAILED,
+        response_code: responseCode,
+        response_body: responseBody,
+        next_attempt_at: next,
+      })
+    }
+
+    await (this as any).updateWebhookSubscriptions({
+      id: subscription.id,
+      failure_count: (subscription.failure_count ?? 0) + 1,
+      last_attempt_at: new Date(),
+    })
+
+    return false
+  }
+
+  /**
+   * Pull deliveries that are due (status pending OR failed-with-due-retry)
+   * and attempt them. Intended to be called from a scheduled job.
+   */
+  async drainDueDeliveries(limit = 25): Promise<number> {
+    const now = new Date()
+    const due = await this.listWebhookDeliveries(
+      {
+        $or: [
+          { status: WebhookDeliveryStatus.PENDING },
+          {
+            status: WebhookDeliveryStatus.FAILED,
+            next_attempt_at: { $lte: now },
+          },
+        ],
+      },
+      { take: limit, order: { next_attempt_at: "ASC" } }
+    )
+
+    let attempted = 0
+    for (const d of due) {
+      await this.attemptDelivery(d.id)
+      attempted++
+    }
+    return attempted
+  }
+}
+
+export function signWithSecret(secret: string, body: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex")
+}
+
+export default MarketplaceWebhooksService

--- a/backend/src/types/optional-deps.d.ts
+++ b/backend/src/types/optional-deps.d.ts
@@ -26,12 +26,50 @@ declare module "jsonwebtoken" {
   export class TokenExpiredError extends Error {}
   export class JsonWebTokenError extends Error {}
 
+  export interface SignOptions {
+    expiresIn?: number | string
+    notBefore?: number | string
+    audience?: string | string[]
+    issuer?: string
+    subject?: string
+    jwtid?: string
+    algorithm?: string
+    keyid?: string
+    noTimestamp?: boolean
+    header?: Record<string, unknown>
+    encoding?: string
+    mutatePayload?: boolean
+  }
+
+  export interface VerifyOptions {
+    audience?: string | RegExp | (string | RegExp)[]
+    issuer?: string | string[]
+    subject?: string
+    algorithms?: string[]
+    clockTolerance?: number
+    maxAge?: string | number
+    ignoreExpiration?: boolean
+    ignoreNotBefore?: boolean
+    nonce?: string
+    complete?: boolean
+  }
+
   export function decode(token: string): Record<string, unknown> | null
-  export function verify(token: string, secretOrPublicKey: string): Record<string, unknown> | string
+  export function verify(
+    token: string,
+    secretOrPublicKey: string,
+    options?: VerifyOptions
+  ): Record<string, unknown> | string
+  export function sign(
+    payload: string | Buffer | Record<string, unknown>,
+    secretOrPrivateKey: string | Buffer,
+    options?: SignOptions
+  ): string
 
   const jwt: {
     decode: typeof decode
     verify: typeof verify
+    sign: typeof sign
     TokenExpiredError: typeof TokenExpiredError
     JsonWebTokenError: typeof JsonWebTokenError
   }


### PR DESCRIPTION
Implements the FBM-side counterpart to the BlackOut client work pushed
in commit d49192a (claude/marketplace-plugins-apps-1yBZ1):

- /v1/seller/* — listings CRUD, publish, payouts onboarding/status,
  webhook subscription management. Auth: seller bearer JWT (re-uses
  the existing vendor login token; new requireSellerContextV1
  middleware does the actor->seller resolution without the MercurJS
  rewrites that /vendor/** needs).
- /v1/marketplace/* — public listings + signing-keys read endpoints.
- /v1/checkout/sessions* — JWT-tokened checkout sessions; the page
  route emits postMessage events (checkout.ready/completed/cancelled/
  error) targeted at the embed_origin captured at session creation,
  with frame-ancestors CSP overriding the default SAMEORIGIN.
- /v1/admin/marketplace/* — admin endpoints to record completed
  payouts and suspend creator accounts; both fan out via the new
  outbound webhook dispatcher.

Three new modules:
  marketplace-listing  — CreatorListing + CreatorPayoutAccount models
  marketplace-signing  — Ed25519 envelope service whose output matches
                         @blackout/protocol's PluginSignatureEnvelope;
                         keys live in env vars
                         (MARKETPLACE_SIGNING_PRIVATE_KEY_PEM /
                         MARKETPLACE_SIGNING_KEY_ID).
  marketplace-webhooks — WebhookSubscription + WebhookDelivery with
                         HMAC-SHA256 signing (X-FBM-Signature),
                         3x retry with 1m/5m/30m backoff, dead-letter.

Wires the three contract events end-to-end:
  listing.signed_bundle.published → emitted on publishListing
  creator.payout.completed         → emitted on /v1/admin payouts POST
  creator.account.suspended        → emitted on /v1/admin creators
                                     suspend POST

Tests: 6 new unit tests cover signature round-trips against an
Ed25519 keypair and the HMAC body signer; full unit suite is 70/70.
medusa build is clean.

https://claude.ai/code/session_016BBPt3XWLwSTUdh6UbcNzt