### PR TITLE
Release A: creator monetization MVP — attribution + commission ledger loop

### DIFF
--- a/admin-panel/src/components/layout/main-layout/main-layout.tsx
+++ b/admin-panel/src/components/layout/main-layout/main-layout.tsx
@@ -256,6 +256,12 @@ const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
       icon: <Star />,
       label: "Creators",
       to: "/creators",
+      items: [
+        {
+          label: "Programs",
+          to: "/creator-programs",
+        },
+      ],
     },
     {
       icon: <ReceiptPercent />,

--- a/admin-panel/src/components/layout/main-layout/main-layout.tsx
+++ b/admin-panel/src/components/layout/main-layout/main-layout.tsx
@@ -268,6 +268,11 @@ const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
       ],
     },
     {
+      icon: <SquaresPlus />,
+      label: "Services",
+      to: "/services",
+    },
+    {
       icon: <ReceiptPercent />,
       label: t("promotions.domain"),
       to: "/promotions",

--- a/admin-panel/src/components/layout/main-layout/main-layout.tsx
+++ b/admin-panel/src/components/layout/main-layout/main-layout.tsx
@@ -261,6 +261,10 @@ const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
           label: "Programs",
           to: "/creator-programs",
         },
+        {
+          label: "Reward Pools",
+          to: "/creator-rewards",
+        },
       ],
     },
     {

--- a/admin-panel/src/components/layout/main-layout/main-layout.tsx
+++ b/admin-panel/src/components/layout/main-layout/main-layout.tsx
@@ -14,6 +14,7 @@ import {
   Shopping,
   ShoppingCart,
   SquaresPlus,
+  Star,
   Sun,
   Tag,
   Users,
@@ -250,6 +251,11 @@ const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
       icon: <Sun />,
       label: "Producers",
       to: "/producers",
+    },
+    {
+      icon: <Star />,
+      label: "Creators",
+      to: "/creators",
     },
     {
       icon: <ReceiptPercent />,

--- a/admin-panel/src/dashboard-app/routes/get-route.map.tsx
+++ b/admin-panel/src/dashboard-app/routes/get-route.map.tsx
@@ -838,6 +838,14 @@ export function getRouteMap({
               lazy: () => import("../../routes/creators"),
             },
             {
+              path: "/creator-programs",
+              errorElement: <ErrorBoundary />,
+              handle: {
+                breadcrumb: () => "Creator Programs",
+              },
+              lazy: () => import("../../routes/creator-programs"),
+            },
+            {
               path: "/messages",
               errorElement: <ErrorBoundary />,
               handle: {

--- a/admin-panel/src/dashboard-app/routes/get-route.map.tsx
+++ b/admin-panel/src/dashboard-app/routes/get-route.map.tsx
@@ -846,6 +846,14 @@ export function getRouteMap({
               lazy: () => import("../../routes/creator-programs"),
             },
             {
+              path: "/creator-rewards",
+              errorElement: <ErrorBoundary />,
+              handle: {
+                breadcrumb: () => "Creator Rewards",
+              },
+              lazy: () => import("../../routes/creator-rewards"),
+            },
+            {
               path: "/messages",
               errorElement: <ErrorBoundary />,
               handle: {

--- a/admin-panel/src/dashboard-app/routes/get-route.map.tsx
+++ b/admin-panel/src/dashboard-app/routes/get-route.map.tsx
@@ -854,6 +854,14 @@ export function getRouteMap({
               lazy: () => import("../../routes/creator-rewards"),
             },
             {
+              path: "/services",
+              errorElement: <ErrorBoundary />,
+              handle: {
+                breadcrumb: () => "Services",
+              },
+              lazy: () => import("../../routes/services"),
+            },
+            {
               path: "/messages",
               errorElement: <ErrorBoundary />,
               handle: {

--- a/admin-panel/src/dashboard-app/routes/get-route.map.tsx
+++ b/admin-panel/src/dashboard-app/routes/get-route.map.tsx
@@ -830,6 +830,14 @@ export function getRouteMap({
               ],
             },
             {
+              path: "/creators",
+              errorElement: <ErrorBoundary />,
+              handle: {
+                breadcrumb: () => "Creators",
+              },
+              lazy: () => import("../../routes/creators"),
+            },
+            {
               path: "/messages",
               errorElement: <ErrorBoundary />,
               handle: {

--- a/admin-panel/src/routes/creator-programs/creator-programs.tsx
+++ b/admin-panel/src/routes/creator-programs/creator-programs.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react"
+import { Button, Container, Heading, Label, Text, toast } from "@medusajs/ui"
+import { backendUrl } from "@lib/client/client"
+
+interface Program {
+  id: string
+  vendor_id: string
+  title: string
+  slug: string
+  program_type: string
+  status: string
+  commission_percent: number | null
+  budget_cap_cents: number | null
+  budget_spent_cents: number
+  currency_code: string
+  requires_kyc: boolean
+  starts_at: string | null
+  ends_at: string | null
+  created_at: string
+}
+
+const formatCents = (cents: number | null | undefined, currency = "USD") =>
+  cents == null
+    ? "—"
+    : new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+        Number(cents) / 100
+      )
+
+const formatDate = (s: string | null) =>
+  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—"
+
+async function adminFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    credentials: "include",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const CreatorProgramsAdminPage = () => {
+  const [programs, setPrograms] = useState<Program[]>([])
+  const [statusFilter, setStatusFilter] = useState<string>("")
+  const [loading, setLoading] = useState(false)
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const qs = new URLSearchParams({ limit: "100" })
+      if (statusFilter) qs.set("status", statusFilter)
+      const { programs } = await adminFetch<{ programs: Program[] }>(
+        `/v1/admin/marketplace/programs?${qs.toString()}`
+      )
+      setPrograms(programs)
+    } catch (err) {
+      toast.error("Failed to load programs", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter])
+
+  const forceClose = async (id: string) => {
+    const reason = window.prompt("Reason for force-closing:")
+    if (!reason || reason.trim().length < 2) return
+    try {
+      await adminFetch(`/v1/admin/marketplace/programs/${id}/force-close`, {
+        method: "POST",
+        body: JSON.stringify({ reason }),
+      })
+      toast.success("Program force-closed")
+      await reload()
+    } catch (err) {
+      toast.error("Force-close failed", {
+        description: (err as Error).message,
+      })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Heading level="h1">Creator Programs — Admin Oversight</Heading>
+        <div className="flex items-end gap-3">
+          <div>
+            <Label htmlFor="status">Status</Label>
+            <select
+              id="status"
+              className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+            >
+              <option value="">All</option>
+              <option value="draft">draft</option>
+              <option value="active">active</option>
+              <option value="paused">paused</option>
+              <option value="closed">closed</option>
+              <option value="archived">archived</option>
+            </select>
+          </div>
+          <Button size="small" onClick={() => void reload()} disabled={loading}>
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="border border-ui-border-base rounded-md p-4">
+        {programs.length === 0 ? (
+          <Text className="text-ui-fg-subtle italic">No programs.</Text>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-ui-fg-subtle border-b">
+                <th className="py-2">Title</th>
+                <th className="py-2">Vendor</th>
+                <th className="py-2">Type</th>
+                <th className="py-2">Status</th>
+                <th className="py-2">KYC</th>
+                <th className="py-2 text-right">Budget cap</th>
+                <th className="py-2 text-right">Spent</th>
+                <th className="py-2">Ends</th>
+                <th className="py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {programs.map((p) => (
+                <tr key={p.id} className="border-b">
+                  <td className="py-2">
+                    <div className="font-medium">{p.title}</div>
+                    <div className="text-xs text-ui-fg-subtle font-mono">
+                      {p.slug}
+                    </div>
+                  </td>
+                  <td className="py-2 font-mono text-xs">{p.vendor_id}</td>
+                  <td className="py-2">{p.program_type}</td>
+                  <td className="py-2">{p.status}</td>
+                  <td className="py-2">{p.requires_kyc ? "Yes" : "No"}</td>
+                  <td className="py-2 text-right">
+                    {formatCents(p.budget_cap_cents, p.currency_code.toUpperCase())}
+                  </td>
+                  <td className="py-2 text-right">
+                    {formatCents(p.budget_spent_cents, p.currency_code.toUpperCase())}
+                  </td>
+                  <td className="py-2">{formatDate(p.ends_at)}</td>
+                  <td className="py-2 text-right">
+                    {p.status !== "closed" && p.status !== "archived" ? (
+                      <Button
+                        size="small"
+                        variant="danger"
+                        onClick={() => void forceClose(p.id)}
+                      >
+                        Force-close
+                      </Button>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/admin-panel/src/routes/creator-programs/index.ts
+++ b/admin-panel/src/routes/creator-programs/index.ts
@@ -1,0 +1,1 @@
+export { CreatorProgramsAdminPage as Component } from "./creator-programs"

--- a/admin-panel/src/routes/creator-rewards/creator-rewards.tsx
+++ b/admin-panel/src/routes/creator-rewards/creator-rewards.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from "react"
+import { Button, Container, Heading, Label, Text, toast } from "@medusajs/ui"
+import { backendUrl } from "@lib/client/client"
+
+interface Pool {
+  id: string
+  program_id: string | null
+  funder_seller_id: string | null
+  kind: string
+  status: string
+  period_start: string
+  period_end: string
+  total_cents: number
+  rate_per_kqv_cents: number | null
+  currency_code: string
+  distributed_at: string | null
+}
+
+interface DistributionPreview {
+  pool_id: string
+  total_qv: number
+  total_distributed_cents: number
+  per_creator: Array<{
+    creator_seller_id: string
+    qualified_views: number
+    amount_cents: number
+  }>
+  ineligible_below_threshold: number
+}
+
+const formatCents = (cents: number, currency = "USD") =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+    Number(cents) / 100
+  )
+
+const formatDate = (s: string | null) =>
+  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—"
+
+async function adminFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    credentials: "include",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const CreatorRewardsPage = () => {
+  const [pools, setPools] = useState<Pool[]>([])
+  const [statusFilter, setStatusFilter] = useState<string>("")
+  const [loading, setLoading] = useState(false)
+  const [previewById, setPreviewById] = useState<Record<string, DistributionPreview>>({})
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const qs = new URLSearchParams({ limit: "100" })
+      if (statusFilter) qs.set("status", statusFilter)
+      const { pools } = await adminFetch<{ pools: Pool[] }>(
+        `/v1/admin/marketplace/reward-pools?${qs.toString()}`
+      )
+      setPools(pools)
+    } catch (err) {
+      toast.error("Failed to load pools", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter])
+
+  const previewDistribution = async (id: string) => {
+    try {
+      const result = await adminFetch<DistributionPreview & { dry_run: boolean }>(
+        `/v1/admin/marketplace/reward-pools/${id}/distribute?dry_run=1`,
+        { method: "POST" }
+      )
+      setPreviewById((m) => ({ ...m, [id]: result }))
+      toast.success(
+        `Preview: ${formatCents(result.total_distributed_cents)} across ${result.per_creator.length} creators`
+      )
+    } catch (err) {
+      toast.error("Preview failed", { description: (err as Error).message })
+    }
+  }
+
+  const distribute = async (id: string) => {
+    if (
+      !window.confirm(
+        "Commit distribution? This writes ledger entries and credits creator earnings."
+      )
+    ) {
+      return
+    }
+    try {
+      const result = await adminFetch<{
+        distributed_count: number
+        total_distributed_cents: number
+      }>(`/v1/admin/marketplace/reward-pools/${id}/distribute`, {
+        method: "POST",
+      })
+      toast.success(
+        `Distributed ${formatCents(result.total_distributed_cents)} to ${result.distributed_count} creators`
+      )
+      setPreviewById((m) => {
+        const next = { ...m }
+        delete next[id]
+        return next
+      })
+      await reload()
+    } catch (err) {
+      toast.error("Distribute failed", { description: (err as Error).message })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Heading level="h1">Creator Rewards — Pools</Heading>
+        <div className="flex items-end gap-3">
+          <div>
+            <Label htmlFor="status">Status</Label>
+            <select
+              id="status"
+              className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+            >
+              <option value="">All</option>
+              <option value="scheduled">scheduled</option>
+              <option value="accruing">accruing</option>
+              <option value="calculating">calculating</option>
+              <option value="distributed">distributed</option>
+              <option value="reverted">reverted</option>
+            </select>
+          </div>
+          <Button size="small" onClick={() => void reload()} disabled={loading}>
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="border border-ui-border-base rounded-md p-4">
+        {pools.length === 0 ? (
+          <Text className="text-ui-fg-subtle italic">No reward pools.</Text>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-ui-fg-subtle border-b">
+                <th className="py-2">Pool</th>
+                <th className="py-2">Program</th>
+                <th className="py-2">Funder</th>
+                <th className="py-2">Kind</th>
+                <th className="py-2">Status</th>
+                <th className="py-2 text-right">Total</th>
+                <th className="py-2">Period</th>
+                <th className="py-2">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pools.map((p) => (
+                <tr key={p.id} className="border-b align-top">
+                  <td className="py-2 font-mono text-xs">{p.id}</td>
+                  <td className="py-2 font-mono text-xs">{p.program_id ?? "—"}</td>
+                  <td className="py-2 font-mono text-xs">
+                    {p.funder_seller_id ?? "platform"}
+                  </td>
+                  <td className="py-2">{p.kind}</td>
+                  <td className="py-2">{p.status}</td>
+                  <td className="py-2 text-right">
+                    {formatCents(p.total_cents, p.currency_code.toUpperCase())}
+                  </td>
+                  <td className="py-2 text-xs">
+                    {formatDate(p.period_start)} – {formatDate(p.period_end)}
+                  </td>
+                  <td className="py-2">
+                    {p.status === "distributed" || p.status === "reverted" ? (
+                      <Text className="text-ui-fg-subtle italic">
+                        {formatDate(p.distributed_at)}
+                      </Text>
+                    ) : (
+                      <div className="flex flex-col gap-1">
+                        <Button
+                          size="small"
+                          variant="secondary"
+                          onClick={() => void previewDistribution(p.id)}
+                        >
+                          Preview
+                        </Button>
+                        <Button
+                          size="small"
+                          onClick={() => void distribute(p.id)}
+                        >
+                          Distribute
+                        </Button>
+                      </div>
+                    )}
+                    {previewById[p.id] ? (
+                      <div className="mt-2 text-xs text-ui-fg-subtle">
+                        {previewById[p.id].per_creator.length} creators ·
+                        {" "}
+                        {formatCents(
+                          previewById[p.id].total_distributed_cents,
+                          p.currency_code.toUpperCase()
+                        )}
+                        {previewById[p.id].ineligible_below_threshold > 0
+                          ? ` · ${previewById[p.id].ineligible_below_threshold} below threshold`
+                          : ""}
+                      </div>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/admin-panel/src/routes/creator-rewards/index.ts
+++ b/admin-panel/src/routes/creator-rewards/index.ts
@@ -1,0 +1,1 @@
+export { CreatorRewardsPage as Component } from "./creator-rewards"

--- a/admin-panel/src/routes/creators/creators-moderation.tsx
+++ b/admin-panel/src/routes/creators/creators-moderation.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from "react"
+import {
+  Button,
+  Container,
+  Heading,
+  Label,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { backendUrl } from "@lib/client/client"
+
+interface CreatorRow {
+  seller_id: string
+  handle: string | null
+  bio: string | null
+  niches: string[]
+  total_followers: number
+  verified: boolean
+  featured: boolean
+  rating: number | null
+  review_count: number
+  created_at: string
+}
+
+interface AttributionRow {
+  id: string
+  order_id: string
+  creator_seller_id: string
+  vendor_id: string | null
+  source: string
+  commission_amount_cents: number
+  commission_status: string
+  attribution_decided_at: string
+  hold_until: string | null
+  disqualified_reason: string | null
+}
+
+const formatCents = (cents: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
+    Number(cents) / 100
+  )
+
+const formatDate = (s: string | null) =>
+  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—"
+
+async function adminFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    credentials: "include",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const CreatorsModerationPage = () => {
+  const [tab, setTab] = useState<"creators" | "attributions">("creators")
+  const [creators, setCreators] = useState<CreatorRow[]>([])
+  const [attributions, setAttributions] = useState<AttributionRow[]>([])
+  const [statusFilter, setStatusFilter] = useState<string>("")
+  const [loading, setLoading] = useState(false)
+  const [reasonByAttribution, setReasonByAttribution] = useState<
+    Record<string, string>
+  >({})
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const cQs = new URLSearchParams({ limit: "100" })
+      const aQs = new URLSearchParams({ limit: "100" })
+      if (statusFilter) aQs.set("status", statusFilter)
+      const [cRes, aRes] = await Promise.all([
+        adminFetch<{ creators: CreatorRow[] }>(
+          `/v1/admin/marketplace/creators?${cQs.toString()}`
+        ),
+        adminFetch<{ attributions: AttributionRow[] }>(
+          `/v1/admin/marketplace/attributions?${aQs.toString()}`
+        ),
+      ])
+      setCreators(cRes.creators)
+      setAttributions(aRes.attributions)
+    } catch (err) {
+      toast.error("Failed to load creator moderation data", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter])
+
+  const handleDisqualify = async (id: string) => {
+    const reason = (reasonByAttribution[id] || "").trim()
+    if (reason.length < 2) {
+      toast.error("Please provide a reason before disqualifying")
+      return
+    }
+    try {
+      await adminFetch(`/v1/admin/marketplace/attributions/${id}/disqualify`, {
+        method: "POST",
+        body: JSON.stringify({ reason }),
+      })
+      toast.success("Attribution disqualified")
+      setReasonByAttribution((m) => {
+        const next = { ...m }
+        delete next[id]
+        return next
+      })
+      await reload()
+    } catch (err) {
+      toast.error("Disqualify failed", { description: (err as Error).message })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Heading level="h1">Creator Program — Moderation</Heading>
+        <div className="flex gap-2">
+          <Button
+            variant={tab === "creators" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("creators")}
+          >
+            Creators ({creators.length})
+          </Button>
+          <Button
+            variant={tab === "attributions" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("attributions")}
+          >
+            Attributions ({attributions.length})
+          </Button>
+        </div>
+      </div>
+
+      {tab === "creators" && (
+        <div className="border border-ui-border-base rounded-md p-4">
+          <Heading level="h2" className="mb-3">
+            Registered creators
+          </Heading>
+          {creators.length === 0 ? (
+            <Text className="text-ui-fg-subtle italic">No creators yet.</Text>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-ui-fg-subtle border-b">
+                  <th className="py-2">Handle</th>
+                  <th className="py-2">Seller ID</th>
+                  <th className="py-2">Niches</th>
+                  <th className="py-2 text-right">Followers</th>
+                  <th className="py-2">Verified</th>
+                  <th className="py-2">Featured</th>
+                  <th className="py-2">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {creators.map((c) => (
+                  <tr key={c.seller_id} className="border-b">
+                    <td className="py-2 font-mono">@{c.handle ?? "—"}</td>
+                    <td className="py-2 font-mono text-xs">{c.seller_id}</td>
+                    <td className="py-2 text-ui-fg-subtle">
+                      {(c.niches || []).join(", ")}
+                    </td>
+                    <td className="py-2 text-right">
+                      {Number(c.total_followers).toLocaleString()}
+                    </td>
+                    <td className="py-2">{c.verified ? "Yes" : "No"}</td>
+                    <td className="py-2">{c.featured ? "Yes" : "No"}</td>
+                    <td className="py-2">{formatDate(c.created_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {tab === "attributions" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-end gap-3">
+            <div>
+              <Label htmlFor="status">Filter by status</Label>
+              <select
+                id="status"
+                className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base"
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="pending">pending</option>
+                <option value="held">held</option>
+                <option value="approved">approved</option>
+                <option value="paid">paid</option>
+                <option value="reversed">reversed</option>
+                <option value="disqualified">disqualified</option>
+              </select>
+            </div>
+            <Button size="small" onClick={() => void reload()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+
+          <div className="border border-ui-border-base rounded-md p-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-ui-fg-subtle border-b">
+                  <th className="py-2">Order</th>
+                  <th className="py-2">Creator</th>
+                  <th className="py-2">Source</th>
+                  <th className="py-2 text-right">Amount</th>
+                  <th className="py-2">Status</th>
+                  <th className="py-2">Hold until</th>
+                  <th className="py-2">Disqualify</th>
+                </tr>
+              </thead>
+              <tbody>
+                {attributions.map((a) => (
+                  <tr key={a.id} className="border-b align-top">
+                    <td className="py-2 font-mono text-xs">{a.order_id}</td>
+                    <td className="py-2 font-mono text-xs">{a.creator_seller_id}</td>
+                    <td className="py-2">{a.source}</td>
+                    <td className="py-2 text-right">
+                      {formatCents(a.commission_amount_cents)}
+                    </td>
+                    <td className="py-2">{a.commission_status}</td>
+                    <td className="py-2">{formatDate(a.hold_until)}</td>
+                    <td className="py-2">
+                      {a.commission_status === "approved" ||
+                      a.commission_status === "paid" ||
+                      a.commission_status === "reversed" ||
+                      a.commission_status === "disqualified" ? (
+                        <Text className="text-ui-fg-subtle italic">
+                          {a.disqualified_reason || "—"}
+                        </Text>
+                      ) : (
+                        <div className="flex flex-col gap-1">
+                          <Textarea
+                            placeholder="Reason"
+                            rows={2}
+                            value={reasonByAttribution[a.id] ?? ""}
+                            onChange={(e) =>
+                              setReasonByAttribution((m) => ({
+                                ...m,
+                                [a.id]: e.target.value,
+                              }))
+                            }
+                          />
+                          <Button
+                            size="small"
+                            variant="danger"
+                            onClick={() => void handleDisqualify(a.id)}
+                          >
+                            Disqualify
+                          </Button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {attributions.length === 0 && (
+              <Text className="text-ui-fg-subtle italic">
+                No attributions for this filter.
+              </Text>
+            )}
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}

--- a/admin-panel/src/routes/creators/index.ts
+++ b/admin-panel/src/routes/creators/index.ts
@@ -1,0 +1,1 @@
+export { CreatorsModerationPage as Component } from "./creators-moderation"

--- a/admin-panel/src/routes/services/index.ts
+++ b/admin-panel/src/routes/services/index.ts
@@ -1,0 +1,1 @@
+export { ServicesAdminPage as Component } from "./services"

--- a/admin-panel/src/routes/services/services.tsx
+++ b/admin-panel/src/routes/services/services.tsx
@@ -1,0 +1,460 @@
+import { useEffect, useState } from "react"
+import { Button, Container, Heading, Label, Text, Textarea, toast } from "@medusajs/ui"
+import { backendUrl } from "@lib/client/client"
+
+interface ServiceProgramRow {
+  id: string
+  vendor_id: string
+  title: string
+  service_category: string
+  program_type: string
+  status: string
+  unit_price_cents: number | null
+  currency_code: string
+  requires_kyc: boolean
+}
+
+interface SubcontractRow {
+  id: string
+  parent_order_id: string
+  parent_seller_id: string
+  subcontract_seller_id: string
+  status: string
+  total_cents: number
+  currency_code: string
+  dispute_reason: string | null
+}
+
+interface ProofRow {
+  id: string
+  owner_seller_id: string
+  context_type: string
+  context_id: string
+  kind: string
+  storage_url: string | null
+  verification_status: string
+  verification_method: string | null
+  verified_at: string | null
+}
+
+const formatCents = (cents: number | null | undefined, currency = "USD") =>
+  cents == null
+    ? "—"
+    : new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+        Number(cents) / 100
+      )
+
+async function adminFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    credentials: "include",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const ServicesAdminPage = () => {
+  const [tab, setTab] = useState<"programs" | "subcontracts" | "proofs">("programs")
+  const [programs, setPrograms] = useState<ServiceProgramRow[]>([])
+  const [subcontracts, setSubcontracts] = useState<SubcontractRow[]>([])
+  const [proofs, setProofs] = useState<ProofRow[]>([])
+  const [statusFilter, setStatusFilter] = useState<string>("")
+  const [proofStatusFilter, setProofStatusFilter] = useState<string>("")
+  const [loading, setLoading] = useState(false)
+  const [resolveAmountById, setResolveAmountById] = useState<Record<string, string>>({})
+  const [rejectReasonById, setRejectReasonById] = useState<Record<string, string>>({})
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const subQs = new URLSearchParams({ limit: "100" })
+      if (statusFilter) subQs.set("status", statusFilter)
+      const proofQs = new URLSearchParams({ limit: "100" })
+      if (proofStatusFilter) proofQs.set("verification_status", proofStatusFilter)
+      const [{ programs }, { subcontracts: subs }, { proofs: ps }] = await Promise.all([
+        adminFetch<{ programs: ServiceProgramRow[] }>(
+          `/v1/admin/marketplace/service-programs?limit=100`
+        ),
+        adminFetch<{ subcontracts: SubcontractRow[] }>(
+          `/v1/admin/marketplace/subcontracts?${subQs.toString()}`
+        ),
+        adminFetch<{ proofs: ProofRow[] }>(
+          `/v1/admin/marketplace/proofs?${proofQs.toString()}`
+        ),
+      ])
+      setPrograms(programs)
+      setSubcontracts(subs)
+      setProofs(ps)
+    } catch (err) {
+      toast.error("Failed to load services data", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter, proofStatusFilter])
+
+  const resolveSubcontract = async (
+    id: string,
+    decision: "release" | "refund" | "split"
+  ) => {
+    const reason = window.prompt(`Reason for ${decision}:`)
+    if (!reason || reason.trim().length < 2) return
+    let body: Record<string, unknown> = { decision, reason }
+    if (decision === "split") {
+      const amt = parseInt(resolveAmountById[id] || "0", 10)
+      body.release_amount_cents = Number.isFinite(amt) ? amt : 0
+    }
+    try {
+      await adminFetch(`/v1/admin/marketplace/subcontracts/${id}/resolve`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+      toast.success(`Subcontract ${decision}d`)
+      await reload()
+    } catch (err) {
+      toast.error("Resolve failed", { description: (err as Error).message })
+    }
+  }
+
+  const verifyProof = async (id: string) => {
+    try {
+      await adminFetch(`/v1/admin/marketplace/proofs/${id}/verify`, {
+        method: "POST",
+      })
+      toast.success("Proof manually verified")
+      await reload()
+    } catch (err) {
+      toast.error("Verify failed", { description: (err as Error).message })
+    }
+  }
+
+  const rejectProof = async (id: string) => {
+    const reason = (rejectReasonById[id] || "").trim()
+    if (reason.length < 2) {
+      toast.error("Please provide a reason")
+      return
+    }
+    try {
+      await adminFetch(`/v1/admin/marketplace/proofs/${id}/reject`, {
+        method: "POST",
+        body: JSON.stringify({ reason }),
+      })
+      toast.success("Proof rejected")
+      setRejectReasonById((m) => {
+        const next = { ...m }
+        delete next[id]
+        return next
+      })
+      await reload()
+    } catch (err) {
+      toast.error("Reject failed", { description: (err as Error).message })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Heading level="h1">Services — Admin Oversight</Heading>
+        <div className="flex gap-2">
+          <Button
+            variant={tab === "programs" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("programs")}
+          >
+            Programs ({programs.length})
+          </Button>
+          <Button
+            variant={tab === "subcontracts" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("subcontracts")}
+          >
+            Subcontracts ({subcontracts.length})
+          </Button>
+          <Button
+            variant={tab === "proofs" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("proofs")}
+          >
+            Proofs ({proofs.length})
+          </Button>
+        </div>
+      </div>
+
+      {tab === "programs" && (
+        <div className="border border-ui-border-base rounded-md p-4">
+          {programs.length === 0 ? (
+            <Text className="text-ui-fg-subtle italic">No service programs.</Text>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-ui-fg-subtle border-b">
+                  <th className="py-2">Title</th>
+                  <th className="py-2">Vendor</th>
+                  <th className="py-2">Category</th>
+                  <th className="py-2">Type</th>
+                  <th className="py-2">Status</th>
+                  <th className="py-2 text-right">Unit price</th>
+                  <th className="py-2">KYC</th>
+                </tr>
+              </thead>
+              <tbody>
+                {programs.map((p) => (
+                  <tr key={p.id} className="border-b">
+                    <td className="py-2">{p.title}</td>
+                    <td className="py-2 font-mono text-xs">{p.vendor_id}</td>
+                    <td className="py-2">{p.service_category}</td>
+                    <td className="py-2">{p.program_type}</td>
+                    <td className="py-2">{p.status}</td>
+                    <td className="py-2 text-right">
+                      {formatCents(p.unit_price_cents, p.currency_code.toUpperCase())}
+                    </td>
+                    <td className="py-2">{p.requires_kyc ? "Yes" : "No"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {tab === "subcontracts" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-end gap-3">
+            <div>
+              <Label htmlFor="sc-status">Status</Label>
+              <select
+                id="sc-status"
+                className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base"
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="proposed">proposed</option>
+                <option value="accepted">accepted</option>
+                <option value="in_progress">in_progress</option>
+                <option value="delivered">delivered</option>
+                <option value="accepted_by_parent">accepted_by_parent</option>
+                <option value="disputed">disputed</option>
+                <option value="canceled">canceled</option>
+              </select>
+            </div>
+            <Button size="small" onClick={() => void reload()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+          <div className="border border-ui-border-base rounded-md p-4">
+            {subcontracts.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">No subcontracts.</Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Subcontract</th>
+                    <th className="py-2">Parent / provider</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2 text-right">Total</th>
+                    <th className="py-2">Resolve</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subcontracts.map((s) => (
+                    <tr key={s.id} className="border-b align-top">
+                      <td className="py-2 font-mono text-xs">{s.id}</td>
+                      <td className="py-2 font-mono text-xs">
+                        {s.parent_seller_id} → {s.subcontract_seller_id}
+                      </td>
+                      <td className="py-2">
+                        {s.status}
+                        {s.dispute_reason ? (
+                          <div className="text-xs text-ui-fg-subtle italic mt-1">
+                            {s.dispute_reason}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="py-2 text-right">
+                        {formatCents(s.total_cents, s.currency_code.toUpperCase())}
+                      </td>
+                      <td className="py-2">
+                        {s.status === "disputed" ? (
+                          <div className="flex flex-col gap-1">
+                            <div className="flex gap-1">
+                              <Button
+                                size="small"
+                                onClick={() => void resolveSubcontract(s.id, "release")}
+                              >
+                                Release to provider
+                              </Button>
+                              <Button
+                                size="small"
+                                variant="secondary"
+                                onClick={() => void resolveSubcontract(s.id, "refund")}
+                              >
+                                Refund parent
+                              </Button>
+                            </div>
+                            <div className="flex gap-1 items-center">
+                              <input
+                                type="number"
+                                min="0"
+                                placeholder="release cents"
+                                className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base text-xs w-32"
+                                value={resolveAmountById[s.id] ?? ""}
+                                onChange={(e) =>
+                                  setResolveAmountById((m) => ({
+                                    ...m,
+                                    [s.id]: e.target.value,
+                                  }))
+                                }
+                              />
+                              <Button
+                                size="small"
+                                variant="secondary"
+                                onClick={() => void resolveSubcontract(s.id, "split")}
+                              >
+                                Split
+                              </Button>
+                            </div>
+                          </div>
+                        ) : (
+                          <Text className="text-ui-fg-subtle italic">—</Text>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === "proofs" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-end gap-3">
+            <div>
+              <Label htmlFor="proof-status">Status</Label>
+              <select
+                id="proof-status"
+                className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base"
+                value={proofStatusFilter}
+                onChange={(e) => setProofStatusFilter(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="unverified">unverified</option>
+                <option value="auto_verified">auto_verified</option>
+                <option value="manually_verified">manually_verified</option>
+                <option value="disputed">disputed</option>
+                <option value="rejected">rejected</option>
+              </select>
+            </div>
+            <Button size="small" onClick={() => void reload()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+          <div className="border border-ui-border-base rounded-md p-4">
+            {proofs.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">No proofs.</Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Proof</th>
+                    <th className="py-2">Owner</th>
+                    <th className="py-2">Context</th>
+                    <th className="py-2">Kind</th>
+                    <th className="py-2">URL</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {proofs.map((p) => (
+                    <tr key={p.id} className="border-b align-top">
+                      <td className="py-2 font-mono text-xs">{p.id}</td>
+                      <td className="py-2 font-mono text-xs">{p.owner_seller_id}</td>
+                      <td className="py-2 text-xs">
+                        {p.context_type}
+                        <br />
+                        <span className="font-mono">{p.context_id}</span>
+                      </td>
+                      <td className="py-2">{p.kind}</td>
+                      <td className="py-2">
+                        {p.storage_url ? (
+                          <a
+                            href={p.storage_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 underline truncate block max-w-xs"
+                          >
+                            view
+                          </a>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="py-2">
+                        {p.verification_status}
+                        {p.verification_method ? (
+                          <div className="text-xs text-ui-fg-subtle">
+                            {p.verification_method}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="py-2">
+                        {p.verification_status !== "manually_verified" &&
+                        p.verification_status !== "rejected" ? (
+                          <div className="flex flex-col gap-1">
+                            <Button
+                              size="small"
+                              onClick={() => void verifyProof(p.id)}
+                            >
+                              Verify
+                            </Button>
+                            <Textarea
+                              rows={2}
+                              placeholder="Reject reason"
+                              value={rejectReasonById[p.id] ?? ""}
+                              onChange={(e) =>
+                                setRejectReasonById((m) => ({
+                                  ...m,
+                                  [p.id]: e.target.value,
+                                }))
+                              }
+                            />
+                            <Button
+                              size="small"
+                              variant="danger"
+                              onClick={() => void rejectProof(p.id)}
+                            >
+                              Reject
+                            </Button>
+                          </div>
+                        ) : (
+                          <Text className="text-ui-fg-subtle italic">—</Text>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -188,6 +188,7 @@ const marketplaceModules = [
   { resolve: './src/modules/marketplace-listing' },
   { resolve: './src/modules/marketplace-signing' },
   { resolve: './src/modules/marketplace-webhooks' },
+  { resolve: './src/modules/creator-attribution' },
 ]
 
 // Community infrastructure modules

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -189,6 +189,7 @@ const marketplaceModules = [
   { resolve: './src/modules/marketplace-signing' },
   { resolve: './src/modules/marketplace-webhooks' },
   { resolve: './src/modules/creator-attribution' },
+  { resolve: './src/modules/creator-program' },
 ]
 
 // Community infrastructure modules

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -192,6 +192,9 @@ const marketplaceModules = [
   { resolve: './src/modules/creator-program' },
   { resolve: './src/modules/content-platform' },
   { resolve: './src/modules/creator-rewards' },
+  { resolve: './src/modules/service-program' },
+  { resolve: './src/modules/work-verification' },
+  { resolve: './src/modules/order-subcontract' },
 ]
 
 // Community infrastructure modules

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -190,6 +190,8 @@ const marketplaceModules = [
   { resolve: './src/modules/marketplace-webhooks' },
   { resolve: './src/modules/creator-attribution' },
   { resolve: './src/modules/creator-program' },
+  { resolve: './src/modules/content-platform' },
+  { resolve: './src/modules/creator-rewards' },
 ]
 
 // Community infrastructure modules

--- a/backend/src/api/r/[shortCode]/route.ts
+++ b/backend/src/api/r/[shortCode]/route.ts
@@ -1,0 +1,158 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createHash, randomUUID } from "crypto"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../modules/creator-attribution/service"
+
+/**
+ * Public affiliate-link redirector.
+ *
+ * Resolves a short code to its destination, sets two first-party cookies
+ * (signed visitor token + affiliate code), records an `AttributionClickEvent`
+ * (best-effort, non-blocking), and 302s to the destination URL with UTM
+ * parameters appended.
+ *
+ * Mounted at `/r/:shortCode` so creators can drop short URLs anywhere
+ * (TikTok bio, Instagram link-in-bio, podcast show notes, etc.).
+ */
+
+const VISITOR_COOKIE = "_fbm_visitor"
+const AFF_COOKIE = "_fbm_aff"
+const COOKIE_MAX_AGE_DAYS = 90
+
+function getStorefrontBase(): string {
+  // STORE_CORS is a comma-separated list of allowed storefront origins; first
+  // entry doubles as the canonical base for redirect targets when the
+  // affiliate link's destination_path is relative.
+  const storeCors = process.env.STORE_CORS || ""
+  const first = storeCors.split(",").map((s) => s.trim()).filter(Boolean)[0]
+  return process.env.STOREFRONT_URL || first || ""
+}
+
+function getCookieSecret(): string {
+  return (
+    process.env.STOREFRONT_VISITOR_SIGNING_KEY ||
+    process.env.JWT_SECRET ||
+    "fbm-default-cookie-key"
+  )
+}
+
+function hashIp(ip: string | null | undefined): string | null {
+  if (!ip) return null
+  const salt = process.env.CREATOR_ATTRIBUTION_IP_SALT || ""
+  return createHash("sha256").update(`${salt}:${ip}`).digest("hex").slice(0, 32)
+}
+
+function hashUserAgent(ua: string | null | undefined): string | null {
+  if (!ua) return null
+  return createHash("sha256").update(ua).digest("hex").slice(0, 32)
+}
+
+function setCookie(
+  res: MedusaResponse,
+  name: string,
+  value: string,
+  maxAgeSeconds: number
+): void {
+  // Append-friendly Set-Cookie so we can set both visitor and aff cookies.
+  const existing = res.getHeader("Set-Cookie")
+  const next = `${name}=${value}; Path=/; Max-Age=${maxAgeSeconds}; SameSite=Lax`
+  if (Array.isArray(existing)) {
+    res.setHeader("Set-Cookie", [...existing, next])
+  } else if (typeof existing === "string") {
+    res.setHeader("Set-Cookie", [existing, next])
+  } else {
+    res.setHeader("Set-Cookie", next)
+  }
+}
+
+function readCookie(req: MedusaRequest, name: string): string | null {
+  const raw = req.headers.cookie
+  if (!raw) return null
+  const parts = raw.split(/;\s*/)
+  for (const p of parts) {
+    const eq = p.indexOf("=")
+    if (eq < 0) continue
+    if (p.slice(0, eq) === name) return decodeURIComponent(p.slice(eq + 1))
+  }
+  return null
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const shortCode = (req.params as { shortCode?: string })?.shortCode
+  if (!shortCode) {
+    res.status(400).send("Missing short code")
+    return
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const resolved = await service.resolveShortCode(shortCode)
+  if (!resolved) {
+    res.status(404).send("Affiliate link not found")
+    return
+  }
+
+  // Visitor cookie: read existing or mint a new UUID, sign it.
+  const cookieSecret = getCookieSecret()
+  const existingSignedVisitor = readCookie(req, VISITOR_COOKIE)
+  let visitorToken: string | null = null
+  if (existingSignedVisitor) {
+    visitorToken = CreatorAttributionService.verifyCookieValue(
+      existingSignedVisitor,
+      cookieSecret
+    )
+  }
+  if (!visitorToken) {
+    visitorToken = randomUUID()
+  }
+  const signedVisitor = CreatorAttributionService.signCookieValue(
+    visitorToken,
+    cookieSecret
+  )
+  setCookie(res, VISITOR_COOKIE, signedVisitor, COOKIE_MAX_AGE_DAYS * 24 * 60 * 60)
+
+  // Affiliate cookie: pin to this short code for the cookie window.
+  const affPayload = `${shortCode}.${Date.now()}`
+  const signedAff = CreatorAttributionService.signCookieValue(affPayload, cookieSecret)
+  setCookie(
+    res,
+    AFF_COOKIE,
+    signedAff,
+    Number(process.env.CREATOR_ATTRIBUTION_DEFAULT_COOKIE_DAYS || 7) * 24 * 60 * 60
+  )
+
+  // Best-effort click recording. We do not await failures.
+  const ip =
+    (req.headers["x-forwarded-for"] as string | undefined)?.split(",")[0]?.trim() ||
+    req.socket.remoteAddress ||
+    null
+  const ua = (req.headers["user-agent"] as string | undefined) || null
+  const referrer = (req.headers["referer"] as string | undefined) || null
+  const country =
+    (req.headers["cf-ipcountry"] as string | undefined) ||
+    (req.headers["x-vercel-ip-country"] as string | undefined) ||
+    null
+
+  service
+    .recordClick({
+      shortCode,
+      visitorToken,
+      ipHash: hashIp(ip),
+      userAgentHash: hashUserAgent(ua),
+      referrer,
+      country,
+    })
+    .catch((err) => {
+      console.error("[creator-attribution] recordClick failed", err)
+    })
+
+  // Compose the redirect URL.
+  const base = getStorefrontBase().replace(/\/$/, "")
+  const target = resolved.redirectUrl.startsWith("http")
+    ? resolved.redirectUrl
+    : `${base}${resolved.redirectUrl.startsWith("/") ? "" : "/"}${resolved.redirectUrl}`
+
+  res.redirect(302, target)
+}

--- a/backend/src/api/v1/admin/marketplace/attributions/[id]/disqualify/route.ts
+++ b/backend/src/api/v1/admin/marketplace/attributions/[id]/disqualify/route.ts
@@ -1,0 +1,76 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../../../modules/creator-attribution/service"
+import { CommissionStatus } from "../../../../../../../modules/creator-attribution/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const Schema = z.object({
+  reason: z.string().min(2).max(512),
+})
+
+/**
+ * POST /v1/admin/marketplace/attributions/:id/disqualify
+ *
+ * Block a suspected fraudulent attribution from paying out. If the
+ * commission has already been ledger-credited (status=approved|paid), the
+ * admin should use the reverse path instead.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+
+  const parsed = Schema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid disqualify payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const list = await service.listOrderAttributions({ id })
+  if (list.length === 0) {
+    return res.status(404).json({ message: "Attribution not found", type: "not_found" })
+  }
+  const attr = list[0]
+  if (
+    attr.commission_status === CommissionStatus.PAID ||
+    attr.commission_status === CommissionStatus.APPROVED
+  ) {
+    return res.status(409).json({
+      message:
+        "Cannot disqualify already-credited commission; use reverse instead",
+      type: "conflict",
+    })
+  }
+
+  const updated = await service.disqualifyAttribution(id, parsed.data.reason)
+
+  // Best-effort fraud webhook
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+    await webhooks.dispatch(
+      "creator.commission.disqualified",
+      attr.creator_seller_id,
+      {
+        attribution_id: id,
+        order_id: attr.order_id,
+        reason: parsed.data.reason,
+      }
+    )
+  } catch (err) {
+    console.error("[admin/disqualify] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({ attribution: updated })
+}

--- a/backend/src/api/v1/admin/marketplace/attributions/route.ts
+++ b/backend/src/api/v1/admin/marketplace/attributions/route.ts
@@ -1,0 +1,31 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../modules/creator-attribution/service"
+
+/**
+ * GET /v1/admin/marketplace/attributions
+ *
+ * Moderation queue. Filter by ?status=pending|held|approved|paid|reversed|disqualified
+ * and ?creator_seller_id=...
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1), 200)
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const filter: Record<string, unknown> = {}
+  if (req.query.status) filter.commission_status = req.query.status as string
+  if (req.query.creator_seller_id) filter.creator_seller_id = req.query.creator_seller_id as string
+  if (req.query.program_id) filter.program_id = req.query.program_id as string
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const attributions = await service.listOrderAttributions(filter, {
+    take: limit,
+    skip: offset,
+    order: { attribution_decided_at: "DESC" } as any,
+  })
+
+  return res.status(200).json({ attributions, limit, offset })
+}

--- a/backend/src/api/v1/admin/marketplace/creators/route.ts
+++ b/backend/src/api/v1/admin/marketplace/creators/route.ts
@@ -1,0 +1,42 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { SELLER_EXTENSION_MODULE } from "../../../../../modules/seller-extension"
+
+/**
+ * GET /v1/admin/marketplace/creators
+ *
+ * List all sellers with vendor_type=creator. Supports pagination and
+ * verified-only filter. Used by the admin panel creator oversight page.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1), 200)
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+  const verifiedOnly = req.query.verified === "true"
+
+  const service = req.scope.resolve<any>(SELLER_EXTENSION_MODULE)
+
+  const filter: Record<string, unknown> = { vendor_type: "creator" }
+  if (verifiedOnly) filter.verified = true
+
+  const creators = await service.listSellerMetadata(filter, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" },
+  })
+
+  return res.status(200).json({
+    creators: creators.map((c: any) => ({
+      seller_id: c.seller_id,
+      handle: c.creator_handle,
+      bio: c.creator_bio,
+      niches: c.creator_niches ?? [],
+      total_followers: Number(c.creator_total_followers ?? 0),
+      verified: !!c.verified,
+      featured: !!c.featured,
+      rating: c.rating,
+      review_count: Number(c.review_count ?? 0),
+      created_at: c.created_at,
+    })),
+    limit,
+    offset,
+  })
+}

--- a/backend/src/api/v1/admin/marketplace/programs/[id]/force-close/route.ts
+++ b/backend/src/api/v1/admin/marketplace/programs/[id]/force-close/route.ts
@@ -1,0 +1,30 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../../modules/creator-program/service"
+
+const Schema = z.object({
+  reason: z.string().min(2).max(2000),
+})
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const parsed = Schema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const list = await service.listCreatorPrograms({ id })
+  if (list.length === 0) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const updated = await service.closeProgram(id, parsed.data.reason)
+  return res.status(200).json({ program: updated })
+}

--- a/backend/src/api/v1/admin/marketplace/programs/route.ts
+++ b/backend/src/api/v1/admin/marketplace/programs/route.ts
@@ -1,0 +1,31 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../modules/creator-program/service"
+
+/**
+ * GET /v1/admin/marketplace/programs
+ *
+ * Admin oversight: list all programs across all vendors.
+ * Filters: ?status=, ?vendor_id=, ?program_type=, ?limit=, ?offset=
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const filter: Record<string, unknown> = {}
+  if (req.query.status) filter.status = req.query.status as string
+  if (req.query.vendor_id) filter.vendor_id = req.query.vendor_id as string
+  if (req.query.program_type) filter.program_type = req.query.program_type as string
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const programs = await service.listCreatorPrograms(filter, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" } as any,
+  })
+
+  return res.status(200).json({ programs, limit, offset })
+}

--- a/backend/src/api/v1/admin/marketplace/proofs/[id]/reject/route.ts
+++ b/backend/src/api/v1/admin/marketplace/proofs/[id]/reject/route.ts
@@ -1,0 +1,48 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { WORK_VERIFICATION_MODULE } from "../../../../../../../modules/work-verification"
+import type WorkVerificationService from "../../../../../../../modules/work-verification/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const Schema = z.object({
+  reason: z.string().min(2).max(2000),
+})
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const parsed = Schema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid reject payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const wv = req.scope.resolve<WorkVerificationService>(WORK_VERIFICATION_MODULE)
+  const list = await wv.listProofArtifacts({ id })
+  const proof = list[0]
+  if (!proof) {
+    return res.status(404).json({ message: "Proof not found", type: "not_found" })
+  }
+  const updated = await wv.rejectProof({
+    proofId: id,
+    verifierId: "admin",
+    reason: parsed.data.reason,
+  })
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+    await webhooks.dispatch("service.proof.rejected", proof.owner_seller_id, {
+      proof_id: id,
+      reason: parsed.data.reason,
+    })
+  } catch (err) {
+    console.error("[admin/proof/reject] webhook failed", err)
+  }
+  return res.status(200).json({ proof: updated })
+}

--- a/backend/src/api/v1/admin/marketplace/proofs/[id]/verify/route.ts
+++ b/backend/src/api/v1/admin/marketplace/proofs/[id]/verify/route.ts
@@ -1,0 +1,37 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { WORK_VERIFICATION_MODULE } from "../../../../../../../modules/work-verification"
+import type WorkVerificationService from "../../../../../../../modules/work-verification/service"
+import { ProofVerificationMethod } from "../../../../../../../modules/work-verification/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const wv = req.scope.resolve<WorkVerificationService>(WORK_VERIFICATION_MODULE)
+  const list = await wv.listProofArtifacts({ id })
+  const proof = list[0]
+  if (!proof) {
+    return res.status(404).json({ message: "Proof not found", type: "not_found" })
+  }
+  const updated = await wv.manuallyVerify({
+    proofId: id,
+    verifierId: "admin",
+    method: ProofVerificationMethod.ADMIN_REVIEW,
+  })
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+    await webhooks.dispatch("service.proof.verified", proof.owner_seller_id, {
+      proof_id: id,
+      context_type: proof.context_type,
+      context_id: proof.context_id,
+    })
+  } catch (err) {
+    console.error("[admin/proof/verify] webhook failed", err)
+  }
+  return res.status(200).json({ proof: updated })
+}

--- a/backend/src/api/v1/admin/marketplace/proofs/route.ts
+++ b/backend/src/api/v1/admin/marketplace/proofs/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { WORK_VERIFICATION_MODULE } from "../../../../../modules/work-verification"
+import type WorkVerificationService from "../../../../../modules/work-verification/service"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+  const filter: Record<string, unknown> = {}
+  if (req.query.verification_status)
+    filter.verification_status = req.query.verification_status as string
+  if (req.query.context_type) filter.context_type = req.query.context_type as string
+  if (req.query.context_id) filter.context_id = req.query.context_id as string
+  if (req.query.owner_seller_id)
+    filter.owner_seller_id = req.query.owner_seller_id as string
+
+  const wv = req.scope.resolve<WorkVerificationService>(WORK_VERIFICATION_MODULE)
+  const proofs = await wv.listProofArtifacts(filter, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" } as any,
+  })
+  return res.status(200).json({ proofs, limit, offset })
+}

--- a/backend/src/api/v1/admin/marketplace/reward-pools/[id]/distribute/route.ts
+++ b/backend/src/api/v1/admin/marketplace/reward-pools/[id]/distribute/route.ts
@@ -1,0 +1,104 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CREATOR_REWARDS_MODULE } from "../../../../../../../modules/creator-rewards"
+import type CreatorRewardsService from "../../../../../../../modules/creator-rewards/service"
+import { HAWALA_LEDGER_MODULE } from "../../../../../../../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../../../../../../../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+import {
+  RewardPoolStatus,
+  RewardPayoutStatus,
+} from "../../../../../../../modules/creator-rewards/models"
+
+/**
+ * POST /v1/admin/marketplace/reward-pools/:id/distribute
+ *
+ * Manually trigger pool distribution. Same engine that runs in the
+ * scheduled job — admin can preview (?dry_run=1) or commit.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const dryRun =
+    req.query.dry_run === "1" || req.query.dry_run === "true"
+
+  const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const pools = await rewards.listRewardPools({ id })
+  const pool = pools[0]
+  if (!pool) {
+    return res.status(404).json({ message: "Pool not found", type: "not_found" })
+  }
+  if (
+    pool.status === RewardPoolStatus.DISTRIBUTED ||
+    pool.status === RewardPoolStatus.REVERTED
+  ) {
+    return res.status(409).json({
+      message: `Pool is in terminal status: ${pool.status}`,
+      type: "conflict",
+    })
+  }
+
+  const result = await rewards.calculatePoolDistribution(id)
+  if (dryRun) {
+    return res.status(200).json({ dry_run: true, ...result })
+  }
+
+  const payouts = await rewards.persistDistribution(id, result)
+
+  const hawala = req.scope.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+  const currencyCode = String(pool.currency_code || "usd").toUpperCase()
+  const succeeded: string[] = []
+  for (const payout of payouts) {
+    if (Number(payout.amount_cents) <= 0) continue
+    try {
+      const entry = await hawala.creditCreatorReward({
+        poolId: id,
+        creatorSellerId: payout.creator_seller_id,
+        amountCents: Number(payout.amount_cents),
+        rewardPayoutId: payout.id,
+        currencyCode,
+      })
+      await rewards.markPayoutPaid(payout.id, entry.id)
+      succeeded.push(payout.id)
+    } catch (err) {
+      console.error(
+        `[admin/distribute] payout ${payout.id} failed`,
+        err
+      )
+    }
+  }
+  await rewards.markPoolDistributed(id)
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    if (pool.funder_seller_id) {
+      await webhooks.dispatch("creator.reward.distributed", pool.funder_seller_id, {
+        pool_id: id,
+        program_id: pool.program_id,
+        total_distributed_cents: result.total_distributed_cents,
+        creator_count: succeeded.length,
+      })
+    }
+    for (const payout of payouts) {
+      if (succeeded.includes(payout.id)) {
+        await webhooks.dispatch("creator.reward.distributed", payout.creator_seller_id, {
+          pool_id: id,
+          payout_id: payout.id,
+          amount_cents: Number(payout.amount_cents),
+          qualified_views: Number(payout.qualified_views),
+        })
+      }
+    }
+  } catch (err) {
+    console.error("[admin/distribute] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({
+    pool_id: id,
+    distributed_count: succeeded.length,
+    total_payouts: payouts.length,
+    total_distributed_cents: result.total_distributed_cents,
+  })
+}

--- a/backend/src/api/v1/admin/marketplace/reward-pools/route.ts
+++ b/backend/src/api/v1/admin/marketplace/reward-pools/route.ts
@@ -1,0 +1,29 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CREATOR_REWARDS_MODULE } from "../../../../../modules/creator-rewards"
+import type CreatorRewardsService from "../../../../../modules/creator-rewards/service"
+
+/**
+ * GET /v1/admin/marketplace/reward-pools
+ *
+ * Admin listing of all reward pools across programs. Filters: ?status=,
+ * ?program_id=, ?limit=, ?offset=.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const filter: Record<string, unknown> = {}
+  if (req.query.status) filter.status = req.query.status as string
+  if (req.query.program_id) filter.program_id = req.query.program_id as string
+
+  const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const pools = await rewards.listRewardPools(filter, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" } as any,
+  })
+  return res.status(200).json({ pools, limit, offset })
+}

--- a/backend/src/api/v1/admin/marketplace/service-programs/route.ts
+++ b/backend/src/api/v1/admin/marketplace/service-programs/route.ts
@@ -1,0 +1,31 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../modules/service-program/service"
+
+/**
+ * GET /v1/admin/marketplace/service-programs
+ *
+ * Filters: ?status=, ?vendor_id=, ?service_category=, ?program_type=,
+ *         ?limit=, ?offset=
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+  const filter: Record<string, unknown> = {}
+  if (req.query.status) filter.status = req.query.status as string
+  if (req.query.vendor_id) filter.vendor_id = req.query.vendor_id as string
+  if (req.query.service_category)
+    filter.service_category = req.query.service_category as string
+  if (req.query.program_type) filter.program_type = req.query.program_type as string
+
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const programs = await service.listServicePrograms(filter, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" } as any,
+  })
+  return res.status(200).json({ programs, limit, offset })
+}

--- a/backend/src/api/v1/admin/marketplace/subcontracts/[id]/resolve/route.ts
+++ b/backend/src/api/v1/admin/marketplace/subcontracts/[id]/resolve/route.ts
@@ -1,0 +1,132 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../../../modules/order-subcontract/service"
+import { OrderSubcontractStatus } from "../../../../../../../modules/order-subcontract/models"
+import { HAWALA_LEDGER_MODULE } from "../../../../../../../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../../../../../../../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const Schema = z.object({
+  decision: z.enum(["release", "refund", "split"]),
+  reason: z.string().min(2).max(2000),
+  // For "split": cents to release to service vendor; remainder refunds.
+  release_amount_cents: z.number().int().min(0).max(1_000_000_000_000).optional(),
+})
+
+/**
+ * POST /v1/admin/marketplace/subcontracts/:id/resolve
+ *
+ * Admin resolves a disputed subcontract. Three decisions:
+ *   - release: full escrow → service vendor (matches "accept-delivery" path)
+ *   - refund: full escrow → buyer-vendor
+ *   - split: partial release + partial refund
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const parsed = Schema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid resolve payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const subSvc = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const list = await subSvc.listOrderSubcontracts({ id })
+  const sub = list[0]
+  if (!sub) {
+    return res.status(404).json({ message: "Subcontract not found", type: "not_found" })
+  }
+
+  const total = Number(sub.total_cents)
+  const currency = String(sub.currency_code).toUpperCase()
+  const hawala = req.scope.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+
+  let releaseAmount = 0
+  let refundAmount = 0
+  if (parsed.data.decision === "release") {
+    releaseAmount = total
+  } else if (parsed.data.decision === "refund") {
+    refundAmount = total
+  } else {
+    releaseAmount = Math.max(0, Math.min(total, parsed.data.release_amount_cents ?? 0))
+    refundAmount = total - releaseAmount
+  }
+
+  const ops: { kind: "release" | "refund"; entry_id: string }[] = []
+  try {
+    if (releaseAmount > 0) {
+      const e = await hawala.releaseSubcontractEscrow({
+        subcontractId: id,
+        serviceSellerId: sub.subcontract_seller_id,
+        amountCents: releaseAmount,
+        currencyCode: currency,
+      })
+      ops.push({ kind: "release", entry_id: e.id })
+    }
+    if (refundAmount > 0) {
+      const e = await hawala.refundSubcontractEscrow({
+        subcontractId: id,
+        parentSellerId: sub.parent_seller_id,
+        amountCents: refundAmount,
+        reason: parsed.data.reason,
+        currencyCode: currency,
+      })
+      ops.push({ kind: "refund", entry_id: e.id })
+    }
+  } catch (err) {
+    return res.status(402).json({
+      message: `Escrow operation failed: ${(err as Error).message}`,
+      type: "escrow_failed",
+    })
+  }
+
+  // Status transition
+  let newStatus = OrderSubcontractStatus.CANCELED
+  if (releaseAmount > 0 && refundAmount === 0) {
+    newStatus = OrderSubcontractStatus.ACCEPTED_BY_PARENT
+  }
+  await subSvc.recordEvent({
+    subcontractId: id,
+    eventType: "resolved" as any,
+    note: `${parsed.data.decision}: ${parsed.data.reason}`,
+    metadata: {
+      release_amount_cents: releaseAmount,
+      refund_amount_cents: refundAmount,
+      ledger_entries: ops,
+    },
+  })
+  const finalSub = await (subSvc as any).updateOrderSubcontracts({
+    id,
+    status: newStatus,
+    release_ledger_entry_id:
+      ops.find((o) => o.kind === "release")?.entry_id ?? null,
+  })
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    const payload = {
+      subcontract_id: id,
+      decision: parsed.data.decision,
+      release_amount_cents: releaseAmount,
+      refund_amount_cents: refundAmount,
+      ledger_entries: ops,
+    }
+    await webhooks.dispatch("subcontract.completed", sub.parent_seller_id, payload)
+    await webhooks.dispatch("subcontract.completed", sub.subcontract_seller_id, payload)
+  } catch (err) {
+    console.error("[admin/resolve] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({
+    subcontract: finalSub,
+    release_amount_cents: releaseAmount,
+    refund_amount_cents: refundAmount,
+    ledger_entries: ops,
+  })
+}

--- a/backend/src/api/v1/admin/marketplace/subcontracts/route.ts
+++ b/backend/src/api/v1/admin/marketplace/subcontracts/route.ts
@@ -1,0 +1,25 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../modules/order-subcontract/service"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+  const filter: Record<string, unknown> = {}
+  if (req.query.status) filter.status = req.query.status as string
+  if (req.query.parent_seller_id)
+    filter.parent_seller_id = req.query.parent_seller_id as string
+  if (req.query.subcontract_seller_id)
+    filter.subcontract_seller_id = req.query.subcontract_seller_id as string
+
+  const service = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const subcontracts = await service.listOrderSubcontracts(filter, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" } as any,
+  })
+  return res.status(200).json({ subcontracts, limit, offset })
+}

--- a/backend/src/api/v1/marketplace/attribution/click/route.ts
+++ b/backend/src/api/v1/marketplace/attribution/click/route.ts
@@ -1,0 +1,73 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { createHash } from "crypto"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../modules/creator-attribution/service"
+
+/**
+ * Record a click without redirect. Used by SPA / iframe widgets that can't
+ * invoke the /r/:shortCode redirector (e.g. a shoppable widget embedded in
+ * Blackout where the link clicks happen client-side).
+ *
+ * The caller MUST send a `visitor_token` it has already minted (matching the
+ * `_fbm_visitor` cookie pattern); the server only validates the short code.
+ */
+
+const ClickSchema = z.object({
+  short_code: z.string().min(3).max(64),
+  visitor_token: z.string().min(8).max(128),
+  referrer: z.string().max(2048).optional().nullable(),
+  fingerprint: z.string().max(128).optional().nullable(),
+})
+
+function hashIp(ip: string | null | undefined): string | null {
+  if (!ip) return null
+  const salt = process.env.CREATOR_ATTRIBUTION_IP_SALT || ""
+  return createHash("sha256").update(`${salt}:${ip}`).digest("hex").slice(0, 32)
+}
+
+function hashUserAgent(ua: string | null | undefined): string | null {
+  if (!ua) return null
+  return createHash("sha256").update(ua).digest("hex").slice(0, 32)
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const parsed = ClickSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid click payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const ip =
+    (req.headers["x-forwarded-for"] as string | undefined)?.split(",")[0]?.trim() ||
+    req.socket.remoteAddress ||
+    null
+  const ua = (req.headers["user-agent"] as string | undefined) || null
+
+  try {
+    const event = await service.recordClick({
+      shortCode: parsed.data.short_code,
+      visitorToken: parsed.data.visitor_token,
+      ipHash: hashIp(ip),
+      userAgentHash: hashUserAgent(ua),
+      referrer: parsed.data.referrer ?? null,
+      fingerprint: parsed.data.fingerprint ?? null,
+    })
+    return res.status(201).json({
+      click_event_id: event.id,
+      occurred_at: event.occurred_at,
+    })
+  } catch (err) {
+    return res.status(404).json({
+      message: (err as Error).message,
+      type: "not_found",
+    })
+  }
+}

--- a/backend/src/api/v1/marketplace/creators/[handle]/route.ts
+++ b/backend/src/api/v1/marketplace/creators/[handle]/route.ts
@@ -1,0 +1,53 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { SELLER_EXTENSION_MODULE } from "../../../../../modules/seller-extension"
+
+/**
+ * Public creator profile endpoint.
+ *
+ * GET /v1/marketplace/creators/:handle
+ *
+ * Returns the creator's public profile (handle, bio, niches, follower count,
+ * social links). Used by the storefront `/creators/[handle]` page and by
+ * external content platforms (Blackout, etc.) to display embedded creator info.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const handle = (req.params as { handle?: string })?.handle
+  if (!handle) {
+    return res.status(400).json({
+      message: "Missing creator handle",
+      type: "invalid_request",
+    })
+  }
+
+  const service = req.scope.resolve<any>(SELLER_EXTENSION_MODULE)
+
+  const matches = await service.listSellerMetadata({
+    creator_handle: handle,
+    vendor_type: "creator",
+  })
+
+  if (!matches || matches.length === 0) {
+    return res.status(404).json({
+      message: "Creator not found",
+      type: "not_found",
+    })
+  }
+
+  const m = matches[0]
+
+  return res.status(200).json({
+    creator: {
+      seller_id: m.seller_id,
+      handle: m.creator_handle,
+      bio: m.creator_bio,
+      niches: m.creator_niches ?? [],
+      total_followers: Number(m.creator_total_followers ?? 0),
+      audience_geo: m.creator_audience_geo ?? null,
+      social_links: m.social_links ?? null,
+      verified: !!m.verified,
+      featured: !!m.featured,
+      rating: m.rating ?? null,
+      review_count: Number(m.review_count ?? 0),
+    },
+  })
+}

--- a/backend/src/api/v1/marketplace/programs/[id]/route.ts
+++ b/backend/src/api/v1/marketplace/programs/[id]/route.ts
@@ -1,0 +1,25 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../modules/creator-program/service"
+import { CreatorProgramStatus } from "../../../../../modules/creator-program/models"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const list = await service.listCreatorPrograms({ id })
+  const program = list[0]
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+
+  // Don't surface drafts publicly
+  if (program.status === CreatorProgramStatus.DRAFT) {
+    return res.status(404).json({ message: "Program not available", type: "not_found" })
+  }
+
+  return res.status(200).json({ program })
+}

--- a/backend/src/api/v1/marketplace/programs/route.ts
+++ b/backend/src/api/v1/marketplace/programs/route.ts
@@ -1,0 +1,71 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CREATOR_PROGRAM_MODULE } from "../../../../modules/creator-program"
+import CreatorProgramService from "../../../../modules/creator-program/service"
+import {
+  CreatorProgramType,
+  CreatorProgramStatus,
+} from "../../../../modules/creator-program/models"
+
+/**
+ * GET /v1/marketplace/programs
+ *
+ * Public discovery of `affiliate_open` and `engagement_pool` programs that
+ * any creator can apply to. Filters: `?vendor_id=`, `?program_type=`,
+ * `?product_id=`. Used by the storefront and Creator Studio "Find programs"
+ * tab.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const programType = req.query.program_type as string | undefined
+  const vendorId = req.query.vendor_id as string | undefined
+  const productId = req.query.product_id as string | undefined
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+
+  const open = await service.listOpenPrograms({
+    vendorId,
+    programType: programType as CreatorProgramType | undefined,
+    productId,
+  })
+
+  // Only surface open-application program types in public listing
+  const filtered = open.filter(
+    (p: any) =>
+      p.program_type === CreatorProgramType.AFFILIATE_OPEN ||
+      p.program_type === CreatorProgramType.ENGAGEMENT_POOL ||
+      p.program_type === CreatorProgramType.COMMISSION_BOOST
+  )
+
+  const slice = filtered.slice(offset, offset + limit)
+
+  return res.status(200).json({
+    programs: slice.map((p: any) => ({
+      id: p.id,
+      vendor_id: p.vendor_id,
+      title: p.title,
+      slug: p.slug,
+      description: p.description,
+      program_type: p.program_type,
+      commission_percent: p.commission_percent,
+      commission_flat_cents: p.commission_flat_cents,
+      sponsorship_flat_cents: p.sponsorship_flat_cents,
+      pool_total_cents: p.pool_total_cents,
+      pool_period: p.pool_period,
+      cookie_window_days: p.cookie_window_days,
+      currency_code: p.currency_code,
+      starts_at: p.starts_at,
+      ends_at: p.ends_at,
+      requires_kyc: p.requires_kyc,
+      min_followers: p.min_followers,
+      product_ids: p.product_ids ?? [],
+    })),
+    limit,
+    offset,
+    total: filtered.length,
+  })
+}

--- a/backend/src/api/v1/marketplace/services/route.ts
+++ b/backend/src/api/v1/marketplace/services/route.ts
@@ -1,0 +1,68 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { SERVICE_PROGRAM_MODULE } from "../../../../modules/service-program"
+import type ServiceProgramService from "../../../../modules/service-program/service"
+import {
+  ServiceCategory,
+  ServiceProgramType,
+} from "../../../../modules/service-program/models"
+
+/**
+ * GET /v1/marketplace/services
+ *
+ * Public discovery of open service-marketplace bounties. Filters:
+ *   ?service_category=apparel_press
+ *   ?program_type=bounty_open|bounty_invite|fixed_contract|throughput_pool
+ *   ?vendor_id=
+ *   ?limit=&offset=
+ *
+ * Only `bounty_open` and `throughput_pool` programs are surfaced — others
+ * are invite- or contract-only.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const limit = Math.min(
+    Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1),
+    200
+  )
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+
+  const open = await service.listOpenPrograms({
+    serviceCategory: req.query.service_category as ServiceCategory | undefined,
+    programType: req.query.program_type as ServiceProgramType | undefined,
+    vendorId: req.query.vendor_id as string | undefined,
+  })
+
+  const filtered = open.filter(
+    (p: any) =>
+      p.program_type === ServiceProgramType.BOUNTY_OPEN ||
+      p.program_type === ServiceProgramType.THROUGHPUT_POOL
+  )
+
+  const slice = filtered.slice(offset, offset + limit)
+
+  return res.status(200).json({
+    programs: slice.map((p: any) => ({
+      id: p.id,
+      vendor_id: p.vendor_id,
+      title: p.title,
+      slug: p.slug,
+      description: p.description,
+      service_category: p.service_category,
+      program_type: p.program_type,
+      pricing_model: p.pricing_model,
+      unit_price_cents: p.unit_price_cents,
+      hourly_rate_cents: p.hourly_rate_cents,
+      flat_price_cents: p.flat_price_cents,
+      pool_total_cents: p.pool_total_cents,
+      currency_code: p.currency_code,
+      min_units: p.min_units,
+      max_units: p.max_units,
+      deadline_at: p.deadline_at,
+      requires_kyc: p.requires_kyc,
+    })),
+    limit,
+    offset,
+    total: filtered.length,
+  })
+}

--- a/backend/src/api/v1/seller/creator/deals/route.ts
+++ b/backend/src/api/v1/seller/creator/deals/route.ts
@@ -1,0 +1,33 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../modules/creator-program/service"
+
+/**
+ * GET /v1/seller/creator/deals
+ *
+ * List active and historical deals for the authenticated creator.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const deals = await service.listCreatorDeals({ creator_seller_id: sellerId })
+
+  // Hydrate each deal with program title for nicer display
+  const programIds = Array.from(new Set(deals.map((d: any) => d.program_id)))
+  const programs = programIds.length
+    ? await service.listCreatorPrograms({ id: programIds })
+    : []
+  const programById = new Map(programs.map((p: any) => [p.id, p]))
+
+  return res.status(200).json({
+    deals: deals.map((d: any) => ({
+      ...d,
+      program_title: programById.get(d.program_id)?.title ?? null,
+    })),
+  })
+}

--- a/backend/src/api/v1/seller/creator/earnings/route.ts
+++ b/backend/src/api/v1/seller/creator/earnings/route.ts
@@ -1,0 +1,47 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../modules/creator-attribution/service"
+
+/**
+ * GET /v1/seller/creator/earnings
+ *   ?from=ISO8601&to=ISO8601&limit=N&offset=N
+ *
+ * Returns rollup totals plus the most recent attribution rows for drill-down.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const fromParam = req.query.from as string | undefined
+  const toParam = req.query.to as string | undefined
+  const from = fromParam ? new Date(fromParam) : undefined
+  const to = toParam ? new Date(toParam) : undefined
+  if ((from && isNaN(from.getTime())) || (to && isNaN(to.getTime()))) {
+    return res.status(400).json({ message: "Invalid date range", type: "invalid_request" })
+  }
+
+  const limit = Math.min(Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1), 200)
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const [rollup, attributions] = await Promise.all([
+    service.creatorEarningsRollup(sellerId, { from, to }),
+    service.listOrderAttributions(
+      { creator_seller_id: sellerId },
+      { take: limit, skip: offset, order: { attribution_decided_at: "DESC" } as any }
+    ),
+  ])
+
+  return res.status(200).json({
+    rollup,
+    attributions,
+    limit,
+    offset,
+  })
+}

--- a/backend/src/api/v1/seller/creator/links/[id]/route.ts
+++ b/backend/src/api/v1/seller/creator/links/[id]/route.ts
@@ -1,0 +1,69 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../../modules/creator-attribution/service"
+import { AffiliateLinkStatus } from "../../../../../../modules/creator-attribution/models"
+
+const UpdateLinkSchema = z.object({
+  status: z.nativeEnum(AffiliateLinkStatus).optional(),
+  utm_medium: z.string().min(1).max(64).optional().nullable(),
+  utm_campaign: z.string().min(1).max(128).optional().nullable(),
+  utm_content: z.string().min(1).max(128).optional().nullable(),
+})
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const linkId = (req.params as { id?: string })?.id
+  if (!linkId) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+  const links = await service.listAffiliateLinks({ id: linkId, creator_seller_id: sellerId })
+  if (links.length === 0) {
+    return res.status(404).json({ message: "Link not found", type: "not_found" })
+  }
+  return res.status(200).json({ link: links[0] })
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const linkId = (req.params as { id?: string })?.id
+  if (!linkId) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+
+  const parsed = UpdateLinkSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid update",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+  const links = await service.listAffiliateLinks({ id: linkId, creator_seller_id: sellerId })
+  if (links.length === 0) {
+    return res.status(404).json({ message: "Link not found", type: "not_found" })
+  }
+
+  const updated = await (service as any).updateAffiliateLinks({
+    id: linkId,
+    ...parsed.data,
+  })
+  return res.status(200).json({ link: updated })
+}

--- a/backend/src/api/v1/seller/creator/links/route.ts
+++ b/backend/src/api/v1/seller/creator/links/route.ts
@@ -1,0 +1,79 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../modules/creator-attribution/service"
+
+const CreateLinkSchema = z.object({
+  product_id: z.string().min(1).max(128).optional().nullable(),
+  collection_id: z.string().min(1).max(128).optional().nullable(),
+  destination_path: z.string().min(1).max(2048).optional(),
+  utm_medium: z.string().min(1).max(64).optional().nullable(),
+  utm_campaign: z.string().min(1).max(128).optional().nullable(),
+  utm_content: z.string().min(1).max(128).optional().nullable(),
+  deal_id: z.string().min(1).max(64).optional().nullable(),
+  program_id: z.string().min(1).max(64).optional().nullable(),
+  vendor_id: z.string().min(1).max(64).optional().nullable(),
+  allowed_origins: z.array(z.string().url()).max(16).optional().nullable(),
+})
+
+/**
+ * GET /v1/seller/creator/links — list this creator's affiliate links.
+ * POST /v1/seller/creator/links — generate a new affiliate link.
+ */
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const limit = Math.min(Math.max(parseInt((req.query.limit as string) || "50", 10) || 50, 1), 200)
+  const offset = Math.max(parseInt((req.query.offset as string) || "0", 10) || 0, 0)
+
+  const links = await service.listAffiliateLinks(
+    { creator_seller_id: sellerId },
+    { take: limit, skip: offset, order: { created_at: "DESC" } as any }
+  )
+  return res.status(200).json({ links, limit, offset })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const parsed = CreateLinkSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid link payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const link = await service.generateLink({
+    creatorSellerId: sellerId,
+    productId: parsed.data.product_id ?? null,
+    collectionId: parsed.data.collection_id ?? null,
+    destinationPath: parsed.data.destination_path,
+    utmMedium: parsed.data.utm_medium ?? null,
+    utmCampaign: parsed.data.utm_campaign ?? null,
+    utmContent: parsed.data.utm_content ?? null,
+    dealId: parsed.data.deal_id ?? null,
+    programId: parsed.data.program_id ?? null,
+    vendorId: parsed.data.vendor_id ?? null,
+    allowedOrigins: parsed.data.allowed_origins ?? null,
+  })
+
+  return res.status(201).json({ link })
+}

--- a/backend/src/api/v1/seller/creator/platform-accounts/[id]/route.ts
+++ b/backend/src/api/v1/seller/creator/platform-accounts/[id]/route.ts
@@ -1,0 +1,22 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CONTENT_PLATFORM_MODULE } from "../../../../../../modules/content-platform"
+import type ContentPlatformService from "../../../../../../modules/content-platform/service"
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const cp = req.scope.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+  const accounts = await cp.listPlatformAccounts({ id, creator_seller_id: sellerId })
+  if (accounts.length === 0) {
+    return res.status(404).json({ message: "Account not found", type: "not_found" })
+  }
+  const updated = await cp.revokeAccount(id)
+  return res.status(200).json({ account: updated })
+}

--- a/backend/src/api/v1/seller/creator/platform-accounts/connect/route.ts
+++ b/backend/src/api/v1/seller/creator/platform-accounts/connect/route.ts
@@ -1,0 +1,56 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CONTENT_PLATFORM_MODULE } from "../../../../../../modules/content-platform"
+import type ContentPlatformService from "../../../../../../modules/content-platform/service"
+import type { ContentPlatform } from "../../../../../../modules/content-platform/providers/types"
+
+const Schema = z.object({
+  platform: z.enum(["tiktok", "instagram", "youtube", "twitch", "blackout"]),
+  redirect_uri: z.string().url(),
+})
+
+/**
+ * POST /v1/seller/creator/platform-accounts/connect
+ *
+ * Begin OAuth for an OAuth-based platform. Returns the auth URL and a
+ * `state` value the client should set as a short-lived cookie before
+ * redirecting; the matching callback endpoint will round-trip it.
+ *
+ * Non-OAuth platforms (rss, custom, podcast) should use POST
+ * /v1/seller/creator/platform-accounts directly.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = Schema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid connect payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const cp = req.scope.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+  if (!cp.hasProvider(parsed.data.platform as ContentPlatform)) {
+    return res.status(404).json({
+      message: `Platform ${parsed.data.platform} is not enabled on this deployment`,
+      type: "platform_disabled",
+    })
+  }
+  try {
+    const result = await cp.startOAuth({
+      creatorSellerId: sellerId,
+      platform: parsed.data.platform as ContentPlatform,
+      redirectUri: parsed.data.redirect_uri,
+    })
+    return res.status(200).json(result)
+  } catch (err) {
+    return res.status(400).json({
+      message: (err as Error).message,
+      type: "provider_error",
+    })
+  }
+}

--- a/backend/src/api/v1/seller/creator/platform-accounts/route.ts
+++ b/backend/src/api/v1/seller/creator/platform-accounts/route.ts
@@ -1,0 +1,89 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CONTENT_PLATFORM_MODULE } from "../../../../../modules/content-platform"
+import type ContentPlatformService from "../../../../../modules/content-platform/service"
+import type { ContentPlatform } from "../../../../../modules/content-platform/providers/types"
+
+const PLATFORMS = [
+  "tiktok",
+  "instagram",
+  "youtube",
+  "twitch",
+  "blackout",
+  "rss",
+  "podcast",
+  "custom",
+] as const
+
+const ConnectNonOAuthSchema = z.object({
+  platform: z.enum(PLATFORMS),
+  external_account_id: z.string().min(1).max(256),
+  handle: z.string().min(1).max(128).optional().nullable(),
+  metadata: z.record(z.unknown()).optional().nullable(),
+})
+
+/**
+ * GET /v1/seller/creator/platform-accounts
+ *   List the creator's connected platform accounts.
+ *
+ * POST /v1/seller/creator/platform-accounts
+ *   Connect a non-OAuth platform (rss, custom, podcast). For OAuth-based
+ *   platforms (tiktok/instagram/youtube/twitch/blackout) use the
+ *   /connect endpoint instead.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const cp = req.scope.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+  const accounts = await cp.listPlatformAccounts({ creator_seller_id: sellerId })
+  // Don't leak encrypted tokens to the client.
+  return res.status(200).json({
+    accounts: accounts.map((a: any) => ({
+      id: a.id,
+      platform: a.platform,
+      external_account_id: a.external_account_id,
+      handle: a.handle,
+      display_name: a.display_name,
+      avatar_url: a.avatar_url,
+      follower_count: Number(a.follower_count ?? 0),
+      status: a.status,
+      last_synced_at: a.last_synced_at,
+      inbound_webhook_secret: a.inbound_webhook_secret,
+      metadata: a.metadata,
+    })),
+    available_platforms: cp.listAvailablePlatforms(),
+  })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = ConnectNonOAuthSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid connect payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const cp = req.scope.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+  if (!cp.hasProvider(parsed.data.platform as ContentPlatform)) {
+    return res.status(404).json({
+      message: `Platform ${parsed.data.platform} is not enabled on this deployment`,
+      type: "platform_disabled",
+    })
+  }
+  const account = await cp.connectNonOAuth({
+    creatorSellerId: sellerId,
+    platform: parsed.data.platform as ContentPlatform,
+    externalAccountId: parsed.data.external_account_id,
+    handle: parsed.data.handle ?? null,
+    metadata: (parsed.data.metadata as Record<string, unknown> | null) ?? undefined,
+  })
+  return res.status(201).json({ account })
+}

--- a/backend/src/api/v1/seller/creator/posts/route.ts
+++ b/backend/src/api/v1/seller/creator/posts/route.ts
@@ -1,0 +1,116 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_REWARDS_MODULE } from "../../../../../modules/creator-rewards"
+import type CreatorRewardsService from "../../../../../modules/creator-rewards/service"
+import { CONTENT_PLATFORM_MODULE } from "../../../../../modules/content-platform"
+import type ContentPlatformService from "../../../../../modules/content-platform/service"
+import type { ContentPlatform } from "../../../../../modules/content-platform/providers/types"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../modules/marketplace-webhooks/service"
+
+const PLATFORMS = [
+  "tiktok",
+  "instagram",
+  "youtube",
+  "twitch",
+  "blackout",
+  "rss",
+  "podcast",
+  "custom",
+] as const
+
+const RegisterSchema = z.object({
+  platform: z.enum(PLATFORMS),
+  external_post_id: z.string().min(1).max(256),
+  external_url: z.string().url(),
+  caption: z.string().max(4000).optional().nullable(),
+  thumbnail_url: z.string().url().optional().nullable(),
+  affiliate_link_id: z.string().min(1).max(64).optional().nullable(),
+  deal_id: z.string().min(1).max(64).optional().nullable(),
+  program_id: z.string().min(1).max(64).optional().nullable(),
+})
+
+/**
+ * GET /v1/seller/creator/posts — list this creator's registered posts.
+ * POST /v1/seller/creator/posts — register a new post. Best-effort
+ * ownership verification is attempted via the matching content-platform
+ * adapter; if it succeeds, the post is auto-marked verified.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const posts = await rewards.listContentPosts({ creator_seller_id: sellerId })
+  return res.status(200).json({ posts })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = RegisterSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid post payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+
+  let post = await rewards.registerPost({
+    creatorSellerId: sellerId,
+    platform: parsed.data.platform,
+    externalPostId: parsed.data.external_post_id,
+    externalUrl: parsed.data.external_url,
+    caption: parsed.data.caption ?? null,
+    thumbnailUrl: parsed.data.thumbnail_url ?? null,
+    affiliateLinkId: parsed.data.affiliate_link_id ?? null,
+    dealId: parsed.data.deal_id ?? null,
+    programId: parsed.data.program_id ?? null,
+  })
+
+  // Best-effort ownership verification.
+  try {
+    const cp = req.scope.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+    if (cp.hasProvider(parsed.data.platform as ContentPlatform)) {
+      const ok = await cp.verifyPostOwnership({
+        platform: parsed.data.platform as ContentPlatform,
+        creatorSellerId: sellerId,
+        externalPostId: parsed.data.external_post_id,
+      })
+      if (ok) {
+        post = await rewards.verifyPost(post.id, "oauth")
+      }
+    }
+  } catch (err) {
+    console.error("[posts/register] verifyPostOwnership failed", err)
+  }
+
+  // Best-effort webhook
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    await webhooks.dispatch("creator.post.registered", sellerId, {
+      post_id: post.id,
+      platform: parsed.data.platform,
+      external_post_id: parsed.data.external_post_id,
+      external_url: parsed.data.external_url,
+      verification_status: post.verification_status,
+    })
+    if (post.verification_status === "verified") {
+      await webhooks.dispatch("creator.post.verified", sellerId, {
+        post_id: post.id,
+        platform: parsed.data.platform,
+        external_post_id: parsed.data.external_post_id,
+      })
+    }
+  } catch (err) {
+    console.error("[posts/register] webhook dispatch failed", err)
+  }
+
+  return res.status(201).json({ post })
+}

--- a/backend/src/api/v1/seller/creator/programs/[id]/apply/route.ts
+++ b/backend/src/api/v1/seller/creator/programs/[id]/apply/route.ts
@@ -1,0 +1,104 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../../modules/creator-program/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const ApplySchema = z.object({
+  pitch: z.string().max(4000).optional().nullable(),
+  proposed_platforms: z.array(z.string().max(64)).max(8).optional().nullable(),
+  follower_snapshot: z
+    .record(z.string().max(32), z.number().int().nonnegative().max(2_000_000_000))
+    .optional()
+    .nullable(),
+})
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+
+  const parsed = ApplySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid application payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  let webhooks: MarketplaceWebhooksService | null = null
+  try {
+    webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+  } catch {
+    webhooks = null
+  }
+
+  try {
+    const application = await service.applyToProgram({
+      programId,
+      creatorSellerId: sellerId,
+      pitch: parsed.data.pitch ?? null,
+      proposedPlatforms: parsed.data.proposed_platforms ?? null,
+      followerSnapshot: parsed.data.follower_snapshot ?? null,
+    })
+
+    if (webhooks) {
+      const programs = await service.listCreatorPrograms({ id: programId })
+      const program = programs[0]
+      if (program) {
+        try {
+          await webhooks.dispatch("creator.application.submitted", program.vendor_id, {
+            application_id: application.id,
+            program_id: programId,
+            creator_seller_id: sellerId,
+          })
+        } catch (err) {
+          console.error("[apply] webhook dispatch failed", err)
+        }
+      }
+    }
+
+    return res.status(201).json({ application })
+  } catch (err) {
+    return res.status(409).json({
+      message: (err as Error).message,
+      type: "conflict",
+    })
+  }
+}
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const apps = await service.listCreatorApplications({
+    program_id: programId,
+    creator_seller_id: sellerId,
+  })
+  const app = apps[0]
+  if (!app) {
+    return res.status(404).json({ message: "Application not found", type: "not_found" })
+  }
+  try {
+    const updated = await service.withdrawApplication(app.id, sellerId)
+    return res.status(200).json({ application: updated })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+}

--- a/backend/src/api/v1/seller/creator/programs/route.ts
+++ b/backend/src/api/v1/seller/creator/programs/route.ts
@@ -1,0 +1,60 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../modules/creator-program/service"
+import {
+  CreatorProgramType,
+  CreatorProgramStatus,
+} from "../../../../../modules/creator-program/models"
+
+/**
+ * GET /v1/seller/creator/programs
+ *
+ * Lists programs visible to this creator: open public programs + programs
+ * the creator has already applied to (regardless of decision) + active
+ * deals. Frontend can split into tabs.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+
+  const [openPrograms, myApplications, myDeals] = await Promise.all([
+    service.listOpenPrograms(),
+    service.listCreatorApplications({ creator_seller_id: sellerId }),
+    service.listCreatorDeals({ creator_seller_id: sellerId }),
+  ])
+
+  const appProgramIds = new Set(myApplications.map((a: any) => a.program_id))
+
+  return res.status(200).json({
+    open: openPrograms
+      .filter(
+        (p: any) =>
+          (p.program_type === CreatorProgramType.AFFILIATE_OPEN ||
+            p.program_type === CreatorProgramType.ENGAGEMENT_POOL ||
+            p.program_type === CreatorProgramType.COMMISSION_BOOST) &&
+          !appProgramIds.has(p.id)
+      )
+      .map((p: any) => ({
+        id: p.id,
+        vendor_id: p.vendor_id,
+        title: p.title,
+        program_type: p.program_type,
+        commission_percent: p.commission_percent,
+        commission_flat_cents: p.commission_flat_cents,
+        sponsorship_flat_cents: p.sponsorship_flat_cents,
+        pool_total_cents: p.pool_total_cents,
+        cookie_window_days: p.cookie_window_days,
+        currency_code: p.currency_code,
+        requires_kyc: p.requires_kyc,
+        min_followers: p.min_followers,
+        ends_at: p.ends_at,
+      })),
+    applications: myApplications,
+    deals: myDeals,
+  })
+}

--- a/backend/src/api/v1/seller/creator/promo-codes/route.ts
+++ b/backend/src/api/v1/seller/creator/promo-codes/route.ts
@@ -1,0 +1,70 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../modules/creator-attribution"
+import CreatorAttributionService from "../../../../../modules/creator-attribution/service"
+
+const BindSchema = z.object({
+  promotion_id: z.string().min(1).max(128),
+  promotion_code: z.string().min(2).max(64),
+  deal_id: z.string().min(1).max(64).optional().nullable(),
+  program_id: z.string().min(1).max(64).optional().nullable(),
+  vendor_id: z.string().min(1).max(64).optional().nullable(),
+})
+
+/**
+ * GET /v1/seller/creator/promo-codes — list this creator's bound promo codes.
+ * POST /v1/seller/creator/promo-codes — bind an existing Medusa promotion code
+ * to this creator. When a customer applies the code at checkout, the
+ * resulting order will be attributed to this creator.
+ *
+ * Note: ownership of the underlying Medusa promotion is enforced upstream by
+ * the vendor that created it; this binding is creator-scoped so the *same*
+ * promotion can be marketed by multiple creators only if each is given a
+ * distinct code (which is what unique constraint on `promotion_code` enforces).
+ */
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const bindings = await service.listPromoCodeBindings({ creator_seller_id: sellerId })
+  return res.status(200).json({ bindings })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const parsed = BindSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid binding payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  const binding = await service.bindPromoCode({
+    promotionId: parsed.data.promotion_id,
+    promotionCode: parsed.data.promotion_code,
+    creatorSellerId: sellerId,
+    dealId: parsed.data.deal_id ?? null,
+    programId: parsed.data.program_id ?? null,
+    vendorId: parsed.data.vendor_id ?? null,
+  })
+
+  return res.status(201).json({ binding })
+}

--- a/backend/src/api/v1/seller/programs/[id]/applications/[appId]/decide/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/applications/[appId]/decide/route.ts
@@ -1,0 +1,176 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../../../modules/creator-program/service"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../../../../modules/creator-attribution"
+import type CreatorAttributionService from "../../../../../../../../modules/creator-attribution/service"
+import { VENDOR_VERIFICATION_MODULE } from "../../../../../../../../modules/vendor-verification"
+import { VerificationLevel } from "../../../../../../../../modules/vendor-verification/models/verification"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../../modules/marketplace-webhooks/service"
+
+const DecideSchema = z.object({
+  decision: z.enum(["approve", "reject"]),
+  reason: z.string().max(2000).optional().nullable(),
+})
+
+const LEVEL_RANK: Record<string, number> = {
+  UNVERIFIED: 0,
+  SELF_REPORTED: 1,
+  VERIFIED: 2,
+  AUDITED: 3,
+  CERTIFIED: 4,
+}
+
+/**
+ * POST /v1/seller/programs/:id/applications/:appId/decide
+ *
+ * The vendor approves or rejects a creator's application. On approval:
+ *   1. KYC gating runs against the program's `min_verification_level` if
+ *      `requires_kyc` is true. Block with 412 if the creator falls short.
+ *   2. The application transitions to `approved`.
+ *   3. A `CreatorDeal` is opened with a frozen `terms_snapshot`.
+ *   4. A default `AffiliateLink` is auto-generated and back-referenced on the
+ *      deal so the creator has an immediately shareable URL.
+ *   5. `creator.deal.opened` webhook is dispatched to both vendor and creator.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  const appId = (req.params as { appId?: string })?.appId
+  if (!programId || !appId) {
+    return res.status(400).json({ message: "Missing ids", type: "invalid_request" })
+  }
+
+  const parsed = DecideSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid decide payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const programService = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+
+  // Ownership check: this vendor must own the program.
+  const programs = await programService.listCreatorPrograms({
+    id: programId,
+    vendor_id: sellerId,
+  })
+  const program = programs[0]
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+
+  const apps = await programService.listCreatorApplications({
+    id: appId,
+    program_id: programId,
+  })
+  const application = apps[0]
+  if (!application) {
+    return res.status(404).json({ message: "Application not found", type: "not_found" })
+  }
+
+  // KYC gate (only on approval)
+  if (parsed.data.decision === "approve" && program.requires_kyc) {
+    try {
+      const verificationSvc = req.scope.resolve<any>(VENDOR_VERIFICATION_MODULE)
+      const verification = await verificationSvc.getOrCreateVerification(
+        application.creator_seller_id
+      )
+      const required = program.min_verification_level ?? VerificationLevel.VERIFIED
+      const requiredRank = LEVEL_RANK[required] ?? LEVEL_RANK.VERIFIED
+      const actualRank = LEVEL_RANK[verification.level] ?? LEVEL_RANK.UNVERIFIED
+      if (actualRank < requiredRank) {
+        return res.status(412).json({
+          message: `Creator KYC level (${verification.level}) below required (${required})`,
+          type: "kyc_insufficient",
+          creator_level: verification.level,
+          required_level: required,
+        })
+      }
+    } catch (err) {
+      console.error("[program/decide] KYC check failed", err)
+      return res.status(500).json({
+        message: "KYC verification check failed",
+        type: "kyc_check_failed",
+      })
+    }
+  }
+
+  let updatedApp
+  try {
+    updatedApp = await programService.decideApplication({
+      applicationId: appId,
+      decision: parsed.data.decision,
+      decidedBy: sellerId,
+      reason: parsed.data.reason ?? null,
+    })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+
+  let deal: any | null = null
+  if (parsed.data.decision === "approve") {
+    deal = await programService.openDealForApprovedApp(appId)
+
+    // Auto-generate the default affiliate link for the creator.
+    try {
+      const attributionSvc = req.scope.resolve<CreatorAttributionService>(
+        CREATOR_ATTRIBUTION_MODULE
+      )
+      const productIds = Array.isArray(program.product_ids) ? program.product_ids : []
+      const link = (await attributionSvc.generateLink({
+        creatorSellerId: application.creator_seller_id,
+        vendorId: sellerId,
+        dealId: deal.id,
+        programId: programId,
+        productId: productIds.length === 1 ? productIds[0] : null,
+        utmCampaign: program.slug,
+      })) as any
+      deal = await programService.attachDefaultLinkToDeal(deal.id, link.id)
+    } catch (err) {
+      console.error("[program/decide] auto-link generation failed", err)
+    }
+
+    try {
+      const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+      const payload = {
+        deal_id: deal.id,
+        program_id: programId,
+        application_id: appId,
+        creator_seller_id: application.creator_seller_id,
+        vendor_id: sellerId,
+        terms_snapshot: deal.terms_snapshot,
+        default_affiliate_link_id: deal.default_affiliate_link_id ?? null,
+      }
+      await webhooks.dispatch("creator.deal.opened", sellerId, payload)
+      await webhooks.dispatch("creator.deal.opened", application.creator_seller_id, payload)
+      await webhooks.dispatch("creator.application.approved", application.creator_seller_id, {
+        application_id: appId,
+        program_id: programId,
+        deal_id: deal.id,
+      })
+    } catch (err) {
+      console.error("[program/decide] webhook dispatch failed", err)
+    }
+  } else {
+    try {
+      const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+      await webhooks.dispatch("creator.application.rejected", application.creator_seller_id, {
+        application_id: appId,
+        program_id: programId,
+        reason: parsed.data.reason ?? null,
+      })
+    } catch (err) {
+      console.error("[program/decide] reject webhook dispatch failed", err)
+    }
+  }
+
+  return res.status(200).json({ application: updatedApp, deal })
+}

--- a/backend/src/api/v1/seller/programs/[id]/applications/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/applications/route.ts
@@ -1,0 +1,33 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../modules/creator-program/service"
+
+/**
+ * GET /v1/seller/programs/:id/applications
+ *
+ * List applications for one of this vendor's programs. Supports
+ * `?status=pending|approved|rejected|withdrawn` filter.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const list = await service.listCreatorPrograms({ id: programId, vendor_id: sellerId })
+  if (list.length === 0) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+
+  const filter: Record<string, unknown> = { program_id: programId }
+  if (req.query.status) filter.status = req.query.status as string
+
+  const applications = await service.listCreatorApplications(filter)
+  return res.status(200).json({ applications })
+}

--- a/backend/src/api/v1/seller/programs/[id]/deals/[dealId]/violate/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/deals/[dealId]/violate/route.ts
@@ -1,0 +1,93 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../../../modules/creator-program/service"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../../../../modules/creator-attribution"
+import type CreatorAttributionService from "../../../../../../../../modules/creator-attribution/service"
+import { AffiliateLinkStatus } from "../../../../../../../../modules/creator-attribution/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../../modules/marketplace-webhooks/service"
+
+const ViolateSchema = z.object({
+  reason: z.string().min(2).max(2000),
+  pause_links: z.boolean().optional(),
+})
+
+/**
+ * POST /v1/seller/programs/:id/deals/:dealId/violate
+ *
+ * Vendor flags a creator deal as violated (e.g. brand-safety violation).
+ * Optionally pauses all affiliate links generated under this deal so no
+ * further attributions can land. Held attributions can still be reviewed
+ * via admin moderation.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  const dealId = (req.params as { dealId?: string })?.dealId
+  if (!programId || !dealId) {
+    return res.status(400).json({ message: "Missing ids", type: "invalid_request" })
+  }
+  const parsed = ViolateSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid violate payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+
+  // Ownership check
+  const programs = await service.listCreatorPrograms({ id: programId, vendor_id: sellerId })
+  if (programs.length === 0) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const deals = await service.listCreatorDeals({ id: dealId, program_id: programId })
+  const deal = deals[0]
+  if (!deal) {
+    return res.status(404).json({ message: "Deal not found", type: "not_found" })
+  }
+
+  const updated = await service.violateDeal(dealId, parsed.data.reason)
+
+  if (parsed.data.pause_links) {
+    try {
+      const attributionSvc = req.scope.resolve<CreatorAttributionService>(
+        CREATOR_ATTRIBUTION_MODULE
+      )
+      const links = await attributionSvc.listAffiliateLinks({ deal_id: dealId })
+      for (const l of links) {
+        await (attributionSvc as any).updateAffiliateLinks({
+          id: l.id,
+          status: AffiliateLinkStatus.PAUSED,
+        })
+      }
+    } catch (err) {
+      console.error("[deal/violate] failed to pause links", err)
+    }
+  }
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    const payload = {
+      deal_id: dealId,
+      program_id: programId,
+      vendor_id: sellerId,
+      creator_seller_id: deal.creator_seller_id,
+      reason: parsed.data.reason,
+      paused_links: !!parsed.data.pause_links,
+    }
+    await webhooks.dispatch("creator.deal.violated", sellerId, payload)
+    await webhooks.dispatch("creator.deal.violated", deal.creator_seller_id, payload)
+  } catch (err) {
+    console.error("[deal/violate] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({ deal: updated })
+}

--- a/backend/src/api/v1/seller/programs/[id]/deals/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/deals/route.ts
@@ -1,0 +1,29 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../modules/creator-program/service"
+
+/**
+ * GET /v1/seller/programs/:id/deals
+ *
+ * List deals on this program (vendor view). Supports `?status=` filter.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const programs = await service.listCreatorPrograms({ id: programId, vendor_id: sellerId })
+  if (programs.length === 0) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const filter: Record<string, unknown> = { program_id: programId }
+  if (req.query.status) filter.status = req.query.status as string
+  const deals = await service.listCreatorDeals(filter)
+  return res.status(200).json({ deals })
+}

--- a/backend/src/api/v1/seller/programs/[id]/publish/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/publish/route.ts
@@ -1,0 +1,58 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../../modules/creator-program/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../modules/marketplace-webhooks/service"
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const list = await service.listCreatorPrograms({ id: programId, vendor_id: sellerId })
+  const program = list[0]
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+
+  const updated = await service.publishProgram(programId)
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    await webhooks.dispatch("creator.program.published", sellerId, {
+      program_id: programId,
+      vendor_id: sellerId,
+      title: program.title,
+      program_type: program.program_type,
+    })
+  } catch (err) {
+    console.error("[program/publish] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({ program: updated })
+}
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const list = await service.listCreatorPrograms({ id: programId, vendor_id: sellerId })
+  if (list.length === 0) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const updated = await service.closeProgram(programId)
+  return res.status(200).json({ program: updated })
+}

--- a/backend/src/api/v1/seller/programs/[id]/reward-pools/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/reward-pools/route.ts
@@ -1,0 +1,139 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../../modules/creator-program"
+import type CreatorProgramService from "../../../../../../modules/creator-program/service"
+import { CREATOR_REWARDS_MODULE } from "../../../../../../modules/creator-rewards"
+import type CreatorRewardsService from "../../../../../../modules/creator-rewards/service"
+import { RewardPoolKind } from "../../../../../../modules/creator-rewards/models"
+import { HAWALA_LEDGER_MODULE } from "../../../../../../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../../../../../../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../modules/marketplace-webhooks/service"
+
+const CreateSchema = z.object({
+  total_cents: z.number().int().min(100).max(1_000_000_000_000),
+  period_start: z.string().datetime().optional(),
+  period_end: z.string().datetime(),
+  kind: z.nativeEnum(RewardPoolKind).optional(),
+  rate_per_kqv_cents: z.number().int().min(0).max(1_000_000).optional().nullable(),
+  currency_code: z.string().length(3).optional(),
+})
+
+/**
+ * POST /v1/seller/programs/:id/reward-pools
+ *
+ * Vendor opens an engagement reward pool against one of their programs
+ * and funds it from their seller-earnings account.
+ *
+ * GET /v1/seller/programs/:id/reward-pools — list pools on this program.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+  const programService = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const programs = await programService.listCreatorPrograms({
+    id: programId,
+    vendor_id: sellerId,
+  })
+  if (programs.length === 0) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const pools = await rewards.listRewardPools({ program_id: programId })
+  return res.status(200).json({ pools })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+  const parsed = CreateSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid pool payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const programService = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const programs = await programService.listCreatorPrograms({
+    id: programId,
+    vendor_id: sellerId,
+  })
+  const program = programs[0]
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+
+  const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const periodStart = parsed.data.period_start
+    ? new Date(parsed.data.period_start)
+    : new Date()
+  const periodEnd = new Date(parsed.data.period_end)
+
+  let pool
+  try {
+    pool = await rewards.openPool({
+      programId,
+      funderSellerId: sellerId,
+      kind: parsed.data.kind,
+      periodStart,
+      periodEnd,
+      totalCents: parsed.data.total_cents,
+      ratePerKqvCents: parsed.data.rate_per_kqv_cents ?? null,
+      currencyCode: parsed.data.currency_code ?? program.currency_code,
+    })
+  } catch (err) {
+    return res.status(400).json({ message: (err as Error).message, type: "invalid_request" })
+  }
+
+  // Fund the pool from the vendor's seller-earnings account.
+  try {
+    const hawala = req.scope.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+    await hawala.fundCreatorRewardPool({
+      poolId: pool.id,
+      funderSellerId: sellerId,
+      amountCents: parsed.data.total_cents,
+      currencyCode: (parsed.data.currency_code ?? program.currency_code).toUpperCase(),
+    })
+  } catch (err) {
+    console.error("[reward-pools] funding failed", err)
+    return res.status(402).json({
+      message: `Pool created but funding failed: ${(err as Error).message}`,
+      type: "funding_failed",
+      pool,
+    })
+  }
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    const payload = {
+      pool_id: pool.id,
+      program_id: programId,
+      vendor_id: sellerId,
+      total_cents: parsed.data.total_cents,
+      kind: pool.kind,
+      period_start: periodStart,
+      period_end: periodEnd,
+    }
+    await webhooks.dispatch("creator.reward.pool_opened", sellerId, payload)
+    await webhooks.dispatch("creator.reward.pool_funded", sellerId, payload)
+  } catch (err) {
+    console.error("[reward-pools] webhook dispatch failed", err)
+  }
+
+  return res.status(201).json({ pool })
+}

--- a/backend/src/api/v1/seller/programs/[id]/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/route.ts
@@ -1,0 +1,75 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../modules/creator-program"
+import CreatorProgramService from "../../../../../modules/creator-program/service"
+import { CreatorProgramStatus } from "../../../../../modules/creator-program/models"
+
+const PatchSchema = z.object({
+  title: z.string().min(2).max(200).optional(),
+  description: z.string().max(4000).optional().nullable(),
+  brief_markdown: z.string().max(20000).optional().nullable(),
+  status: z.nativeEnum(CreatorProgramStatus).optional(),
+  ends_at: z.string().datetime().optional().nullable(),
+  budget_cap_cents: z.number().int().min(0).max(1_000_000_000_000).optional().nullable(),
+  min_followers: z.number().int().min(0).max(2_000_000_000).optional().nullable(),
+  requires_kyc: z.boolean().optional(),
+  min_verification_level: z.string().max(64).optional().nullable(),
+})
+
+async function ownProgram(
+  req: MedusaRequest,
+  service: CreatorProgramService
+): Promise<{ program: any | null; sellerId: string | null; programId: string | null }> {
+  const sellerId = (req as SellerAuthRequest).seller_id ?? null
+  const programId = (req.params as { id?: string })?.id ?? null
+  if (!sellerId || !programId) return { program: null, sellerId, programId }
+  const list = await service.listCreatorPrograms({ id: programId, vendor_id: sellerId })
+  return { program: list[0] ?? null, sellerId, programId }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const { program, sellerId } = await ownProgram(req, service)
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  return res.status(200).json({ program })
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const { program, sellerId, programId } = await ownProgram(req, service)
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  if (!program || !programId) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const parsed = PatchSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid update payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const updates: Record<string, unknown> = { id: programId }
+  if (parsed.data.title !== undefined) updates.title = parsed.data.title
+  if (parsed.data.description !== undefined) updates.description = parsed.data.description
+  if (parsed.data.brief_markdown !== undefined) updates.brief_markdown = parsed.data.brief_markdown
+  if (parsed.data.status !== undefined) updates.status = parsed.data.status
+  if (parsed.data.ends_at !== undefined)
+    updates.ends_at = parsed.data.ends_at ? new Date(parsed.data.ends_at) : null
+  if (parsed.data.budget_cap_cents !== undefined) updates.budget_cap_cents = parsed.data.budget_cap_cents
+  if (parsed.data.min_followers !== undefined) updates.min_followers = parsed.data.min_followers
+  if (parsed.data.requires_kyc !== undefined) updates.requires_kyc = parsed.data.requires_kyc
+  if (parsed.data.min_verification_level !== undefined)
+    updates.min_verification_level = parsed.data.min_verification_level
+
+  const updated = await (service as any).updateCreatorPrograms(updates)
+  return res.status(200).json({ program: updated })
+}

--- a/backend/src/api/v1/seller/programs/route.ts
+++ b/backend/src/api/v1/seller/programs/route.ts
@@ -1,0 +1,98 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../middlewares/seller-context-v1"
+import { CREATOR_PROGRAM_MODULE } from "../../../../modules/creator-program"
+import CreatorProgramService from "../../../../modules/creator-program/service"
+import {
+  CreatorProgramType,
+  CreatorProgramAttributionModel,
+} from "../../../../modules/creator-program/models"
+
+const slugRegex = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/
+
+const CreateProgramSchema = z.object({
+  title: z.string().min(2).max(200),
+  slug: z.string().regex(slugRegex),
+  description: z.string().max(4000).optional().nullable(),
+  brief_markdown: z.string().max(20000).optional().nullable(),
+  program_type: z.nativeEnum(CreatorProgramType),
+  commission_percent: z.number().min(0).max(100).optional().nullable(),
+  commission_flat_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  sponsorship_flat_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  pool_total_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  pool_period: z.enum(["weekly", "monthly"]).optional().nullable(),
+  cookie_window_days: z.number().int().min(0).max(180).optional(),
+  hold_days: z.number().int().min(0).max(180).optional(),
+  attribution_model: z.nativeEnum(CreatorProgramAttributionModel).optional(),
+  currency_code: z.string().length(3).optional(),
+  product_ids: z.array(z.string()).max(500).optional().nullable(),
+  collection_ids: z.array(z.string()).max(200).optional().nullable(),
+  category_ids: z.array(z.string()).max(200).optional().nullable(),
+  required_platforms: z.array(z.string().max(64)).max(16).optional().nullable(),
+  min_followers: z.number().int().min(0).max(2_000_000_000).optional().nullable(),
+  geo_allowlist: z.array(z.string().length(2)).max(250).optional().nullable(),
+  starts_at: z.string().datetime().optional().nullable(),
+  ends_at: z.string().datetime().optional().nullable(),
+  budget_cap_cents: z.number().int().min(0).max(1_000_000_000_000).optional().nullable(),
+  requires_kyc: z.boolean().optional(),
+  min_verification_level: z.string().max(64).optional().nullable(),
+})
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const programs = await service.listCreatorPrograms({ vendor_id: sellerId })
+  return res.status(200).json({ programs })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = CreateProgramSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid program payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const service = req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  try {
+    const program = await service.createProgram({
+      vendorId: sellerId,
+      title: parsed.data.title,
+      slug: parsed.data.slug,
+      description: parsed.data.description ?? null,
+      briefMarkdown: parsed.data.brief_markdown ?? null,
+      programType: parsed.data.program_type,
+      commissionPercent: parsed.data.commission_percent ?? null,
+      commissionFlatCents: parsed.data.commission_flat_cents ?? null,
+      sponsorshipFlatCents: parsed.data.sponsorship_flat_cents ?? null,
+      poolTotalCents: parsed.data.pool_total_cents ?? null,
+      poolPeriod: parsed.data.pool_period ?? null,
+      cookieWindowDays: parsed.data.cookie_window_days,
+      holdDays: parsed.data.hold_days,
+      attributionModel: parsed.data.attribution_model,
+      currencyCode: parsed.data.currency_code,
+      productIds: parsed.data.product_ids ?? null,
+      collectionIds: parsed.data.collection_ids ?? null,
+      categoryIds: parsed.data.category_ids ?? null,
+      requiredPlatforms: parsed.data.required_platforms ?? null,
+      minFollowers: parsed.data.min_followers ?? null,
+      geoAllowlist: parsed.data.geo_allowlist ?? null,
+      startsAt: parsed.data.starts_at ? new Date(parsed.data.starts_at) : null,
+      endsAt: parsed.data.ends_at ? new Date(parsed.data.ends_at) : null,
+      budgetCapCents: parsed.data.budget_cap_cents ?? null,
+      requiresKyc: parsed.data.requires_kyc ?? false,
+      minVerificationLevel: parsed.data.min_verification_level ?? null,
+    })
+    return res.status(201).json({ program })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+}

--- a/backend/src/api/v1/seller/services/applications/route.ts
+++ b/backend/src/api/v1/seller/services/applications/route.ts
@@ -1,0 +1,79 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../modules/service-program/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../modules/marketplace-webhooks/service"
+
+const ApplySchema = z.object({
+  program_id: z.string().min(1).max(64),
+  proposed_unit_price_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  proposed_capacity: z.number().int().min(0).max(1_000_000).optional().nullable(),
+  proposed_lead_time_days: z.number().int().min(0).max(365).optional().nullable(),
+  sample_portfolio_urls: z.array(z.string().url()).max(20).optional().nullable(),
+  pitch: z.string().max(4000).optional().nullable(),
+})
+
+/**
+ * GET /v1/seller/services/applications — list this service vendor's
+ * applications.
+ *
+ * POST /v1/seller/services/applications — apply to a service program /
+ * claim an open bounty.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const apps = await service.listServiceApplications({ service_seller_id: sellerId })
+  return res.status(200).json({ applications: apps })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = ApplySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid application payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  try {
+    const application = await service.applyToProgram({
+      programId: parsed.data.program_id,
+      serviceSellerId: sellerId,
+      proposedUnitPriceCents: parsed.data.proposed_unit_price_cents ?? null,
+      proposedCapacity: parsed.data.proposed_capacity ?? null,
+      proposedLeadTimeDays: parsed.data.proposed_lead_time_days ?? null,
+      samplePortfolioUrls: parsed.data.sample_portfolio_urls ?? null,
+      pitch: parsed.data.pitch ?? null,
+    })
+
+    try {
+      const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+      const programs = await service.listServicePrograms({ id: parsed.data.program_id })
+      const program = programs[0]
+      if (program) {
+        await webhooks.dispatch("service.application.submitted", program.vendor_id, {
+          application_id: application.id,
+          program_id: parsed.data.program_id,
+          service_seller_id: sellerId,
+        })
+      }
+    } catch (err) {
+      console.error("[service-applications] webhook dispatch failed", err)
+    }
+
+    return res.status(201).json({ application })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+}

--- a/backend/src/api/v1/seller/services/contracts/route.ts
+++ b/backend/src/api/v1/seller/services/contracts/route.ts
@@ -1,0 +1,27 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../modules/service-program/service"
+
+/**
+ * GET /v1/seller/services/contracts
+ *
+ * List all contracts where this seller is either the service provider or
+ * the buyer. Returns both perspectives so the vendor panel can show
+ * "Work I'm doing" and "Work I'm buying" tabs from one fetch.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const [asProvider, asBuyer] = await Promise.all([
+    service.listServiceContracts({ service_seller_id: sellerId }),
+    service.listServiceContracts({ vendor_id: sellerId }),
+  ])
+  return res.status(200).json({
+    as_provider: asProvider,
+    as_buyer: asBuyer,
+  })
+}

--- a/backend/src/api/v1/seller/services/programs/[id]/applications/[appId]/decide/route.ts
+++ b/backend/src/api/v1/seller/services/programs/[id]/applications/[appId]/decide/route.ts
@@ -1,0 +1,158 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../../../../middlewares/seller-context-v1"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../../../../../modules/service-program/service"
+import { VENDOR_VERIFICATION_MODULE } from "../../../../../../../../../modules/vendor-verification"
+import { VerificationLevel } from "../../../../../../../../../modules/vendor-verification/models/verification"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../../../modules/marketplace-webhooks/service"
+
+const DecideSchema = z.object({
+  decision: z.enum(["approve", "reject"]),
+  reason: z.string().max(2000).optional().nullable(),
+})
+
+const LEVEL_RANK: Record<string, number> = {
+  UNVERIFIED: 0,
+  SELF_REPORTED: 1,
+  VERIFIED: 2,
+  AUDITED: 3,
+  CERTIFIED: 4,
+}
+
+/**
+ * POST /v1/seller/services/programs/:id/applications/:appId/decide
+ *
+ * Vendor approves/rejects a service-vendor application. On approval:
+ *   1. Optional KYC gating against `min_verification_level`.
+ *   2. Application -> approved.
+ *   3. Service contract opened with frozen `terms_snapshot`.
+ *   4. `service.contract.opened` webhook dispatched to both parties.
+ *
+ * Note: this endpoint does NOT auto-fund escrow — the buyer-vendor opens
+ * a separate subcontract (which carries the escrow) when assigning work.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  const appId = (req.params as { appId?: string })?.appId
+  if (!programId || !appId) {
+    return res.status(400).json({ message: "Missing ids", type: "invalid_request" })
+  }
+
+  const parsed = DecideSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid decide payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const programs = await service.listServicePrograms({
+    id: programId,
+    vendor_id: sellerId,
+  })
+  const program = programs[0]
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const apps = await service.listServiceApplications({
+    id: appId,
+    program_id: programId,
+  })
+  const app = apps[0]
+  if (!app) {
+    return res.status(404).json({ message: "Application not found", type: "not_found" })
+  }
+
+  // KYC gate
+  if (parsed.data.decision === "approve" && program.requires_kyc) {
+    try {
+      const verificationSvc = req.scope.resolve<any>(VENDOR_VERIFICATION_MODULE)
+      const verification = await verificationSvc.getOrCreateVerification(
+        app.service_seller_id
+      )
+      const required = program.min_verification_level ?? VerificationLevel.VERIFIED
+      const requiredRank = LEVEL_RANK[required] ?? LEVEL_RANK.VERIFIED
+      const actualRank = LEVEL_RANK[verification.level] ?? LEVEL_RANK.UNVERIFIED
+      if (actualRank < requiredRank) {
+        return res.status(412).json({
+          message: `Service vendor KYC level (${verification.level}) below required (${required})`,
+          type: "kyc_insufficient",
+          service_seller_level: verification.level,
+          required_level: required,
+        })
+      }
+    } catch (err) {
+      console.error("[service-decide] KYC check failed", err)
+      return res.status(500).json({
+        message: "KYC verification check failed",
+        type: "kyc_check_failed",
+      })
+    }
+  }
+
+  let updatedApp
+  try {
+    updatedApp = await service.decideApplication({
+      applicationId: appId,
+      decision: parsed.data.decision,
+      decidedBy: sellerId,
+      reason: parsed.data.reason ?? null,
+    })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+
+  let contract: any | null = null
+  if (parsed.data.decision === "approve") {
+    contract = await service.openContractForApprovedApp(appId)
+    try {
+      const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+      const payload = {
+        contract_id: contract.id,
+        program_id: programId,
+        application_id: appId,
+        service_seller_id: app.service_seller_id,
+        vendor_id: sellerId,
+        terms_snapshot: contract.terms_snapshot,
+      }
+      await webhooks.dispatch("service.contract.opened", sellerId, payload)
+      await webhooks.dispatch("service.contract.opened", app.service_seller_id, payload)
+      await webhooks.dispatch(
+        "service.application.approved",
+        app.service_seller_id,
+        {
+          application_id: appId,
+          program_id: programId,
+          contract_id: contract.id,
+        }
+      )
+    } catch (err) {
+      console.error("[service-decide] webhook dispatch failed", err)
+    }
+  } else {
+    try {
+      const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+      await webhooks.dispatch(
+        "service.application.rejected",
+        app.service_seller_id,
+        {
+          application_id: appId,
+          program_id: programId,
+          reason: parsed.data.reason ?? null,
+        }
+      )
+    } catch (err) {
+      console.error("[service-decide] reject webhook dispatch failed", err)
+    }
+  }
+
+  return res.status(200).json({ application: updatedApp, contract })
+}

--- a/backend/src/api/v1/seller/services/programs/[id]/publish/route.ts
+++ b/backend/src/api/v1/seller/services/programs/[id]/publish/route.ts
@@ -1,0 +1,39 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../../../modules/service-program/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const programId = (req.params as { id?: string })?.id
+  if (!programId) {
+    return res.status(400).json({ message: "Missing program id", type: "invalid_request" })
+  }
+
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const list = await service.listServicePrograms({ id: programId, vendor_id: sellerId })
+  const program = list[0]
+  if (!program) {
+    return res.status(404).json({ message: "Program not found", type: "not_found" })
+  }
+  const updated = await service.publishProgram(programId)
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    await webhooks.dispatch("service.program.published", sellerId, {
+      program_id: programId,
+      vendor_id: sellerId,
+      title: program.title,
+      service_category: program.service_category,
+      program_type: program.program_type,
+    })
+  } catch (err) {
+    console.error("[service-program/publish] webhook dispatch failed", err)
+  }
+  return res.status(200).json({ program: updated })
+}

--- a/backend/src/api/v1/seller/services/programs/route.ts
+++ b/backend/src/api/v1/seller/services/programs/route.ts
@@ -1,0 +1,91 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../modules/service-program/service"
+import {
+  ServiceCategory,
+  ServiceProgramType,
+  ServicePricingModel,
+} from "../../../../../modules/service-program/models"
+
+const slugRegex = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/
+
+const CreateSchema = z.object({
+  title: z.string().min(2).max(200),
+  slug: z.string().regex(slugRegex),
+  description: z.string().max(4000).optional().nullable(),
+  deliverable_spec: z.record(z.unknown()).optional().nullable(),
+  acceptance_criteria: z.record(z.unknown()).optional().nullable(),
+  service_category: z.nativeEnum(ServiceCategory),
+  program_type: z.nativeEnum(ServiceProgramType),
+  pricing_model: z.nativeEnum(ServicePricingModel),
+  unit_price_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  hourly_rate_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  flat_price_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  pool_total_cents: z.number().int().min(0).max(1_000_000_000).optional().nullable(),
+  currency_code: z.string().length(3).optional(),
+  min_units: z.number().int().min(0).optional().nullable(),
+  max_units: z.number().int().min(0).optional().nullable(),
+  deadline_at: z.string().datetime().optional().nullable(),
+  budget_cap_cents: z.number().int().min(0).max(1_000_000_000_000).optional().nullable(),
+  requires_kyc: z.boolean().optional(),
+  min_verification_level: z.string().max(64).optional().nullable(),
+  geo_allowlist: z.array(z.string().length(2)).max(250).optional().nullable(),
+})
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const programs = await service.listServicePrograms({ vendor_id: sellerId })
+  return res.status(200).json({ programs })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = CreateSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid program payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const service = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  try {
+    const program = await service.createProgram({
+      vendorId: sellerId,
+      title: parsed.data.title,
+      slug: parsed.data.slug,
+      description: parsed.data.description ?? null,
+      deliverableSpec:
+        (parsed.data.deliverable_spec as Record<string, unknown> | null) ?? null,
+      acceptanceCriteria:
+        (parsed.data.acceptance_criteria as Record<string, unknown> | null) ?? null,
+      serviceCategory: parsed.data.service_category,
+      programType: parsed.data.program_type,
+      pricingModel: parsed.data.pricing_model,
+      unitPriceCents: parsed.data.unit_price_cents ?? null,
+      hourlyRateCents: parsed.data.hourly_rate_cents ?? null,
+      flatPriceCents: parsed.data.flat_price_cents ?? null,
+      poolTotalCents: parsed.data.pool_total_cents ?? null,
+      currencyCode: parsed.data.currency_code,
+      minUnits: parsed.data.min_units ?? null,
+      maxUnits: parsed.data.max_units ?? null,
+      deadlineAt: parsed.data.deadline_at ? new Date(parsed.data.deadline_at) : null,
+      budgetCapCents: parsed.data.budget_cap_cents ?? null,
+      requiresKyc: parsed.data.requires_kyc ?? false,
+      minVerificationLevel: parsed.data.min_verification_level ?? null,
+      geoAllowlist: parsed.data.geo_allowlist ?? null,
+    })
+    return res.status(201).json({ program })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+}

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/accept-delivery/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/accept-delivery/route.ts
@@ -1,0 +1,98 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../../../modules/order-subcontract/service"
+import { OrderSubcontractStatus } from "../../../../../../../modules/order-subcontract/models"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../../../modules/service-program/service"
+import { HAWALA_LEDGER_MODULE } from "../../../../../../../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../../../../../../../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+/**
+ * POST /v1/seller/services/subcontracts/:id/accept-delivery
+ *
+ * Buyer-vendor accepts the delivered work. Releases escrow to the
+ * service vendor's seller-earnings account, advances the contract to
+ * `accepted`, emits `subcontract.completed` webhook to both parties.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+
+  const subSvc = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const list = await subSvc.listOrderSubcontracts({
+    id,
+    parent_seller_id: sellerId,
+  })
+  const sub = list[0]
+  if (!sub) {
+    return res.status(404).json({ message: "Subcontract not found", type: "not_found" })
+  }
+  if (sub.status !== OrderSubcontractStatus.DELIVERED) {
+    return res.status(409).json({
+      message: `Cannot accept subcontract in status ${sub.status}`,
+      type: "conflict",
+    })
+  }
+
+  // Release escrow.
+  const hawala = req.scope.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+  let releaseEntry
+  try {
+    releaseEntry = await hawala.releaseSubcontractEscrow({
+      subcontractId: id,
+      serviceSellerId: sub.subcontract_seller_id,
+      amountCents: Number(sub.total_cents),
+      currencyCode: String(sub.currency_code).toUpperCase(),
+    })
+  } catch (err) {
+    return res.status(402).json({
+      message: `Escrow release failed: ${(err as Error).message}`,
+      type: "escrow_release_failed",
+    })
+  }
+
+  const updated = await subSvc.markAcceptedByParent({
+    subcontractId: id,
+    parentSellerId: sellerId,
+    releaseLedgerEntryId: releaseEntry.id,
+  })
+
+  // Update the parent service contract's payout total.
+  try {
+    const programSvc = req.scope.resolve<ServiceProgramService>(
+      SERVICE_PROGRAM_MODULE
+    )
+    await programSvc.incrementContractPayout(sub.contract_id, Number(sub.total_cents))
+  } catch (err) {
+    console.error("[accept-delivery] contract payout update failed", err)
+  }
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+    const payload = {
+      subcontract_id: id,
+      release_ledger_entry_id: releaseEntry.id,
+      total_cents: Number(sub.total_cents),
+    }
+    await webhooks.dispatch("subcontract.completed", sellerId, payload)
+    await webhooks.dispatch("subcontract.completed", sub.subcontract_seller_id, payload)
+  } catch (err) {
+    console.error("[accept-delivery] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({
+    subcontract: updated,
+    release_ledger_entry_id: releaseEntry.id,
+  })
+}

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/accept/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/accept/route.ts
@@ -1,0 +1,42 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../../../modules/order-subcontract/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const service = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  try {
+    const sub = await service.acceptSubcontract({
+      subcontractId: id,
+      serviceSellerId: sellerId,
+    })
+    try {
+      const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+        MARKETPLACE_WEBHOOKS_MODULE
+      )
+      await webhooks.dispatch("subcontract.accepted", sellerId, {
+        subcontract_id: id,
+        accepted_by: sellerId,
+      })
+      await webhooks.dispatch("subcontract.accepted", sub.parent_seller_id, {
+        subcontract_id: id,
+        accepted_by: sellerId,
+      })
+    } catch (err) {
+      console.error("[subcontract/accept] webhook dispatch failed", err)
+    }
+    return res.status(200).json({ subcontract: sub })
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message, type: "conflict" })
+  }
+}

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/deliver/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/deliver/route.ts
@@ -1,0 +1,168 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../../../modules/order-subcontract/service"
+import { WORK_VERIFICATION_MODULE } from "../../../../../../../modules/work-verification"
+import WorkVerificationService from "../../../../../../../modules/work-verification/service"
+import {
+  ProofArtifactKind,
+  ProofContextType,
+  ProofVerificationMethod,
+} from "../../../../../../../modules/work-verification/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const DeliverSchema = z.object({
+  units_delivered: z.number().int().min(0).max(1_000_000).optional(),
+  proofs: z
+    .array(
+      z.object({
+        kind: z.nativeEnum(ProofArtifactKind),
+        storage_url: z.string().url().optional().nullable(),
+        sha256: z
+          .string()
+          .regex(/^[a-f0-9]{64}$/i)
+          .optional()
+          .nullable(),
+        captured_at: z.string().datetime().optional().nullable(),
+        metadata: z.record(z.unknown()).optional().nullable(),
+      })
+    )
+    .max(32)
+    .optional(),
+})
+
+/**
+ * POST /v1/seller/services/subcontracts/:id/deliver
+ *
+ * Service vendor marks the subcontract as delivered, attaching one or
+ * more proof artifacts (photos, shipping labels, etc.). Each proof gets
+ * its `signature_envelope` filled in with a deterministic manifest hash
+ * so admins can later verify integrity.
+ *
+ * The buyer-vendor still needs to call `/accept` to release escrow.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const parsed = DeliverSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid deliver payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  const service = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const list = await service.listOrderSubcontracts({
+    id,
+    subcontract_seller_id: sellerId,
+  })
+  const sub = list[0]
+  if (!sub) {
+    return res.status(404).json({ message: "Subcontract not found", type: "not_found" })
+  }
+
+  // Submit proofs (best-effort — don't block delivery on individual proof
+  // failures, just log them).
+  const proofIds: string[] = []
+  let firstProofId: string | null = null
+  if (parsed.data.proofs && parsed.data.proofs.length > 0) {
+    try {
+      const wv = req.scope.resolve<WorkVerificationService>(WORK_VERIFICATION_MODULE)
+      // Build asset hashes for the manifest envelope so all submitted proofs
+      // are bound together cryptographically.
+      const assetHashes: Record<string, string> = {}
+      for (let i = 0; i < parsed.data.proofs.length; i++) {
+        const p = parsed.data.proofs[i]
+        if (p.sha256) assetHashes[`asset_${i}`] = p.sha256
+      }
+      const manifestHash = WorkVerificationService.computeManifestHash(assetHashes)
+
+      for (const p of parsed.data.proofs) {
+        const proof = await wv.submitProof({
+          ownerSellerId: sellerId,
+          contextType: ProofContextType.ORDER_SUBCONTRACT,
+          contextId: id,
+          kind: p.kind,
+          storageUrl: p.storage_url ?? null,
+          storageProvider: "minio",
+          sha256: p.sha256 ?? null,
+          capturedAt: p.captured_at ? new Date(p.captured_at) : null,
+          metadata:
+            (p.metadata as Record<string, unknown> | null) ?? null,
+        })
+        // Attach a signed envelope so the proof can be later audited by
+        // anyone who knows the platform's signing key id. We use a
+        // pseudo-signature placeholder when no real signing infra is
+        // wired up — the manifest hash is what's audit-relevant.
+        await wv.signProof({
+          proofId: proof.id,
+          keyId: process.env.WORK_VERIFICATION_KEY_ID || "platform-default",
+          manifestHash,
+          signature: "",
+          assetHashes,
+        })
+        // Auto-verify if a carrier-style proof was attached (shipping label
+        // or tracking event) — minimal Release E rule profile.
+        if (
+          p.kind === ProofArtifactKind.SHIPPING_LABEL ||
+          p.kind === ProofArtifactKind.TRACKING_EVENT
+        ) {
+          await wv.autoVerify({
+            proofId: proof.id,
+            method: ProofVerificationMethod.CARRIER_WEBHOOK,
+            verifierId: "system",
+          })
+        } else if (p.kind === ProofArtifactKind.SIGNED_MANIFEST) {
+          await wv.autoVerify({
+            proofId: proof.id,
+            method: ProofVerificationMethod.SIGNATURE,
+            verifierId: "system",
+          })
+        }
+        proofIds.push(proof.id)
+        if (!firstProofId) firstProofId = proof.id
+      }
+    } catch (err) {
+      console.error("[subcontract/deliver] proof submission failed", err)
+    }
+  }
+
+  const updated = await service.markDelivered({
+    subcontractId: id,
+    proofId: firstProofId,
+    actorSellerId: sellerId,
+  })
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+    const payload = {
+      subcontract_id: id,
+      proof_ids: proofIds,
+      units_delivered: parsed.data.units_delivered ?? null,
+    }
+    await webhooks.dispatch("subcontract.delivered", sellerId, payload)
+    await webhooks.dispatch("subcontract.delivered", sub.parent_seller_id, payload)
+    for (const proofId of proofIds) {
+      await webhooks.dispatch("service.proof.submitted", sellerId, {
+        proof_id: proofId,
+        subcontract_id: id,
+      })
+    }
+  } catch (err) {
+    console.error("[subcontract/deliver] webhook dispatch failed", err)
+  }
+
+  return res.status(200).json({ subcontract: updated, proof_ids: proofIds })
+}

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/dispute/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/dispute/route.ts
@@ -1,0 +1,79 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../../../modules/order-subcontract/service"
+import { OrderSubcontractStatus } from "../../../../../../../modules/order-subcontract/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../../../modules/marketplace-webhooks/service"
+
+const Schema = z.object({
+  reason: z.string().min(2).max(2000),
+})
+
+/**
+ * POST /v1/seller/services/subcontracts/:id/dispute
+ *
+ * Either party can dispute. Escrow stays frozen pending admin review;
+ * admin handles resolution + escrow disposition through the admin
+ * marketplace endpoints.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const id = (req.params as { id?: string })?.id
+  if (!id) {
+    return res.status(400).json({ message: "Missing id", type: "invalid_request" })
+  }
+  const parsed = Schema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid dispute payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+  const service = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const list = await service.listOrderSubcontracts({ id })
+  const sub = list[0]
+  if (!sub) {
+    return res.status(404).json({ message: "Subcontract not found", type: "not_found" })
+  }
+  if (
+    sub.parent_seller_id !== sellerId &&
+    sub.subcontract_seller_id !== sellerId
+  ) {
+    return res.status(403).json({ message: "Not a party to this subcontract", type: "forbidden" })
+  }
+  if (
+    sub.status === OrderSubcontractStatus.ACCEPTED_BY_PARENT ||
+    sub.status === OrderSubcontractStatus.CANCELED
+  ) {
+    return res.status(409).json({
+      message: `Cannot dispute subcontract in status ${sub.status}`,
+      type: "conflict",
+    })
+  }
+  const updated = await service.dispute({
+    subcontractId: id,
+    actorSellerId: sellerId,
+    reason: parsed.data.reason,
+  })
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+    const payload = {
+      subcontract_id: id,
+      raised_by: sellerId,
+      reason: parsed.data.reason,
+    }
+    await webhooks.dispatch("subcontract.disputed", sub.parent_seller_id, payload)
+    await webhooks.dispatch("subcontract.disputed", sub.subcontract_seller_id, payload)
+  } catch (err) {
+    console.error("[subcontract/dispute] webhook dispatch failed", err)
+  }
+  return res.status(200).json({ subcontract: updated })
+}

--- a/backend/src/api/v1/seller/services/subcontracts/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/route.ts
@@ -1,0 +1,131 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { ORDER_SUBCONTRACT_MODULE } from "../../../../../modules/order-subcontract"
+import type OrderSubcontractService from "../../../../../modules/order-subcontract/service"
+import { SERVICE_PROGRAM_MODULE } from "../../../../../modules/service-program"
+import type ServiceProgramService from "../../../../../modules/service-program/service"
+import { HAWALA_LEDGER_MODULE } from "../../../../../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../../../../../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../../../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../../../../../modules/marketplace-webhooks/service"
+
+const ProposeSchema = z.object({
+  parent_order_id: z.string().min(1).max(128),
+  contract_id: z.string().min(1).max(64),
+  order_item_ids: z.array(z.string()).min(1).max(200),
+  unit_count: z.number().int().min(1).max(1_000_000),
+  unit_price_cents: z.number().int().min(1).max(1_000_000_000),
+  currency_code: z.string().length(3).optional(),
+  pickup_at: z.string().datetime().optional().nullable(),
+  deliver_to: z.record(z.unknown()).optional().nullable(),
+})
+
+/**
+ * GET /v1/seller/services/subcontracts
+ *   Lists subcontracts where the seller is either parent (buyer-vendor) or
+ *   subcontract_seller (service vendor).
+ *
+ * POST /v1/seller/services/subcontracts
+ *   Buyer-vendor proposes a subcontract against an active service contract.
+ *   On creation, escrow funds are moved from the buyer's seller-earnings
+ *   account into a per-subcontract ESCROW account.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const service = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const [asParent, asProvider] = await Promise.all([
+    service.listOrderSubcontracts({ parent_seller_id: sellerId }),
+    service.listOrderSubcontracts({ subcontract_seller_id: sellerId }),
+  ])
+  return res.status(200).json({ as_parent: asParent, as_provider: asProvider })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const parsed = ProposeSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Invalid subcontract payload",
+      type: "invalid_request",
+      errors: parsed.error.flatten(),
+    })
+  }
+
+  // Resolve the contract. The buyer-vendor must own it (vendor_id matches).
+  const programSvc = req.scope.resolve<ServiceProgramService>(SERVICE_PROGRAM_MODULE)
+  const contracts = await programSvc.listServiceContracts({
+    id: parsed.data.contract_id,
+    vendor_id: sellerId,
+  })
+  const contract = contracts[0]
+  if (!contract) {
+    return res.status(404).json({
+      message: "Service contract not found or not owned by this vendor",
+      type: "not_found",
+    })
+  }
+
+  const subcontractSvc = req.scope.resolve<OrderSubcontractService>(ORDER_SUBCONTRACT_MODULE)
+  const sub = await subcontractSvc.proposeSubcontract({
+    parentOrderId: parsed.data.parent_order_id,
+    parentSellerId: sellerId,
+    subcontractSellerId: contract.service_seller_id,
+    contractId: parsed.data.contract_id,
+    programId: contract.program_id,
+    orderItemIds: parsed.data.order_item_ids,
+    unitCount: parsed.data.unit_count,
+    unitPriceCents: parsed.data.unit_price_cents,
+    currencyCode: parsed.data.currency_code,
+    pickupAt: parsed.data.pickup_at ? new Date(parsed.data.pickup_at) : null,
+    deliverTo:
+      (parsed.data.deliver_to as Record<string, unknown> | null) ?? null,
+  })
+
+  // Open escrow.
+  try {
+    const hawala = req.scope.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+    const total = parsed.data.unit_count * parsed.data.unit_price_cents
+    const entry = await hawala.openSubcontractEscrow({
+      subcontractId: sub.id,
+      parentSellerId: sellerId,
+      amountCents: total,
+      currencyCode: (parsed.data.currency_code ?? "usd").toUpperCase(),
+    })
+    await subcontractSvc.attachEscrow({
+      subcontractId: sub.id,
+      escrowLedgerEntryId: entry.id,
+    })
+  } catch (err) {
+    console.error("[subcontracts] escrow open failed", err)
+    return res.status(402).json({
+      message: `Subcontract proposed but escrow failed: ${(err as Error).message}`,
+      type: "escrow_failed",
+      subcontract: sub,
+    })
+  }
+
+  try {
+    const webhooks = req.scope.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+    const payload = {
+      subcontract_id: sub.id,
+      parent_order_id: parsed.data.parent_order_id,
+      parent_seller_id: sellerId,
+      subcontract_seller_id: contract.service_seller_id,
+      contract_id: parsed.data.contract_id,
+      total_cents: parsed.data.unit_count * parsed.data.unit_price_cents,
+    }
+    await webhooks.dispatch("subcontract.proposed", sellerId, payload)
+    await webhooks.dispatch("subcontract.proposed", contract.service_seller_id, payload)
+  } catch (err) {
+    console.error("[subcontracts] webhook dispatch failed", err)
+  }
+
+  return res.status(201).json({ subcontract: sub })
+}

--- a/backend/src/api/v1/webhooks/content-platform/[platform]/route.ts
+++ b/backend/src/api/v1/webhooks/content-platform/[platform]/route.ts
@@ -1,0 +1,101 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { CONTENT_PLATFORM_MODULE } from "../../../../../modules/content-platform"
+import type ContentPlatformService from "../../../../../modules/content-platform/service"
+import type { ContentPlatform } from "../../../../../modules/content-platform/providers/types"
+import { CREATOR_REWARDS_MODULE } from "../../../../../modules/creator-rewards"
+import type CreatorRewardsService from "../../../../../modules/creator-rewards/service"
+
+const SUPPORTED_PLATFORMS: ContentPlatform[] = [
+  "tiktok",
+  "instagram",
+  "youtube",
+  "twitch",
+  "blackout",
+  "rss",
+  "podcast",
+  "custom",
+]
+
+/**
+ * POST /v1/webhooks/content-platform/:platform
+ *
+ * Generic ingress for inbound platform webhooks. Per-platform HMAC
+ * signature verification happens inside the matching adapter (and for
+ * `custom`, against the per-account `inbound_webhook_secret`). Normalized
+ * events are then upserted into `creator-rewards.EngagementSnapshot`.
+ *
+ * Authentication: none — adapters MUST verify their own signatures.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const platform = (req.params as { platform?: string })?.platform as
+    | ContentPlatform
+    | undefined
+  if (!platform || !SUPPORTED_PLATFORMS.includes(platform)) {
+    return res.status(404).json({
+      message: `Unknown platform: ${platform}`,
+      type: "not_found",
+    })
+  }
+
+  const cp = req.scope.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+  if (!cp.hasProvider(platform)) {
+    return res.status(404).json({
+      message: `Platform ${platform} is not enabled on this deployment`,
+      type: "platform_disabled",
+    })
+  }
+
+  let events
+  try {
+    events = await cp.dispatchInbound({
+      platform,
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      rawBody: (req as any).rawBody ?? null,
+      body: req.body,
+    })
+  } catch (err) {
+    return res.status(401).json({
+      message: (err as Error).message,
+      type: "unauthorized",
+    })
+  }
+
+  if (events.length === 0) {
+    return res.status(204).send("")
+  }
+
+  // Upsert engagement snapshots for any post.metrics_updated events that
+  // reference a known content_post.
+  let snapshotsCreated = 0
+  try {
+    const rewards = req.scope.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+    for (const ev of events) {
+      if (ev.type !== "post.metrics_updated" || !ev.externalPostId || !ev.metrics) continue
+      const posts = await rewards.listContentPosts({
+        platform,
+        external_post_id: ev.externalPostId,
+      })
+      const post = posts[0]
+      if (!post) continue
+      await rewards.ingestSnapshot(post.id, {
+        views: ev.metrics.views,
+        qualifiedViews: ev.metrics.qualified_views ?? ev.metrics.views,
+        likes: ev.metrics.likes,
+        shares: ev.metrics.shares,
+        comments: ev.metrics.comments,
+        saves: ev.metrics.saves,
+        watchTimeSeconds: ev.metrics.watch_time_seconds,
+        raw: ev.raw,
+        capturedAt: ev.occurredAt,
+      })
+      snapshotsCreated++
+    }
+  } catch (err) {
+    console.error("[content-platform-webhook] snapshot ingest failed", err)
+  }
+
+  return res.status(200).json({
+    received: events.length,
+    snapshots_created: snapshotsCreated,
+  })
+}

--- a/backend/src/jobs/attribution-fraud-sweep.ts
+++ b/backend/src/jobs/attribution-fraud-sweep.ts
@@ -1,0 +1,124 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
+import type CreatorAttributionService from "../modules/creator-attribution/service"
+import { CommissionStatus } from "../modules/creator-attribution/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
+
+const VELOCITY_BURST_LIMIT = (() => {
+  const v = parseInt(process.env.CREATOR_ATTRIBUTION_VELOCITY_BURST_LIMIT || "60", 10)
+  return Number.isFinite(v) && v >= 0 ? v : 60
+})()
+
+const VELOCITY_WINDOW_MINUTES = 1
+
+/**
+ * Lightweight fraud sweep that runs every 10 minutes. Two signals:
+ *
+ *   1. Velocity bursts: any (ip_hash, affiliate_link_id) seeing >N clicks
+ *      inside the most recent 1-minute window get all their NOT-yet-bot-
+ *      flagged clicks in that window marked `is_bot_suspected=true`. Bot-
+ *      flagged clicks never count toward attribution (lastClickForVisitor
+ *      filters them out).
+ *
+ *   2. For any `held` `OrderAttribution` whose attached `click_event_id`
+ *      is now bot-flagged, transition the attribution to `disqualified`
+ *      and emit `creator.attribution.fraud_flagged`.
+ *
+ * Real-world deployments would also wire in a JS challenge for high-
+ * velocity codes, IP-block intel, and per-customer velocity limits — out
+ * of scope for Release C.
+ */
+export default async function attributionFraudSweepJob(
+  container: MedusaContainer
+) {
+  const service = container.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+  let webhooks: MarketplaceWebhooksService | null = null
+  try {
+    webhooks = container.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+  } catch {
+    webhooks = null
+  }
+
+  const since = new Date(Date.now() - VELOCITY_WINDOW_MINUTES * 60_000)
+
+  // Velocity sweep on recent clicks. We use a simple in-memory aggregation
+  // since the click table is small per-window in normal operation.
+  const recentClicks = await service.listAttributionClickEvents({
+    is_bot_suspected: false,
+  })
+  const filtered = recentClicks.filter(
+    (c: any) => new Date(c.occurred_at as any) >= since
+  )
+  const counters = new Map<string, any[]>()
+  for (const c of filtered as any[]) {
+    if (!c.ip_hash) continue
+    const k = `${c.ip_hash}:${c.affiliate_link_id}`
+    const arr = counters.get(k) ?? []
+    arr.push(c)
+    counters.set(k, arr)
+  }
+
+  let flagged = 0
+  for (const [, list] of counters.entries()) {
+    if (list.length <= VELOCITY_BURST_LIMIT) continue
+    for (const click of list) {
+      try {
+        await (service as any).updateAttributionClickEvents({
+          id: click.id,
+          is_bot_suspected: true,
+        })
+        flagged++
+      } catch (err) {
+        console.error("[attribution-fraud-sweep] click update failed", err)
+      }
+    }
+  }
+
+  // Disqualify held attributions whose click_event got flagged.
+  const held = await service.listOrderAttributions({
+    commission_status: CommissionStatus.HELD,
+  })
+  for (const attr of held as any[]) {
+    if (!attr.click_event_id) continue
+    const clicks = await service.listAttributionClickEvents({
+      id: attr.click_event_id,
+    })
+    const click = clicks[0]
+    if (!click || !click.is_bot_suspected) continue
+    try {
+      await service.disqualifyAttribution(
+        attr.id,
+        "fraud_sweep_velocity_burst"
+      )
+      if (webhooks) {
+        try {
+          await webhooks.dispatch(
+            "creator.attribution.fraud_flagged",
+            attr.creator_seller_id,
+            {
+              attribution_id: attr.id,
+              order_id: attr.order_id,
+              reason: "fraud_sweep_velocity_burst",
+            }
+          )
+        } catch (err) {
+          console.error("[attribution-fraud-sweep] webhook dispatch failed", err)
+        }
+      }
+    } catch (err) {
+      console.error("[attribution-fraud-sweep] disqualify failed", err)
+    }
+  }
+
+  if (flagged > 0) {
+    console.log(`[attribution-fraud-sweep] flagged ${flagged} clicks`)
+  }
+}
+
+export const config = {
+  name: "attribution-fraud-sweep",
+  schedule: "*/10 * * * *", // every 10 minutes
+}

--- a/backend/src/jobs/content-platform-metrics-poll.ts
+++ b/backend/src/jobs/content-platform-metrics-poll.ts
@@ -1,0 +1,82 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { CREATOR_REWARDS_MODULE } from "../modules/creator-rewards"
+import type CreatorRewardsService from "../modules/creator-rewards/service"
+import { CONTENT_PLATFORM_MODULE } from "../modules/content-platform"
+import type ContentPlatformService from "../modules/content-platform/service"
+import type { ContentPlatform } from "../modules/content-platform/providers/types"
+import {
+  ContentPostVerificationStatus,
+} from "../modules/creator-rewards/models"
+
+const POLL_BATCH_SIZE = 100
+
+/**
+ * Pull metrics every 15 minutes for verified content posts whose platform
+ * adapter supports `fetchPostMetrics` (TikTok, Instagram, YouTube, Twitch,
+ * Blackout). Adapters that don't support pull-mode (rss, custom) are
+ * silently skipped — those rely on inbound webhook ingest instead.
+ */
+export default async function contentPlatformMetricsPollJob(
+  container: MedusaContainer
+) {
+  const rewards = container.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const cp = container.resolve<ContentPlatformService>(CONTENT_PLATFORM_MODULE)
+
+  const posts = await rewards.listContentPosts({
+    verification_status: ContentPostVerificationStatus.VERIFIED,
+    qualified: true,
+  })
+
+  let attempted = 0
+  let updated = 0
+  let skipped = 0
+  for (const post of posts.slice(0, POLL_BATCH_SIZE) as any[]) {
+    if (!cp.hasProvider(post.platform as ContentPlatform)) {
+      skipped++
+      continue
+    }
+    attempted++
+    try {
+      const metrics = await cp.fetchPostMetrics({
+        platform: post.platform as ContentPlatform,
+        creatorSellerId: post.creator_seller_id,
+        externalPostId: post.external_post_id,
+      })
+      await rewards.ingestSnapshot(post.id, {
+        views: metrics.views,
+        qualifiedViews: metrics.qualified_views ?? metrics.views,
+        likes: metrics.likes,
+        shares: metrics.shares,
+        comments: metrics.comments,
+        saves: metrics.saves,
+        watchTimeSeconds: metrics.watch_time_seconds,
+        raw: metrics.raw,
+      })
+      updated++
+    } catch (err) {
+      // Adapter may throw `ProviderNotSupportedError` for pull-mode-not-
+      // supported platforms (rss/custom) or transient HTTP errors. Either
+      // way, don't crash the job — just log and move on.
+      const msg = (err as Error).message || ""
+      if (msg.includes("not support")) {
+        skipped++
+      } else {
+        console.error(
+          `[content-platform-metrics-poll] post ${post.id} failed`,
+          err
+        )
+      }
+    }
+  }
+
+  if (attempted > 0 || updated > 0) {
+    console.log(
+      `[content-platform-metrics-poll] attempted=${attempted} updated=${updated} skipped=${skipped}`
+    )
+  }
+}
+
+export const config = {
+  name: "content-platform-metrics-poll",
+  schedule: "*/15 * * * *", // every 15 minutes
+}

--- a/backend/src/jobs/creator-attribution-approve-held.ts
+++ b/backend/src/jobs/creator-attribution-approve-held.ts
@@ -1,0 +1,109 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
+import CreatorAttributionService from "../modules/creator-attribution/service"
+import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
+import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
+
+/**
+ * Hourly scheduled job that finds creator-attributed commissions whose hold
+ * window has expired and credits them to the creator's earnings account via
+ * `hawala-ledger.creditCreatorCommission`.
+ *
+ * The job is idempotent: each ledger entry uses the attribution id as its
+ * idempotency key, and the attribution row's `commission_status` gates
+ * subsequent runs.
+ */
+export default async function approveHeldCreatorAttributionsJob(
+  container: MedusaContainer
+) {
+  const attributionService = container.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+  const hawalaService = container.resolve<HawalaLedgerModuleService>(
+    HAWALA_LEDGER_MODULE
+  )
+  let webhooksService: MarketplaceWebhooksService | null = null
+  try {
+    webhooksService = container.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+  } catch {
+    webhooksService = null
+  }
+
+  const due = await attributionService.listHeldAttributionsDue()
+  if (due.length === 0) return
+
+  console.log(`[creator-approve-held] processing ${due.length} due attributions`)
+
+  for (const a of due) {
+    const amountCents = Number(a.commission_amount_cents)
+    if (!Number.isFinite(amountCents) || amountCents <= 0) {
+      // Edge case: nothing to credit (zero-cent attribution).
+      try {
+        await attributionService.approveCommission(a.id, "")
+      } catch (err) {
+        console.error(`[creator-approve-held] zero-cent approve failed for ${a.id}`, err)
+      }
+      continue
+    }
+
+    if (!a.vendor_id) {
+      // Without a vendor we can't ledger the transfer; mark disqualified
+      // rather than blocking forever.
+      try {
+        await attributionService.disqualifyAttribution(a.id, "missing_vendor_id")
+      } catch (err) {
+        console.error(`[creator-approve-held] disqualify failed for ${a.id}`, err)
+      }
+      continue
+    }
+
+    try {
+      const entry = await hawalaService.creditCreatorCommission({
+        vendorSellerId: a.vendor_id,
+        creatorSellerId: a.creator_seller_id,
+        amountCents,
+        orderId: a.order_id,
+        attributionId: a.id,
+        currencyCode: a.currency_code,
+      })
+      const updated = await attributionService.approveCommission(a.id, entry.id)
+      if (webhooksService) {
+        const payload = {
+          attribution_id: a.id,
+          order_id: a.order_id,
+          creator_seller_id: a.creator_seller_id,
+          vendor_id: a.vendor_id,
+          ledger_entry_id: entry.id,
+          commission_amount_cents: amountCents,
+          currency_code: a.currency_code,
+          commission_status: updated.commission_status,
+        }
+        try {
+          await webhooksService.dispatch(
+            "creator.commission.approved",
+            a.creator_seller_id,
+            payload
+          )
+          await webhooksService.dispatch(
+            "creator.commission.approved",
+            a.vendor_id,
+            payload
+          )
+        } catch (err) {
+          console.error(`[creator-approve-held] webhook dispatch failed for ${a.id}`, err)
+        }
+      }
+    } catch (err) {
+      console.error(`[creator-approve-held] approval failed for ${a.id}`, err)
+    }
+  }
+}
+
+export const config = {
+  name: "creator-attribution-approve-held",
+  schedule: "0 * * * *", // hourly
+}

--- a/backend/src/jobs/creator-rewards-pool-close.ts
+++ b/backend/src/jobs/creator-rewards-pool-close.ts
@@ -1,0 +1,107 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { CREATOR_REWARDS_MODULE } from "../modules/creator-rewards"
+import type CreatorRewardsService from "../modules/creator-rewards/service"
+import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
+
+/**
+ * Daily scheduled job: find any reward pool whose `period_end` has passed
+ * and that is still `accruing` or `scheduled`, calculate the per-creator
+ * distribution from cumulative qualified-view counts, persist payouts, and
+ * credit creator earnings via `hawala-ledger.creditCreatorReward`.
+ */
+export default async function creatorRewardsPoolCloseJob(container: MedusaContainer) {
+  const rewards = container.resolve<CreatorRewardsService>(CREATOR_REWARDS_MODULE)
+  const hawala = container.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+  let webhooks: MarketplaceWebhooksService | null = null
+  try {
+    webhooks = container.resolve<MarketplaceWebhooksService>(MARKETPLACE_WEBHOOKS_MODULE)
+  } catch {
+    webhooks = null
+  }
+
+  const due = await rewards.listPoolsDueForDistribution()
+  if (due.length === 0) return
+  console.log(`[creator-rewards-pool-close] processing ${due.length} due pools`)
+
+  for (const pool of due) {
+    try {
+      const result = await rewards.calculatePoolDistribution(pool.id)
+      if (result.total_distributed_cents === 0) {
+        console.log(`[creator-rewards-pool-close] no eligible creators in pool ${pool.id}`)
+        await rewards.markPoolDistributed(pool.id)
+        continue
+      }
+      const payouts = await rewards.persistDistribution(pool.id, result)
+      const currency = String(pool.currency_code || "usd").toUpperCase()
+      for (const payout of payouts) {
+        if (Number(payout.amount_cents) <= 0) continue
+        try {
+          const entry = await hawala.creditCreatorReward({
+            poolId: pool.id,
+            creatorSellerId: payout.creator_seller_id,
+            amountCents: Number(payout.amount_cents),
+            rewardPayoutId: payout.id,
+            currencyCode: currency,
+          })
+          await rewards.markPayoutPaid(payout.id, entry.id)
+
+          if (webhooks) {
+            try {
+              await webhooks.dispatch(
+                "creator.reward.distributed",
+                payout.creator_seller_id,
+                {
+                  pool_id: pool.id,
+                  payout_id: payout.id,
+                  amount_cents: Number(payout.amount_cents),
+                  qualified_views: Number(payout.qualified_views),
+                }
+              )
+            } catch (err) {
+              console.error(
+                `[creator-rewards-pool-close] webhook failed for ${payout.id}`,
+                err
+              )
+            }
+          }
+        } catch (err) {
+          console.error(
+            `[creator-rewards-pool-close] payout ${payout.id} failed`,
+            err
+          )
+        }
+      }
+      await rewards.markPoolDistributed(pool.id)
+
+      if (webhooks && pool.funder_seller_id) {
+        try {
+          await webhooks.dispatch(
+            "creator.reward.distributed",
+            pool.funder_seller_id,
+            {
+              pool_id: pool.id,
+              program_id: pool.program_id,
+              total_distributed_cents: result.total_distributed_cents,
+              creator_count: result.per_creator.length,
+            }
+          )
+        } catch (err) {
+          console.error(
+            `[creator-rewards-pool-close] funder webhook failed`,
+            err
+          )
+        }
+      }
+    } catch (err) {
+      console.error(`[creator-rewards-pool-close] pool ${pool.id} failed`, err)
+    }
+  }
+}
+
+export const config = {
+  name: "creator-rewards-pool-close",
+  schedule: "30 1 * * *", // daily at 01:30 UTC, after settlement
+}

--- a/backend/src/modules/content-platform/index.ts
+++ b/backend/src/modules/content-platform/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils"
+import ContentPlatformService from "./service"
+
+export const CONTENT_PLATFORM_MODULE = "contentPlatform"
+
+export default Module(CONTENT_PLATFORM_MODULE, {
+  service: ContentPlatformService,
+})
+
+export * from "./models"
+export * from "./providers/types"
+export type { ContentPlatformService }

--- a/backend/src/modules/content-platform/migrations/Migration20260620CreateContentPlatform.ts
+++ b/backend/src/modules/content-platform/migrations/Migration20260620CreateContentPlatform.ts
@@ -1,0 +1,58 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260620CreateContentPlatform extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "platform_account_status_enum" AS ENUM (
+          'pending', 'connected', 'reauth_required', 'revoked'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "platform_account" (
+        "id" TEXT NOT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "platform" TEXT NOT NULL,
+        "external_account_id" TEXT NOT NULL,
+        "handle" TEXT NULL,
+        "display_name" TEXT NULL,
+        "avatar_url" TEXT NULL,
+        "follower_count" INTEGER NOT NULL DEFAULT 0,
+        "access_token_encrypted" TEXT NULL,
+        "refresh_token_encrypted" TEXT NULL,
+        "token_expires_at" TIMESTAMPTZ NULL,
+        "scopes" JSONB NULL,
+        "inbound_webhook_secret" TEXT NULL,
+        "webhook_subscription_id" TEXT NULL,
+        "status" platform_account_status_enum NOT NULL DEFAULT 'pending',
+        "last_synced_at" TIMESTAMPTZ NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "platform_account_pkey" PRIMARY KEY ("id")
+      );
+    `)
+
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_platform_account_creator_platform"
+        ON "platform_account" ("creator_seller_id", "platform")
+        WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_platform_account_external"
+        ON "platform_account" ("platform", "external_account_id");
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_platform_account_status"
+        ON "platform_account" ("status");
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "platform_account" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "platform_account_status_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/content-platform/models/index.ts
+++ b/backend/src/modules/content-platform/models/index.ts
@@ -1,0 +1,2 @@
+export { default as PlatformAccount } from "./platform-account"
+export { PlatformAccountStatus } from "./platform-account"

--- a/backend/src/modules/content-platform/models/platform-account.ts
+++ b/backend/src/modules/content-platform/models/platform-account.ts
@@ -1,0 +1,60 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum PlatformAccountStatus {
+  PENDING = "pending",
+  CONNECTED = "connected",
+  REAUTH_REQUIRED = "reauth_required",
+  REVOKED = "revoked",
+}
+
+const PlatformAccount = model
+  .define("platform_account", {
+    id: model.id().primaryKey(),
+
+    creator_seller_id: model.text(),
+    platform: model.text(), // adapter key: tiktok, instagram, youtube, twitch, blackout, rss, custom
+
+    external_account_id: model.text(),
+    handle: model.text().nullable(),
+    display_name: model.text().nullable(),
+    avatar_url: model.text().nullable(),
+    follower_count: model.number().default(0),
+
+    // OAuth credentials (encrypted at rest in production — env-driven KMS key)
+    access_token_encrypted: model.text().nullable(),
+    refresh_token_encrypted: model.text().nullable(),
+    token_expires_at: model.dateTime().nullable(),
+    scopes: model.json().nullable(),
+
+    // Per-account secret for inbound webhook HMAC (used by webhook-generic
+    // adapter and any platform that supports webhook delivery)
+    inbound_webhook_secret: model.text().nullable(),
+
+    // Optional: id of the subscription registered on the *external* platform
+    webhook_subscription_id: model.text().nullable(),
+
+    status: model
+      .enum(Object.values(PlatformAccountStatus))
+      .default(PlatformAccountStatus.PENDING),
+
+    last_synced_at: model.dateTime().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["creator_seller_id", "platform"],
+      name: "UQ_platform_account_creator_platform",
+      unique: true,
+    },
+    {
+      on: ["platform", "external_account_id"],
+      name: "IDX_platform_account_external",
+    },
+    {
+      on: ["status"],
+      name: "IDX_platform_account_status",
+    },
+  ])
+
+export default PlatformAccount

--- a/backend/src/modules/content-platform/providers/blackout.ts
+++ b/backend/src/modules/content-platform/providers/blackout.ts
@@ -1,0 +1,89 @@
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  InboundWebhookRequest,
+  NormalizedEvent,
+  NormalizedPlatformAccount,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  RefreshResult,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * Blackout adapter scaffold (sister project deep integration).
+ *
+ * Loaded when `FBM_BLACKOUT_INTEGRATION=1` and `BLACKOUT_API_BASE` is set.
+ *
+ * Env vars:
+ *   FBM_BLACKOUT_INTEGRATION   feature flag (must be "1")
+ *   BLACKOUT_API_BASE          base URL of the Blackout API
+ *   BLACKOUT_CLIENT_ID         OAuth client id
+ *   BLACKOUT_CLIENT_SECRET     OAuth client secret
+ *   BLACKOUT_WEBHOOK_SECRET    HMAC secret for inbound webhook verification
+ *
+ * Implementation paused until the Blackout API spec is shared. The
+ * scaffolding below establishes the integration contract:
+ *
+ *   - OAuth: `${BLACKOUT_API_BASE}/oauth/authorize` + `/oauth/token`
+ *   - Account info: `${BLACKOUT_API_BASE}/me`
+ *   - Post metrics: `${BLACKOUT_API_BASE}/posts/:id/metrics`
+ *   - Inbound webhook: signed with `BLACKOUT_WEBHOOK_SECRET`, headers
+ *     follow the same `X-FBM-Signature: sha256=<hex>` convention as
+ *     marketplace-webhooks emits, so symmetric handling on both sides.
+ *
+ * Bidirectional sync target:
+ *   Blackout posts containing FBM affiliate links auto-create ContentPost
+ *   rows on this side; Blackout subscribes to creator.commission.approved
+ *   webhooks on its side to surface creator earnings inline in the
+ *   Blackout UI.
+ */
+export class BlackoutProvider implements ContentPlatformProvider {
+  readonly platform = "blackout" as const
+
+  private base(): string {
+    return (process.env.BLACKOUT_API_BASE ?? "").replace(/\/$/, "")
+  }
+
+  buildAuthUrl(args: { state: string; redirectUri: string; scopes?: string[] }): string {
+    const params = new URLSearchParams({
+      client_id: process.env.BLACKOUT_CLIENT_ID ?? "",
+      redirect_uri: args.redirectUri,
+      response_type: "code",
+      scope: (args.scopes ?? ["profile", "posts:read", "metrics:read"]).join(" "),
+      state: args.state,
+    })
+    return `${this.base()}/oauth/authorize?${params.toString()}`
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    // TODO: POST `${this.base()}/oauth/token` once Blackout API spec is shared
+    throw new ProviderNotSupportedError(this.platform, "exchangeCode (awaiting Blackout API spec)")
+  }
+
+  async refresh(): Promise<RefreshResult> {
+    throw new ProviderNotSupportedError(this.platform, "refresh (awaiting Blackout API spec)")
+  }
+
+  async verifyAccount(_account: NormalizedPlatformAccount): Promise<VerifyAccountResult> {
+    // TODO: GET `${this.base()}/me`
+    return { ok: false, reason: "awaiting_blackout_api_spec" }
+  }
+
+  async verifyPostOwnership(): Promise<boolean> {
+    // TODO: GET `${this.base()}/posts/:id` and check author == account.external_account_id
+    return false
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    // TODO: GET `${this.base()}/posts/:id/metrics`
+    throw new ProviderNotSupportedError(this.platform, "fetchPostMetrics (awaiting Blackout API spec)")
+  }
+
+  async handleInboundWebhook(
+    _req: InboundWebhookRequest
+  ): Promise<{ events: NormalizedEvent[]; externalAccountId?: string | null }> {
+    // TODO: verify HMAC against BLACKOUT_WEBHOOK_SECRET, normalize payload
+    return { events: [] }
+  }
+}

--- a/backend/src/modules/content-platform/providers/instagram.ts
+++ b/backend/src/modules/content-platform/providers/instagram.ts
@@ -1,0 +1,54 @@
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  NormalizedPlatformAccount,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  RefreshResult,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * Instagram adapter scaffold.
+ *
+ * Loaded when `META_APP_ID` is set. Uses Meta Graph API Business Login.
+ *
+ * Env vars: META_APP_ID, META_APP_SECRET, META_VERIFY_TOKEN.
+ */
+export class InstagramProvider implements ContentPlatformProvider {
+  readonly platform = "instagram" as const
+
+  buildAuthUrl(args: { state: string; redirectUri: string; scopes?: string[] }): string {
+    const params = new URLSearchParams({
+      client_id: process.env.META_APP_ID ?? "",
+      redirect_uri: args.redirectUri,
+      response_type: "code",
+      scope: (args.scopes ?? ["instagram_basic", "instagram_manage_insights", "pages_show_list"]).join(","),
+      state: args.state,
+    })
+    return `https://www.facebook.com/v19.0/dialog/oauth?${params.toString()}`
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    // TODO: POST https://graph.facebook.com/v19.0/oauth/access_token
+    throw new ProviderNotSupportedError(this.platform, "exchangeCode (pending impl)")
+  }
+
+  async refresh(): Promise<RefreshResult> {
+    // TODO: GET https://graph.facebook.com/v19.0/oauth/access_token?grant_type=fb_exchange_token
+    throw new ProviderNotSupportedError(this.platform, "refresh (pending impl)")
+  }
+
+  async verifyAccount(): Promise<VerifyAccountResult> {
+    return { ok: false, reason: "pending_impl" }
+  }
+
+  async verifyPostOwnership(): Promise<boolean> {
+    return false
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    // TODO: GET /{ig-media-id}/insights?metric=impressions,reach,engagement
+    throw new ProviderNotSupportedError(this.platform, "fetchPostMetrics (pending impl)")
+  }
+}

--- a/backend/src/modules/content-platform/providers/rss.ts
+++ b/backend/src/modules/content-platform/providers/rss.ts
@@ -1,0 +1,70 @@
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  NormalizedPlatformAccount,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * RSS adapter.
+ *
+ * Stock-bundled: works without any third-party API keys. Verifies post
+ * ownership by parsing the RSS feed at the creator's claimed feed URL
+ * (stored in `metadata.feed_url`) and confirming the externalPostId (the
+ * RSS `<guid>` or `<link>`) is present.
+ *
+ * Pull-mode metrics are intentionally not supported (RSS feeds don't
+ * publish view counts). For engagement-pool eligibility, blogs/podcasts
+ * should pair this adapter with `webhook-generic` to push view counts
+ * from their analytics pipeline.
+ */
+export class RssProvider implements ContentPlatformProvider {
+  readonly platform = "rss" as const
+
+  buildAuthUrl(): string {
+    throw new ProviderNotSupportedError(this.platform, "OAuth")
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    throw new ProviderNotSupportedError(this.platform, "OAuth")
+  }
+
+  async verifyAccount(account: NormalizedPlatformAccount): Promise<VerifyAccountResult> {
+    const feedUrl = (account.metadata as any)?.feed_url
+    if (!feedUrl || typeof feedUrl !== "string") {
+      return { ok: false, reason: "missing_feed_url" }
+    }
+    try {
+      const res = await fetch(feedUrl, { method: "HEAD" })
+      return { ok: res.ok, reason: res.ok ? undefined : `status_${res.status}` }
+    } catch (err) {
+      return { ok: false, reason: (err as Error).message }
+    }
+  }
+
+  async verifyPostOwnership(
+    account: NormalizedPlatformAccount,
+    externalPostId: string
+  ): Promise<boolean> {
+    const feedUrl = (account.metadata as any)?.feed_url
+    if (!feedUrl || typeof feedUrl !== "string") return false
+    try {
+      const res = await fetch(feedUrl)
+      if (!res.ok) return false
+      const xml = await res.text()
+      // Minimal contains-check; a real implementation would parse XML.
+      return xml.includes(externalPostId)
+    } catch {
+      return false
+    }
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    throw new ProviderNotSupportedError(
+      this.platform,
+      "fetchPostMetrics (RSS feeds do not expose engagement metrics)"
+    )
+  }
+}

--- a/backend/src/modules/content-platform/providers/tiktok.ts
+++ b/backend/src/modules/content-platform/providers/tiktok.ts
@@ -1,0 +1,70 @@
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  NormalizedPlatformAccount,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  RefreshResult,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * TikTok adapter scaffold.
+ *
+ * Loaded only when `TIKTOK_CLIENT_KEY` is set. Real implementation depends
+ * on TikTok for Developers OAuth + Display API; the methods below define
+ * the seam, with TODO markers calling out each network call.
+ *
+ * Env vars:
+ *   TIKTOK_CLIENT_KEY
+ *   TIKTOK_CLIENT_SECRET
+ *   TIKTOK_WEBHOOK_SECRET (for inbound webhook signature verification)
+ */
+export class TikTokProvider implements ContentPlatformProvider {
+  readonly platform = "tiktok" as const
+
+  private get clientKey(): string {
+    return process.env.TIKTOK_CLIENT_KEY ?? ""
+  }
+
+  buildAuthUrl(args: { state: string; redirectUri: string; scopes?: string[] }): string {
+    // TODO: switch to https://www.tiktok.com/v2/auth/authorize/ when impl ready
+    const scope = (args.scopes ?? ["user.info.basic", "video.list"]).join(",")
+    const params = new URLSearchParams({
+      client_key: this.clientKey,
+      redirect_uri: args.redirectUri,
+      response_type: "code",
+      scope,
+      state: args.state,
+    })
+    return `https://www.tiktok.com/v2/auth/authorize/?${params.toString()}`
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    // TODO: POST https://open.tiktokapis.com/v2/oauth/token/
+    throw new ProviderNotSupportedError(this.platform, "exchangeCode (pending impl)")
+  }
+
+  async refresh(): Promise<RefreshResult> {
+    // TODO: POST https://open.tiktokapis.com/v2/oauth/token/ with grant_type=refresh_token
+    throw new ProviderNotSupportedError(this.platform, "refresh (pending impl)")
+  }
+
+  async verifyAccount(): Promise<VerifyAccountResult> {
+    // TODO: GET https://open.tiktokapis.com/v2/user/info/
+    return { ok: false, reason: "pending_impl" }
+  }
+
+  async verifyPostOwnership(
+    _account: NormalizedPlatformAccount,
+    _externalPostId: string
+  ): Promise<boolean> {
+    // TODO: GET https://open.tiktokapis.com/v2/video/query/ filtered to creator's videos
+    return false
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    // TODO: GET https://open.tiktokapis.com/v2/video/query/ with stats fields
+    throw new ProviderNotSupportedError(this.platform, "fetchPostMetrics (pending impl)")
+  }
+}

--- a/backend/src/modules/content-platform/providers/twitch.ts
+++ b/backend/src/modules/content-platform/providers/twitch.ts
@@ -1,0 +1,49 @@
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  RefreshResult,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * Twitch adapter scaffold. Loaded when `TWITCH_CLIENT_ID` is set.
+ * Uses Twitch Helix API. Env: TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET.
+ */
+export class TwitchProvider implements ContentPlatformProvider {
+  readonly platform = "twitch" as const
+
+  buildAuthUrl(args: { state: string; redirectUri: string; scopes?: string[] }): string {
+    const params = new URLSearchParams({
+      client_id: process.env.TWITCH_CLIENT_ID ?? "",
+      redirect_uri: args.redirectUri,
+      response_type: "code",
+      scope: (args.scopes ?? ["user:read:email", "channel:read:subscriptions"]).join(" "),
+      state: args.state,
+    })
+    return `https://id.twitch.tv/oauth2/authorize?${params.toString()}`
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    // TODO: POST https://id.twitch.tv/oauth2/token
+    throw new ProviderNotSupportedError(this.platform, "exchangeCode (pending impl)")
+  }
+
+  async refresh(): Promise<RefreshResult> {
+    throw new ProviderNotSupportedError(this.platform, "refresh (pending impl)")
+  }
+
+  async verifyAccount(): Promise<VerifyAccountResult> {
+    return { ok: false, reason: "pending_impl" }
+  }
+
+  async verifyPostOwnership(): Promise<boolean> {
+    return false
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    // TODO: GET https://api.twitch.tv/helix/videos
+    throw new ProviderNotSupportedError(this.platform, "fetchPostMetrics (pending impl)")
+  }
+}

--- a/backend/src/modules/content-platform/providers/types.ts
+++ b/backend/src/modules/content-platform/providers/types.ts
@@ -1,0 +1,135 @@
+/**
+ * ContentPlatformProvider — pluggable adapter interface.
+ *
+ * Each adapter encapsulates one external content platform (TikTok,
+ * Instagram, YouTube, Twitch, Blackout, an RSS-fed blog, or a generic
+ * webhook-emitting site). The creator-program and creator-rewards modules
+ * never import an adapter directly — they call
+ * `ContentPlatformService.getProvider(platform)` and depend only on this
+ * interface. That keeps Blackout/social-platform code optional and
+ * open-source-friendly.
+ */
+
+export type ContentPlatform =
+  | "tiktok"
+  | "instagram"
+  | "youtube"
+  | "twitch"
+  | "blackout"
+  | "rss"
+  | "podcast"
+  | "custom"
+
+export interface ProviderMetrics {
+  views: number
+  likes: number
+  shares: number
+  comments: number
+  saves?: number
+  watch_time_seconds?: number
+  // Platform-specific anti-fraud signal: views deduped by visitor + region
+  // + bot filter. Defaults to `views` when the platform doesn't expose it.
+  qualified_views?: number
+  raw: Record<string, unknown>
+}
+
+export interface NormalizedPlatformAccount {
+  id: string
+  creator_seller_id: string
+  platform: ContentPlatform
+  external_account_id: string
+  handle: string | null
+  access_token_encrypted: string | null
+  refresh_token_encrypted: string | null
+  token_expires_at: Date | null
+  scopes: string[] | null
+  inbound_webhook_secret: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export interface ExchangeCodeResult {
+  access: string
+  refresh?: string
+  expiresAt?: Date
+  externalAccountId: string
+  handle?: string
+  followerCount?: number
+  scopes?: string[]
+}
+
+export interface RefreshResult {
+  access: string
+  refresh?: string
+  expiresAt?: Date
+}
+
+export interface VerifyAccountResult {
+  ok: boolean
+  followerCount?: number
+  reason?: string
+}
+
+export interface NormalizedEvent {
+  type: "post.published" | "post.metrics_updated" | "account.revoked"
+  externalAccountId: string
+  externalPostId?: string
+  metrics?: Partial<ProviderMetrics>
+  occurredAt: Date
+  raw?: Record<string, unknown>
+}
+
+export interface InboundWebhookRequest {
+  headers: Record<string, string | string[] | undefined>
+  rawBody: string | Buffer | null
+  body: unknown
+}
+
+export interface ContentPlatformProvider {
+  readonly platform: ContentPlatform
+
+  // OAuth (optional — adapters that don't use OAuth like `rss` or `custom`
+  // can throw "not_supported" here; the registry never wires up an OAuth
+  // route for them).
+  buildAuthUrl(args: {
+    state: string
+    redirectUri: string
+    scopes?: string[]
+  }): string
+
+  exchangeCode(code: string, redirectUri: string): Promise<ExchangeCodeResult>
+
+  refresh?(refreshToken: string): Promise<RefreshResult>
+
+  // Verification
+  verifyAccount(account: NormalizedPlatformAccount): Promise<VerifyAccountResult>
+
+  verifyPostOwnership(
+    account: NormalizedPlatformAccount,
+    externalPostId: string
+  ): Promise<boolean>
+
+  // Metrics
+  fetchPostMetrics(
+    account: NormalizedPlatformAccount,
+    externalPostId: string
+  ): Promise<ProviderMetrics>
+
+  // Optional: subscribe to push events on the external platform
+  subscribeToPostEvents?(
+    account: NormalizedPlatformAccount
+  ): Promise<{ subscriptionId: string }>
+
+  // Optional: handle inbound webhooks (HMAC verification + payload
+  // normalization). Adapters that support push wire this up via the
+  // /v1/webhooks/content-platform/:platform ingress endpoint.
+  handleInboundWebhook?(
+    req: InboundWebhookRequest
+  ): Promise<{ events: NormalizedEvent[]; externalAccountId?: string | null }>
+}
+
+export class ProviderNotSupportedError extends Error {
+  constructor(platform: string, capability: string) {
+    super(`Provider ${platform} does not support ${capability}`)
+    this.name = "ProviderNotSupportedError"
+  }
+}

--- a/backend/src/modules/content-platform/providers/webhook-generic.ts
+++ b/backend/src/modules/content-platform/providers/webhook-generic.ts
@@ -1,0 +1,129 @@
+import { createHmac, timingSafeEqual } from "crypto"
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  InboundWebhookRequest,
+  NormalizedEvent,
+  NormalizedPlatformAccount,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * Generic webhook adapter.
+ *
+ * Stock-bundled: works without any third-party API keys. Any third-party
+ * site (a custom CMS, a podcast host, a blog, Blackout while its first-
+ * party adapter is in progress) can paste a webhook URL into their
+ * publishing pipeline that POSTs JSON like:
+ *
+ *   {
+ *     "type": "post.metrics_updated",
+ *     "externalAccountId": "<creator's account id on that platform>",
+ *     "externalPostId": "<post id>",
+ *     "metrics": { "views": 1000, "likes": 50, "shares": 3, "comments": 2 },
+ *     "occurredAt": "2026-05-06T12:00:00Z"
+ *   }
+ *
+ * to `POST /v1/webhooks/content-platform/custom`. The request must carry
+ * an `X-FBM-Signature: sha256=<hex>` header computed with the per-account
+ * `inbound_webhook_secret` shown to the creator at platform-account
+ * connect time. We validate the signature here and normalize.
+ *
+ * No OAuth. `verifyPostOwnership` always succeeds on this adapter; the
+ * creator establishes ownership by being the holder of the webhook secret.
+ */
+export class WebhookGenericProvider implements ContentPlatformProvider {
+  readonly platform = "custom" as const
+
+  buildAuthUrl(): string {
+    throw new ProviderNotSupportedError(this.platform, "OAuth")
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    throw new ProviderNotSupportedError(this.platform, "OAuth")
+  }
+
+  async verifyAccount(): Promise<VerifyAccountResult> {
+    return { ok: true }
+  }
+
+  async verifyPostOwnership(): Promise<boolean> {
+    return true
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    // Pull-mode is not supported — push-only via inbound webhook.
+    throw new ProviderNotSupportedError(this.platform, "fetchPostMetrics (push-only adapter)")
+  }
+
+  async handleInboundWebhook(
+    req: InboundWebhookRequest
+  ): Promise<{ events: NormalizedEvent[]; externalAccountId?: string | null }> {
+    const sigHeader = readHeader(req.headers, "x-fbm-signature")
+    if (!sigHeader) {
+      throw new Error("Missing X-FBM-Signature header")
+    }
+
+    // Body parsing
+    const payload = typeof req.body === "object" && req.body !== null ? req.body : null
+    if (!payload) {
+      throw new Error("Invalid webhook body")
+    }
+    const externalAccountId = (payload as any).externalAccountId
+    if (!externalAccountId || typeof externalAccountId !== "string") {
+      throw new Error("Missing externalAccountId in payload")
+    }
+
+    // Signature verification happens at the service layer (it has access to
+    // the per-account secret). Here we just normalize.
+    const type = (payload as any).type
+    const externalPostId = (payload as any).externalPostId
+    const metrics = (payload as any).metrics ?? null
+    const occurredAtRaw = (payload as any).occurredAt
+    const occurredAt = occurredAtRaw ? new Date(occurredAtRaw) : new Date()
+
+    const events: NormalizedEvent[] = []
+    if (type === "post.published" || type === "post.metrics_updated" || type === "account.revoked") {
+      events.push({
+        type,
+        externalAccountId,
+        externalPostId,
+        metrics: metrics ?? undefined,
+        occurredAt,
+        raw: payload as Record<string, unknown>,
+      })
+    }
+    return { events, externalAccountId }
+  }
+
+  /**
+   * Verify HMAC signature against the per-account secret. Exposed as a
+   * static helper so the service layer (which holds the secret) can call it
+   * before invoking handleInboundWebhook.
+   */
+  static verifySignature(
+    rawBody: string | Buffer,
+    sigHeader: string,
+    secret: string
+  ): boolean {
+    const m = /^sha256=([a-f0-9]+)$/i.exec(sigHeader.trim())
+    if (!m) return false
+    const provided = Buffer.from(m[1], "hex")
+    const expected = createHmac("sha256", secret)
+      .update(rawBody as any)
+      .digest()
+    if (provided.length !== expected.length) return false
+    return timingSafeEqual(provided, expected)
+  }
+}
+
+function readHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | null {
+  const v = headers[name] ?? headers[name.toLowerCase()]
+  if (Array.isArray(v)) return v[0] ?? null
+  return v ?? null
+}

--- a/backend/src/modules/content-platform/providers/youtube.ts
+++ b/backend/src/modules/content-platform/providers/youtube.ts
@@ -1,0 +1,55 @@
+import {
+  ContentPlatformProvider,
+  ExchangeCodeResult,
+  ProviderMetrics,
+  ProviderNotSupportedError,
+  RefreshResult,
+  VerifyAccountResult,
+} from "./types"
+
+/**
+ * YouTube adapter scaffold.
+ *
+ * Loaded when `GOOGLE_CLIENT_ID` is set. Uses Google OAuth + YouTube Data
+ * API v3.
+ *
+ * Env vars: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET.
+ */
+export class YouTubeProvider implements ContentPlatformProvider {
+  readonly platform = "youtube" as const
+
+  buildAuthUrl(args: { state: string; redirectUri: string; scopes?: string[] }): string {
+    const params = new URLSearchParams({
+      client_id: process.env.GOOGLE_CLIENT_ID ?? "",
+      redirect_uri: args.redirectUri,
+      response_type: "code",
+      scope: (args.scopes ?? ["https://www.googleapis.com/auth/youtube.readonly"]).join(" "),
+      access_type: "offline",
+      prompt: "consent",
+      state: args.state,
+    })
+    return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`
+  }
+
+  async exchangeCode(): Promise<ExchangeCodeResult> {
+    // TODO: POST https://oauth2.googleapis.com/token
+    throw new ProviderNotSupportedError(this.platform, "exchangeCode (pending impl)")
+  }
+
+  async refresh(): Promise<RefreshResult> {
+    throw new ProviderNotSupportedError(this.platform, "refresh (pending impl)")
+  }
+
+  async verifyAccount(): Promise<VerifyAccountResult> {
+    return { ok: false, reason: "pending_impl" }
+  }
+
+  async verifyPostOwnership(): Promise<boolean> {
+    return false
+  }
+
+  async fetchPostMetrics(): Promise<ProviderMetrics> {
+    // TODO: GET https://www.googleapis.com/youtube/v3/videos?part=statistics&id=...
+    throw new ProviderNotSupportedError(this.platform, "fetchPostMetrics (pending impl)")
+  }
+}

--- a/backend/src/modules/content-platform/service.ts
+++ b/backend/src/modules/content-platform/service.ts
@@ -1,0 +1,305 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { randomBytes } from "crypto"
+import PlatformAccount, {
+  PlatformAccountStatus,
+} from "./models/platform-account"
+import {
+  ContentPlatform,
+  ContentPlatformProvider,
+  NormalizedEvent,
+  NormalizedPlatformAccount,
+  ProviderMetrics,
+} from "./providers/types"
+import { WebhookGenericProvider } from "./providers/webhook-generic"
+import { RssProvider } from "./providers/rss"
+import { TikTokProvider } from "./providers/tiktok"
+import { InstagramProvider } from "./providers/instagram"
+import { YouTubeProvider } from "./providers/youtube"
+import { TwitchProvider } from "./providers/twitch"
+import { BlackoutProvider } from "./providers/blackout"
+
+class ContentPlatformService extends MedusaService({ PlatformAccount }) {
+  private providers = new Map<ContentPlatform, ContentPlatformProvider>()
+
+  constructor(...args: any[]) {
+    super(...args)
+    this.registerStockProviders()
+  }
+
+  /**
+   * Register the stock-bundled adapters that don't need third-party env
+   * vars (so any open-source deployment has working `rss` and `custom`
+   * providers out of the box). Optional adapters are registered only when
+   * their env vars are present.
+   */
+  private registerStockProviders() {
+    this.registerProvider(new WebhookGenericProvider())
+    this.registerProvider(new RssProvider())
+
+    if (process.env.TIKTOK_CLIENT_KEY) {
+      this.registerProvider(new TikTokProvider())
+    }
+    if (process.env.META_APP_ID) {
+      this.registerProvider(new InstagramProvider())
+    }
+    if (process.env.GOOGLE_CLIENT_ID) {
+      this.registerProvider(new YouTubeProvider())
+    }
+    if (process.env.TWITCH_CLIENT_ID) {
+      this.registerProvider(new TwitchProvider())
+    }
+    if (
+      process.env.FBM_BLACKOUT_INTEGRATION === "1" &&
+      process.env.BLACKOUT_API_BASE
+    ) {
+      this.registerProvider(new BlackoutProvider())
+    }
+  }
+
+  registerProvider(p: ContentPlatformProvider): void {
+    this.providers.set(p.platform, p)
+  }
+
+  hasProvider(platform: ContentPlatform): boolean {
+    return this.providers.has(platform)
+  }
+
+  getProvider(platform: ContentPlatform): ContentPlatformProvider {
+    const p = this.providers.get(platform)
+    if (!p) {
+      throw new Error(
+        `No provider registered for platform "${platform}". ` +
+          `Set the matching env var to enable it (e.g. TIKTOK_CLIENT_KEY).`
+      )
+    }
+    return p
+  }
+
+  listAvailablePlatforms(): ContentPlatform[] {
+    return Array.from(this.providers.keys())
+  }
+
+  /**
+   * Begin OAuth: returns the auth URL the creator should be redirected to
+   * plus an opaque `state` value the caller should round-trip.
+   */
+  async startOAuth(args: {
+    creatorSellerId: string
+    platform: ContentPlatform
+    redirectUri: string
+    scopes?: string[]
+  }): Promise<{ authUrl: string; state: string }> {
+    const provider = this.getProvider(args.platform)
+    const state = randomBytes(16).toString("hex")
+    const authUrl = provider.buildAuthUrl({
+      state,
+      redirectUri: args.redirectUri,
+      scopes: args.scopes,
+    })
+    // The state value is short-lived and only meaningful round-tripped
+    // through the OAuth flow. Caller (route handler) is responsible for
+    // associating `state` with the creator session via cookie.
+    return { authUrl, state }
+  }
+
+  async finishOAuth(args: {
+    creatorSellerId: string
+    platform: ContentPlatform
+    code: string
+    redirectUri: string
+  }): Promise<any> {
+    const provider = this.getProvider(args.platform)
+    const result = await provider.exchangeCode(args.code, args.redirectUri)
+
+    const existing = await this.listPlatformAccounts({
+      creator_seller_id: args.creatorSellerId,
+      platform: args.platform,
+    })
+
+    const fields = {
+      external_account_id: result.externalAccountId,
+      handle: result.handle ?? null,
+      follower_count: result.followerCount ?? 0,
+      access_token_encrypted: result.access,
+      refresh_token_encrypted: result.refresh ?? null,
+      token_expires_at: result.expiresAt ?? null,
+      scopes: result.scopes ?? null,
+      status: PlatformAccountStatus.CONNECTED,
+      last_synced_at: new Date(),
+    }
+
+    if (existing.length > 0) {
+      return (this as any).updatePlatformAccounts({ id: existing[0].id, ...fields })
+    }
+    return (this as any).createPlatformAccounts({
+      creator_seller_id: args.creatorSellerId,
+      platform: args.platform,
+      ...fields,
+    })
+  }
+
+  /**
+   * Connect a platform that doesn't use OAuth (RSS, custom webhook).
+   * Issues an inbound webhook secret the creator must include in
+   * `X-FBM-Signature` HMAC headers when posting events.
+   */
+  async connectNonOAuth(args: {
+    creatorSellerId: string
+    platform: ContentPlatform
+    externalAccountId: string
+    handle?: string | null
+    metadata?: Record<string, unknown>
+  }): Promise<any> {
+    const existing = await this.listPlatformAccounts({
+      creator_seller_id: args.creatorSellerId,
+      platform: args.platform,
+    })
+    const fields = {
+      external_account_id: args.externalAccountId,
+      handle: args.handle ?? null,
+      inbound_webhook_secret:
+        existing[0]?.inbound_webhook_secret ??
+        `fbm_pwhk_${randomBytes(24).toString("hex")}`,
+      status: PlatformAccountStatus.CONNECTED,
+      last_synced_at: new Date(),
+      metadata: args.metadata ?? null,
+    }
+    if (existing.length > 0) {
+      return (this as any).updatePlatformAccounts({ id: existing[0].id, ...fields })
+    }
+    return (this as any).createPlatformAccounts({
+      creator_seller_id: args.creatorSellerId,
+      platform: args.platform,
+      ...fields,
+    })
+  }
+
+  async revokeAccount(accountId: string): Promise<any> {
+    return (this as any).updatePlatformAccounts({
+      id: accountId,
+      status: PlatformAccountStatus.REVOKED,
+      access_token_encrypted: null,
+      refresh_token_encrypted: null,
+    })
+  }
+
+  /**
+   * Pull metrics for a single post via the matching platform adapter.
+   */
+  async fetchPostMetrics(args: {
+    platform: ContentPlatform
+    creatorSellerId: string
+    externalPostId: string
+  }): Promise<ProviderMetrics> {
+    const accounts = await this.listPlatformAccounts({
+      creator_seller_id: args.creatorSellerId,
+      platform: args.platform,
+    })
+    const account = accounts[0]
+    if (!account) throw new Error("Platform account not connected")
+    const provider = this.getProvider(args.platform)
+    return provider.fetchPostMetrics(this.normalizeAccount(account), args.externalPostId)
+  }
+
+  async verifyPostOwnership(args: {
+    platform: ContentPlatform
+    creatorSellerId: string
+    externalPostId: string
+  }): Promise<boolean> {
+    const accounts = await this.listPlatformAccounts({
+      creator_seller_id: args.creatorSellerId,
+      platform: args.platform,
+    })
+    const account = accounts[0]
+    if (!account) return false
+    const provider = this.getProvider(args.platform)
+    try {
+      return await provider.verifyPostOwnership(
+        this.normalizeAccount(account),
+        args.externalPostId
+      )
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Validate + dispatch an inbound webhook from an external content
+   * platform. Returns normalized events. Caller is responsible for then
+   * upserting into `creator-rewards.EngagementSnapshot` (this module
+   * intentionally does not depend on creator-rewards).
+   */
+  async dispatchInbound(args: {
+    platform: ContentPlatform
+    headers: Record<string, string | string[] | undefined>
+    rawBody: string | Buffer | null
+    body: unknown
+  }): Promise<NormalizedEvent[]> {
+    const provider = this.getProvider(args.platform)
+    if (!provider.handleInboundWebhook) return []
+
+    // Signature pre-check for the webhook-generic provider, which uses
+    // per-account secrets. Other providers handle their own signature
+    // verification inside handleInboundWebhook (with platform-wide
+    // secrets from env).
+    if (args.platform === "custom") {
+      const sig = readHeader(args.headers, "x-fbm-signature")
+      const externalAccountId = (args.body as any)?.externalAccountId
+      if (!sig || !externalAccountId || typeof externalAccountId !== "string") {
+        throw new Error("custom webhook requires X-FBM-Signature + externalAccountId")
+      }
+      const accounts = await this.listPlatformAccounts({
+        platform: "custom",
+        external_account_id: externalAccountId,
+      })
+      const account = accounts[0]
+      if (!account || !account.inbound_webhook_secret) {
+        throw new Error("Unknown account for inbound custom webhook")
+      }
+      const ok = WebhookGenericProvider.verifySignature(
+        args.rawBody ?? "",
+        sig,
+        account.inbound_webhook_secret
+      )
+      if (!ok) {
+        throw new Error("Invalid X-FBM-Signature for custom webhook")
+      }
+    }
+
+    const result = await provider.handleInboundWebhook({
+      headers: args.headers,
+      rawBody: args.rawBody,
+      body: args.body,
+    })
+    return result.events
+  }
+
+  private normalizeAccount(account: any): NormalizedPlatformAccount {
+    return {
+      id: account.id,
+      creator_seller_id: account.creator_seller_id,
+      platform: account.platform as ContentPlatform,
+      external_account_id: account.external_account_id,
+      handle: account.handle ?? null,
+      access_token_encrypted: account.access_token_encrypted ?? null,
+      refresh_token_encrypted: account.refresh_token_encrypted ?? null,
+      token_expires_at: account.token_expires_at
+        ? new Date(account.token_expires_at)
+        : null,
+      scopes: (account.scopes as string[] | null) ?? null,
+      inbound_webhook_secret: account.inbound_webhook_secret ?? null,
+      metadata: (account.metadata as Record<string, unknown> | null) ?? null,
+    }
+  }
+}
+
+function readHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | null {
+  const v = headers[name] ?? headers[name.toLowerCase()]
+  if (Array.isArray(v)) return v[0] ?? null
+  return v ?? null
+}
+
+export default ContentPlatformService

--- a/backend/src/modules/creator-attribution/index.ts
+++ b/backend/src/modules/creator-attribution/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import CreatorAttributionService from "./service"
+
+export const CREATOR_ATTRIBUTION_MODULE = "creatorAttribution"
+
+export default Module(CREATOR_ATTRIBUTION_MODULE, {
+  service: CreatorAttributionService,
+})
+
+export * from "./models"
+export type { CreatorAttributionService }

--- a/backend/src/modules/creator-attribution/migrations/Migration20260520CreateCreatorAttribution.ts
+++ b/backend/src/modules/creator-attribution/migrations/Migration20260520CreateCreatorAttribution.ts
@@ -1,0 +1,185 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260520CreateCreatorAttribution extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "affiliate_link_status_enum" AS ENUM (
+          'active', 'paused', 'revoked'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "promo_code_binding_priority_enum" AS ENUM (
+          'override_link', 'fallback', 'tie_breaker'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "promo_code_binding_status_enum" AS ENUM (
+          'active', 'paused', 'revoked'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "attribution_source_enum" AS ENUM (
+          'link_click', 'promo_code', 'direct_landing', 'embed_widget'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "attribution_model_enum" AS ENUM (
+          'last_click', 'first_click', 'linear'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "commission_status_enum" AS ENUM (
+          'pending', 'held', 'approved', 'paid', 'reversed', 'disqualified'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    // affiliate_link
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "affiliate_link" (
+        "id" TEXT NOT NULL,
+        "short_code" TEXT NOT NULL UNIQUE,
+        "creator_seller_id" TEXT NOT NULL,
+        "deal_id" TEXT NULL,
+        "program_id" TEXT NULL,
+        "vendor_id" TEXT NULL,
+        "product_id" TEXT NULL,
+        "collection_id" TEXT NULL,
+        "destination_path" TEXT NOT NULL,
+        "utm_source" TEXT NOT NULL DEFAULT 'creator',
+        "utm_medium" TEXT NULL,
+        "utm_campaign" TEXT NULL,
+        "utm_content" TEXT NULL,
+        "allowed_origins" JSONB NULL,
+        "status" affiliate_link_status_enum NOT NULL DEFAULT 'active',
+        "click_count" INTEGER NOT NULL DEFAULT 0,
+        "attributed_order_count" INTEGER NOT NULL DEFAULT 0,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "affiliate_link_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_affiliate_link_creator" ON "affiliate_link" ("creator_seller_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_affiliate_link_program" ON "affiliate_link" ("program_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_affiliate_link_status" ON "affiliate_link" ("status");`)
+
+    // promo_code_binding
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "promo_code_binding" (
+        "id" TEXT NOT NULL,
+        "promotion_id" TEXT NOT NULL,
+        "promotion_code" TEXT NOT NULL UNIQUE,
+        "creator_seller_id" TEXT NOT NULL,
+        "deal_id" TEXT NULL,
+        "program_id" TEXT NULL,
+        "vendor_id" TEXT NULL,
+        "attribution_priority" promo_code_binding_priority_enum NOT NULL DEFAULT 'override_link',
+        "status" promo_code_binding_status_enum NOT NULL DEFAULT 'active',
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "promo_code_binding_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_promo_binding_creator" ON "promo_code_binding" ("creator_seller_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_promo_binding_promotion" ON "promo_code_binding" ("promotion_id");`)
+
+    // attribution_click_event
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "attribution_click_event" (
+        "id" TEXT NOT NULL,
+        "short_code" TEXT NOT NULL,
+        "affiliate_link_id" TEXT NOT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "visitor_token" TEXT NOT NULL,
+        "ip_hash" TEXT NULL,
+        "user_agent_hash" TEXT NULL,
+        "referrer" TEXT NULL,
+        "country" TEXT NULL,
+        "customer_id" TEXT NULL,
+        "fingerprint" TEXT NULL,
+        "is_bot_suspected" BOOLEAN NOT NULL DEFAULT FALSE,
+        "occurred_at" TIMESTAMPTZ NOT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "attribution_click_event_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_click_event_visitor_time" ON "attribution_click_event" ("visitor_token", "occurred_at");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_click_event_link_time" ON "attribution_click_event" ("affiliate_link_id", "occurred_at");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_click_event_creator_time" ON "attribution_click_event" ("creator_seller_id", "occurred_at");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_click_event_short_code" ON "attribution_click_event" ("short_code");`)
+
+    // order_attribution
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "order_attribution" (
+        "id" TEXT NOT NULL,
+        "order_id" TEXT NOT NULL UNIQUE,
+        "customer_id" TEXT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "affiliate_link_id" TEXT NULL,
+        "promo_code_binding_id" TEXT NULL,
+        "deal_id" TEXT NULL,
+        "program_id" TEXT NULL,
+        "vendor_id" TEXT NULL,
+        "source" attribution_source_enum NOT NULL,
+        "attribution_model" attribution_model_enum NOT NULL DEFAULT 'last_click',
+        "click_event_id" TEXT NULL,
+        "cookie_window_days" INTEGER NOT NULL DEFAULT 7,
+        "attribution_decided_at" TIMESTAMPTZ NOT NULL,
+        "attributed_subtotal_cents" NUMERIC NOT NULL,
+        "commission_basis_cents" NUMERIC NOT NULL,
+        "commission_amount_cents" NUMERIC NOT NULL,
+        "commission_percent" NUMERIC NULL,
+        "currency_code" TEXT NOT NULL DEFAULT 'usd',
+        "commission_status" commission_status_enum NOT NULL DEFAULT 'pending',
+        "hold_until" TIMESTAMPTZ NULL,
+        "ledger_entry_id" TEXT NULL,
+        "disqualified_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "order_attribution_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_order_attribution_creator_status" ON "order_attribution" ("creator_seller_id", "commission_status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_order_attribution_program" ON "order_attribution" ("program_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_order_attribution_deal" ON "order_attribution" ("deal_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_order_attribution_status_hold" ON "order_attribution" ("commission_status", "hold_until");`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "order_attribution" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "attribution_click_event" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "promo_code_binding" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "affiliate_link" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "commission_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "attribution_model_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "attribution_source_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "promo_code_binding_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "promo_code_binding_priority_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "affiliate_link_status_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/creator-attribution/models/affiliate-link.ts
+++ b/backend/src/modules/creator-attribution/models/affiliate-link.ts
@@ -1,0 +1,54 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum AffiliateLinkStatus {
+  ACTIVE = "active",
+  PAUSED = "paused",
+  REVOKED = "revoked",
+}
+
+const AffiliateLink = model
+  .define("affiliate_link", {
+    id: model.id().primaryKey(),
+
+    short_code: model.text().unique(),
+    creator_seller_id: model.text(),
+    deal_id: model.text().nullable(),
+    program_id: model.text().nullable(),
+    vendor_id: model.text().nullable(),
+
+    product_id: model.text().nullable(),
+    collection_id: model.text().nullable(),
+    destination_path: model.text(),
+
+    utm_source: model.text().default("creator"),
+    utm_medium: model.text().nullable(),
+    utm_campaign: model.text().nullable(),
+    utm_content: model.text().nullable(),
+
+    allowed_origins: model.json().nullable(),
+
+    status: model
+      .enum(Object.values(AffiliateLinkStatus))
+      .default(AffiliateLinkStatus.ACTIVE),
+
+    click_count: model.number().default(0),
+    attributed_order_count: model.number().default(0),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["creator_seller_id"],
+      name: "IDX_affiliate_link_creator",
+    },
+    {
+      on: ["program_id"],
+      name: "IDX_affiliate_link_program",
+    },
+    {
+      on: ["status"],
+      name: "IDX_affiliate_link_status",
+    },
+  ])
+
+export default AffiliateLink

--- a/backend/src/modules/creator-attribution/models/click-event.ts
+++ b/backend/src/modules/creator-attribution/models/click-event.ts
@@ -1,0 +1,44 @@
+import { model } from "@medusajs/framework/utils"
+
+const AttributionClickEvent = model
+  .define("attribution_click_event", {
+    id: model.id().primaryKey(),
+
+    short_code: model.text(),
+    affiliate_link_id: model.text(),
+    creator_seller_id: model.text(),
+
+    visitor_token: model.text(),
+    ip_hash: model.text().nullable(),
+    user_agent_hash: model.text().nullable(),
+    referrer: model.text().nullable(),
+    country: model.text().nullable(),
+    customer_id: model.text().nullable(),
+
+    fingerprint: model.text().nullable(),
+    is_bot_suspected: model.boolean().default(false),
+
+    occurred_at: model.dateTime(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["visitor_token", "occurred_at"],
+      name: "IDX_click_event_visitor_time",
+    },
+    {
+      on: ["affiliate_link_id", "occurred_at"],
+      name: "IDX_click_event_link_time",
+    },
+    {
+      on: ["creator_seller_id", "occurred_at"],
+      name: "IDX_click_event_creator_time",
+    },
+    {
+      on: ["short_code"],
+      name: "IDX_click_event_short_code",
+    },
+  ])
+
+export default AttributionClickEvent

--- a/backend/src/modules/creator-attribution/models/index.ts
+++ b/backend/src/modules/creator-attribution/models/index.ts
@@ -1,0 +1,15 @@
+export { default as AffiliateLink } from "./affiliate-link"
+export { default as PromoCodeBinding } from "./promo-code-binding"
+export { default as AttributionClickEvent } from "./click-event"
+export { default as OrderAttribution } from "./order-attribution"
+
+export { AffiliateLinkStatus } from "./affiliate-link"
+export {
+  PromoCodeBindingPriority,
+  PromoCodeBindingStatus,
+} from "./promo-code-binding"
+export {
+  AttributionSource,
+  AttributionModel,
+  CommissionStatus,
+} from "./order-attribution"

--- a/backend/src/modules/creator-attribution/models/order-attribution.ts
+++ b/backend/src/modules/creator-attribution/models/order-attribution.ts
@@ -1,0 +1,82 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum AttributionSource {
+  LINK_CLICK = "link_click",
+  PROMO_CODE = "promo_code",
+  DIRECT_LANDING = "direct_landing",
+  EMBED_WIDGET = "embed_widget",
+}
+
+export enum AttributionModel {
+  LAST_CLICK = "last_click",
+  FIRST_CLICK = "first_click",
+  LINEAR = "linear",
+}
+
+export enum CommissionStatus {
+  PENDING = "pending",
+  HELD = "held",
+  APPROVED = "approved",
+  PAID = "paid",
+  REVERSED = "reversed",
+  DISQUALIFIED = "disqualified",
+}
+
+const OrderAttribution = model
+  .define("order_attribution", {
+    id: model.id().primaryKey(),
+
+    order_id: model.text().unique(),
+    customer_id: model.text().nullable(),
+    creator_seller_id: model.text(),
+    affiliate_link_id: model.text().nullable(),
+    promo_code_binding_id: model.text().nullable(),
+    deal_id: model.text().nullable(),
+    program_id: model.text().nullable(),
+    vendor_id: model.text().nullable(),
+
+    source: model.enum(Object.values(AttributionSource)),
+    attribution_model: model
+      .enum(Object.values(AttributionModel))
+      .default(AttributionModel.LAST_CLICK),
+
+    click_event_id: model.text().nullable(),
+    cookie_window_days: model.number().default(7),
+    attribution_decided_at: model.dateTime(),
+
+    attributed_subtotal_cents: model.bigNumber(),
+    commission_basis_cents: model.bigNumber(),
+    commission_amount_cents: model.bigNumber(),
+    commission_percent: model.number().nullable(),
+    currency_code: model.text().default("usd"),
+
+    commission_status: model
+      .enum(Object.values(CommissionStatus))
+      .default(CommissionStatus.PENDING),
+    hold_until: model.dateTime().nullable(),
+    ledger_entry_id: model.text().nullable(),
+
+    disqualified_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["creator_seller_id", "commission_status"],
+      name: "IDX_order_attribution_creator_status",
+    },
+    {
+      on: ["program_id"],
+      name: "IDX_order_attribution_program",
+    },
+    {
+      on: ["deal_id"],
+      name: "IDX_order_attribution_deal",
+    },
+    {
+      on: ["commission_status", "hold_until"],
+      name: "IDX_order_attribution_status_hold",
+    },
+  ])
+
+export default OrderAttribution

--- a/backend/src/modules/creator-attribution/models/promo-code-binding.ts
+++ b/backend/src/modules/creator-attribution/models/promo-code-binding.ts
@@ -1,0 +1,48 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum PromoCodeBindingPriority {
+  OVERRIDE_LINK = "override_link",
+  FALLBACK = "fallback",
+  TIE_BREAKER = "tie_breaker",
+}
+
+export enum PromoCodeBindingStatus {
+  ACTIVE = "active",
+  PAUSED = "paused",
+  REVOKED = "revoked",
+}
+
+const PromoCodeBinding = model
+  .define("promo_code_binding", {
+    id: model.id().primaryKey(),
+
+    promotion_id: model.text(),
+    promotion_code: model.text().unique(),
+
+    creator_seller_id: model.text(),
+    deal_id: model.text().nullable(),
+    program_id: model.text().nullable(),
+    vendor_id: model.text().nullable(),
+
+    attribution_priority: model
+      .enum(Object.values(PromoCodeBindingPriority))
+      .default(PromoCodeBindingPriority.OVERRIDE_LINK),
+
+    status: model
+      .enum(Object.values(PromoCodeBindingStatus))
+      .default(PromoCodeBindingStatus.ACTIVE),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["creator_seller_id"],
+      name: "IDX_promo_binding_creator",
+    },
+    {
+      on: ["promotion_id"],
+      name: "IDX_promo_binding_promotion",
+    },
+  ])
+
+export default PromoCodeBinding

--- a/backend/src/modules/creator-attribution/service.ts
+++ b/backend/src/modules/creator-attribution/service.ts
@@ -1,0 +1,540 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { randomBytes, createHmac } from "crypto"
+import AffiliateLink, {
+  AffiliateLinkStatus,
+} from "./models/affiliate-link"
+import PromoCodeBinding, {
+  PromoCodeBindingStatus,
+} from "./models/promo-code-binding"
+import AttributionClickEvent from "./models/click-event"
+import OrderAttribution, {
+  AttributionSource,
+  AttributionModel,
+  CommissionStatus,
+} from "./models/order-attribution"
+
+const DEFAULT_COOKIE_WINDOW_DAYS = (() => {
+  const v = process.env.CREATOR_ATTRIBUTION_DEFAULT_COOKIE_DAYS
+  const n = v ? parseInt(v, 10) : 7
+  return Number.isFinite(n) && n > 0 ? n : 7
+})()
+
+const DEFAULT_HOLD_DAYS = (() => {
+  const v = process.env.CREATOR_ATTRIBUTION_DEFAULT_HOLD_DAYS
+  const n = v ? parseInt(v, 10) : 7
+  return Number.isFinite(n) && n > 0 ? n : 7
+})()
+
+const SHORT_CODE_PREFIX = "fbm_"
+
+function generateShortCode(): string {
+  const random = randomBytes(6).toString("base64url").replace(/[^a-zA-Z0-9]/g, "").slice(0, 8)
+  return `${SHORT_CODE_PREFIX}${random.toLowerCase()}`
+}
+
+export interface GenerateLinkInput {
+  creatorSellerId: string
+  vendorId?: string | null
+  dealId?: string | null
+  programId?: string | null
+  productId?: string | null
+  collectionId?: string | null
+  destinationPath?: string
+  utmMedium?: string | null
+  utmCampaign?: string | null
+  utmContent?: string | null
+  allowedOrigins?: string[] | null
+  metadata?: Record<string, unknown> | null
+}
+
+export interface RecordClickInput {
+  shortCode: string
+  visitorToken: string
+  ipHash?: string | null
+  userAgentHash?: string | null
+  referrer?: string | null
+  country?: string | null
+  customerId?: string | null
+  fingerprint?: string | null
+  isBotSuspected?: boolean
+  occurredAt?: Date
+}
+
+export interface AttributeOrderInput {
+  orderId: string
+  customerId?: string | null
+  visitorToken?: string | null
+  shortCode?: string | null
+  appliedPromoCodes?: string[] | null
+  subtotalCents: number
+  currencyCode?: string
+  source?: AttributionSource
+  metadata?: Record<string, unknown> | null
+}
+
+class CreatorAttributionService extends MedusaService({
+  AffiliateLink,
+  PromoCodeBinding,
+  AttributionClickEvent,
+  OrderAttribution,
+}) {
+  /**
+   * Generate a new affiliate link with a unique short code.
+   * Retries on collision; in practice 8 chars of base32 is far more than enough.
+   */
+  async generateLink(input: GenerateLinkInput): Promise<typeof AffiliateLink> {
+    let shortCode = generateShortCode()
+    for (let i = 0; i < 5; i++) {
+      const existing = await this.listAffiliateLinks({ short_code: shortCode })
+      if (existing.length === 0) break
+      shortCode = generateShortCode()
+    }
+
+    const destinationPath = input.destinationPath ?? this.defaultDestination(input)
+
+    const link = await (this as any).createAffiliateLinks({
+      short_code: shortCode,
+      creator_seller_id: input.creatorSellerId,
+      vendor_id: input.vendorId ?? null,
+      deal_id: input.dealId ?? null,
+      program_id: input.programId ?? null,
+      product_id: input.productId ?? null,
+      collection_id: input.collectionId ?? null,
+      destination_path: destinationPath,
+      utm_source: "creator",
+      utm_medium: input.utmMedium ?? null,
+      utm_campaign: input.utmCampaign ?? null,
+      utm_content: input.utmContent ?? null,
+      allowed_origins: input.allowedOrigins ?? null,
+      metadata: input.metadata ?? null,
+    })
+    return link
+  }
+
+  private defaultDestination(input: GenerateLinkInput): string {
+    if (input.productId) return `/products/${input.productId}`
+    if (input.collectionId) return `/collections/${input.collectionId}`
+    return "/"
+  }
+
+  async resolveShortCode(shortCode: string): Promise<{
+    link: any
+    redirectUrl: string
+  } | null> {
+    const links = await this.listAffiliateLinks({ short_code: shortCode })
+    if (links.length === 0) return null
+    const link = links[0]
+    if (link.status !== AffiliateLinkStatus.ACTIVE) return null
+
+    const params = new URLSearchParams()
+    if (link.utm_source) params.set("utm_source", link.utm_source)
+    if (link.utm_medium) params.set("utm_medium", link.utm_medium)
+    if (link.utm_campaign) params.set("utm_campaign", link.utm_campaign)
+    if (link.utm_content) params.set("utm_content", link.utm_content)
+    params.set("fbm_ref", link.short_code)
+
+    const sep = link.destination_path.includes("?") ? "&" : "?"
+    const redirectUrl = `${link.destination_path}${sep}${params.toString()}`
+
+    return { link, redirectUrl }
+  }
+
+  async recordClick(input: RecordClickInput): Promise<any> {
+    const links = await this.listAffiliateLinks({ short_code: input.shortCode })
+    if (links.length === 0) {
+      throw new Error(`Affiliate link not found for short code: ${input.shortCode}`)
+    }
+    const link = links[0]
+
+    const event = await (this as any).createAttributionClickEvents({
+      short_code: input.shortCode,
+      affiliate_link_id: link.id,
+      creator_seller_id: link.creator_seller_id,
+      visitor_token: input.visitorToken,
+      ip_hash: input.ipHash ?? null,
+      user_agent_hash: input.userAgentHash ?? null,
+      referrer: input.referrer ?? null,
+      country: input.country ?? null,
+      customer_id: input.customerId ?? null,
+      fingerprint: input.fingerprint ?? null,
+      is_bot_suspected: input.isBotSuspected ?? false,
+      occurred_at: input.occurredAt ?? new Date(),
+    })
+
+    if (!input.isBotSuspected) {
+      await (this as any).updateAffiliateLinks({
+        id: link.id,
+        click_count: Number(link.click_count) + 1,
+      })
+    }
+
+    return event
+  }
+
+  async lastClickForVisitor(visitorToken: string, withinDays: number): Promise<any | null> {
+    const since = new Date()
+    since.setDate(since.getDate() - withinDays)
+    const events = await this.listAttributionClickEvents(
+      {
+        visitor_token: visitorToken,
+        is_bot_suspected: false,
+      },
+      { order: { occurred_at: "DESC" }, take: 1 }
+    )
+    const ev = events[0]
+    if (!ev) return null
+    const occurred = new Date(ev.occurred_at as any)
+    if (occurred < since) return null
+    return ev
+  }
+
+  async firstClickForVisitor(visitorToken: string, withinDays: number): Promise<any | null> {
+    const since = new Date()
+    since.setDate(since.getDate() - withinDays)
+    const events = await this.listAttributionClickEvents(
+      {
+        visitor_token: visitorToken,
+        is_bot_suspected: false,
+      },
+      { order: { occurred_at: "ASC" }, take: 1 }
+    )
+    const ev = events[0]
+    if (!ev) return null
+    const occurred = new Date(ev.occurred_at as any)
+    if (occurred < since) return null
+    return ev
+  }
+
+  async bindPromoCode(args: {
+    promotionId: string
+    promotionCode: string
+    creatorSellerId: string
+    dealId?: string | null
+    programId?: string | null
+    vendorId?: string | null
+  }): Promise<any> {
+    const existing = await this.listPromoCodeBindings({
+      promotion_code: args.promotionCode,
+    })
+    if (existing.length > 0) {
+      return (this as any).updatePromoCodeBindings({
+        id: existing[0].id,
+        creator_seller_id: args.creatorSellerId,
+        deal_id: args.dealId ?? null,
+        program_id: args.programId ?? null,
+        vendor_id: args.vendorId ?? null,
+        status: PromoCodeBindingStatus.ACTIVE,
+      })
+    }
+    return (this as any).createPromoCodeBindings({
+      promotion_id: args.promotionId,
+      promotion_code: args.promotionCode,
+      creator_seller_id: args.creatorSellerId,
+      deal_id: args.dealId ?? null,
+      program_id: args.programId ?? null,
+      vendor_id: args.vendorId ?? null,
+    })
+  }
+
+  async resolvePromoCodeBinding(code: string): Promise<any | null> {
+    const bindings = await this.listPromoCodeBindings({ promotion_code: code })
+    const b = bindings[0]
+    if (!b) return null
+    if (b.status !== PromoCodeBindingStatus.ACTIVE) return null
+    return b
+  }
+
+  /**
+   * Decide the creator attribution for a placed order. Returns the created
+   * `OrderAttribution` row, or `null` if no creator is attributable.
+   *
+   * Attribution priority:
+   *  1. PromoCodeBinding with priority OVERRIDE_LINK (a creator-bound coupon
+   *     trumps last-click).
+   *  2. Last click within the cookie window.
+   *  3. PromoCodeBinding with priority FALLBACK or TIE_BREAKER.
+   */
+  async attributeOrder(input: AttributeOrderInput): Promise<any | null> {
+    const existing = await this.listOrderAttributions({ order_id: input.orderId })
+    if (existing.length > 0) return existing[0]
+
+    const codes = (input.appliedPromoCodes ?? []).filter(Boolean)
+    const bindings: any[] = []
+    for (const code of codes) {
+      const b = await this.resolvePromoCodeBinding(code)
+      if (b) bindings.push(b)
+    }
+
+    const overrideBinding = bindings.find(
+      (b) => b.attribution_priority === "override_link"
+    )
+
+    let lastClick: any | null = null
+    if (input.visitorToken) {
+      lastClick = await this.lastClickForVisitor(
+        input.visitorToken,
+        DEFAULT_COOKIE_WINDOW_DAYS
+      )
+    }
+
+    let chosen: {
+      source: AttributionSource
+      creatorSellerId: string
+      affiliateLinkId: string | null
+      promoCodeBindingId: string | null
+      dealId: string | null
+      programId: string | null
+      vendorId: string | null
+      clickEventId: string | null
+      commissionPercent: number | null
+    } | null = null
+
+    if (overrideBinding) {
+      chosen = {
+        source: AttributionSource.PROMO_CODE,
+        creatorSellerId: overrideBinding.creator_seller_id,
+        affiliateLinkId: null,
+        promoCodeBindingId: overrideBinding.id,
+        dealId: overrideBinding.deal_id,
+        programId: overrideBinding.program_id,
+        vendorId: overrideBinding.vendor_id,
+        clickEventId: null,
+        commissionPercent: null,
+      }
+    } else if (lastClick) {
+      const links = await this.listAffiliateLinks({ id: lastClick.affiliate_link_id })
+      const link = links[0]
+      if (link && link.status === AffiliateLinkStatus.ACTIVE) {
+        chosen = {
+          source: AttributionSource.LINK_CLICK,
+          creatorSellerId: link.creator_seller_id,
+          affiliateLinkId: link.id,
+          promoCodeBindingId: null,
+          dealId: link.deal_id,
+          programId: link.program_id,
+          vendorId: link.vendor_id,
+          clickEventId: lastClick.id,
+          commissionPercent: null,
+        }
+      }
+    } else if (bindings.length > 0) {
+      const fallback = bindings[0]
+      chosen = {
+        source: AttributionSource.PROMO_CODE,
+        creatorSellerId: fallback.creator_seller_id,
+        affiliateLinkId: null,
+        promoCodeBindingId: fallback.id,
+        dealId: fallback.deal_id,
+        programId: fallback.program_id,
+        vendorId: fallback.vendor_id,
+        clickEventId: null,
+        commissionPercent: null,
+      }
+    }
+
+    if (!chosen) return null
+
+    if (input.customerId && input.customerId === chosen.creatorSellerId) {
+      // self-purchase guard
+      return null
+    }
+
+    const commissionPercent = chosen.commissionPercent ?? this.resolveDefaultCommissionPercent()
+    const subtotal = input.subtotalCents
+    const commissionAmount = Math.floor((subtotal * commissionPercent) / 100)
+
+    const attribution = await (this as any).createOrderAttributions({
+      order_id: input.orderId,
+      customer_id: input.customerId ?? null,
+      creator_seller_id: chosen.creatorSellerId,
+      affiliate_link_id: chosen.affiliateLinkId,
+      promo_code_binding_id: chosen.promoCodeBindingId,
+      deal_id: chosen.dealId,
+      program_id: chosen.programId,
+      vendor_id: chosen.vendorId,
+      source: chosen.source,
+      attribution_model: AttributionModel.LAST_CLICK,
+      click_event_id: chosen.clickEventId,
+      cookie_window_days: DEFAULT_COOKIE_WINDOW_DAYS,
+      attribution_decided_at: new Date(),
+      attributed_subtotal_cents: subtotal,
+      commission_basis_cents: subtotal,
+      commission_amount_cents: commissionAmount,
+      commission_percent: commissionPercent,
+      currency_code: input.currencyCode ?? "usd",
+      commission_status: CommissionStatus.PENDING,
+      metadata: input.metadata ?? null,
+    })
+
+    if (chosen.affiliateLinkId) {
+      const links = await this.listAffiliateLinks({ id: chosen.affiliateLinkId })
+      const link = links[0]
+      if (link) {
+        await (this as any).updateAffiliateLinks({
+          id: link.id,
+          attributed_order_count: Number(link.attributed_order_count) + 1,
+        })
+      }
+    }
+
+    return attribution
+  }
+
+  /**
+   * Move a `pending` attribution to `held` and set its `hold_until` window.
+   * Called by the payment subscriber once the order is paid.
+   */
+  async holdAttribution(
+    attributionId: string,
+    holdDays: number = DEFAULT_HOLD_DAYS
+  ): Promise<any> {
+    const holdUntil = new Date()
+    holdUntil.setDate(holdUntil.getDate() + holdDays)
+    return (this as any).updateOrderAttributions({
+      id: attributionId,
+      commission_status: CommissionStatus.HELD,
+      hold_until: holdUntil,
+    })
+  }
+
+  /**
+   * Mark an attribution `approved` and stamp the resulting ledger entry id.
+   * Caller is responsible for the actual ledger write.
+   */
+  async approveCommission(
+    attributionId: string,
+    ledgerEntryId: string
+  ): Promise<any> {
+    return (this as any).updateOrderAttributions({
+      id: attributionId,
+      commission_status: CommissionStatus.APPROVED,
+      ledger_entry_id: ledgerEntryId,
+    })
+  }
+
+  async markPaid(attributionId: string): Promise<any> {
+    return (this as any).updateOrderAttributions({
+      id: attributionId,
+      commission_status: CommissionStatus.PAID,
+    })
+  }
+
+  async reverseCommission(
+    attributionId: string,
+    reason: string
+  ): Promise<any> {
+    return (this as any).updateOrderAttributions({
+      id: attributionId,
+      commission_status: CommissionStatus.REVERSED,
+      disqualified_reason: reason,
+    })
+  }
+
+  async disqualifyAttribution(
+    attributionId: string,
+    reason: string
+  ): Promise<any> {
+    return (this as any).updateOrderAttributions({
+      id: attributionId,
+      commission_status: CommissionStatus.DISQUALIFIED,
+      disqualified_reason: reason,
+    })
+  }
+
+  async listHeldAttributionsDue(now: Date = new Date()): Promise<any[]> {
+    const all = await this.listOrderAttributions({
+      commission_status: CommissionStatus.HELD,
+    })
+    return all.filter((a: any) => {
+      const hu = a.hold_until ? new Date(a.hold_until as any) : null
+      return hu !== null && hu <= now
+    })
+  }
+
+  async creatorEarningsRollup(
+    creatorSellerId: string,
+    range?: { from?: Date; to?: Date }
+  ): Promise<{
+    pending_cents: number
+    held_cents: number
+    approved_cents: number
+    paid_cents: number
+    reversed_cents: number
+    disqualified_cents: number
+    total_orders: number
+  }> {
+    const list = await this.listOrderAttributions({
+      creator_seller_id: creatorSellerId,
+    })
+    const filtered = list.filter((a: any) => {
+      const at = new Date(a.attribution_decided_at as any)
+      if (range?.from && at < range.from) return false
+      if (range?.to && at > range.to) return false
+      return true
+    })
+    const out = {
+      pending_cents: 0,
+      held_cents: 0,
+      approved_cents: 0,
+      paid_cents: 0,
+      reversed_cents: 0,
+      disqualified_cents: 0,
+      total_orders: filtered.length,
+    }
+    for (const a of filtered) {
+      const cents = Number(a.commission_amount_cents)
+      switch (a.commission_status) {
+        case CommissionStatus.PENDING:
+          out.pending_cents += cents
+          break
+        case CommissionStatus.HELD:
+          out.held_cents += cents
+          break
+        case CommissionStatus.APPROVED:
+          out.approved_cents += cents
+          break
+        case CommissionStatus.PAID:
+          out.paid_cents += cents
+          break
+        case CommissionStatus.REVERSED:
+          out.reversed_cents += cents
+          break
+        case CommissionStatus.DISQUALIFIED:
+          out.disqualified_cents += cents
+          break
+      }
+    }
+    return out
+  }
+
+  /**
+   * Sign a visitor cookie value with HMAC. Used by the storefront and the
+   * /r/:shortCode redirector to detect tampering.
+   */
+  static signCookieValue(value: string, secret: string): string {
+    const hmac = createHmac("sha256", secret).update(value).digest("hex").slice(0, 16)
+    return `${value}.${hmac}`
+  }
+
+  static verifyCookieValue(signed: string, secret: string): string | null {
+    const idx = signed.lastIndexOf(".")
+    if (idx < 0) return null
+    const value = signed.slice(0, idx)
+    const sig = signed.slice(idx + 1)
+    const expected = createHmac("sha256", secret).update(value).digest("hex").slice(0, 16)
+    if (sig.length !== expected.length) return null
+    let diff = 0
+    for (let i = 0; i < sig.length; i++) {
+      diff |= sig.charCodeAt(i) ^ expected.charCodeAt(i)
+    }
+    return diff === 0 ? value : null
+  }
+
+  private resolveDefaultCommissionPercent(): number {
+    const v = process.env.CREATOR_ATTRIBUTION_DEFAULT_COMMISSION_PERCENT
+    const n = v ? parseFloat(v) : 10
+    return Number.isFinite(n) && n >= 0 && n <= 100 ? n : 10
+  }
+}
+
+export default CreatorAttributionService

--- a/backend/src/modules/creator-program/index.ts
+++ b/backend/src/modules/creator-program/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import CreatorProgramService from "./service"
+
+export const CREATOR_PROGRAM_MODULE = "creatorProgram"
+
+export default Module(CREATOR_PROGRAM_MODULE, {
+  service: CreatorProgramService,
+})
+
+export * from "./models"
+export type { CreatorProgramService }

--- a/backend/src/modules/creator-program/migrations/Migration20260615CreateCreatorProgram.ts
+++ b/backend/src/modules/creator-program/migrations/Migration20260615CreateCreatorProgram.ts
@@ -1,0 +1,156 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260615CreateCreatorProgram extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_program_type_enum" AS ENUM (
+          'affiliate_open', 'affiliate_invite', 'sponsored_brief',
+          'commission_boost', 'engagement_pool'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_program_status_enum" AS ENUM (
+          'draft', 'active', 'paused', 'closed', 'archived'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_program_attribution_model_enum" AS ENUM (
+          'last_click', 'first_click', 'linear'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_application_status_enum" AS ENUM (
+          'pending', 'approved', 'rejected', 'withdrawn'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "creator_deal_status_enum" AS ENUM (
+          'active', 'fulfilled', 'violated', 'expired', 'canceled'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "creator_program" (
+        "id" TEXT NOT NULL,
+        "vendor_id" TEXT NOT NULL,
+        "title" TEXT NOT NULL,
+        "slug" TEXT NOT NULL,
+        "description" TEXT NULL,
+        "brief_markdown" TEXT NULL,
+        "program_type" creator_program_type_enum NOT NULL,
+        "status" creator_program_status_enum NOT NULL DEFAULT 'draft',
+        "commission_percent" NUMERIC NULL,
+        "commission_flat_cents" INTEGER NULL,
+        "sponsorship_flat_cents" INTEGER NULL,
+        "pool_total_cents" INTEGER NULL,
+        "pool_period" TEXT NULL,
+        "cookie_window_days" INTEGER NOT NULL DEFAULT 7,
+        "hold_days" INTEGER NOT NULL DEFAULT 7,
+        "attribution_model" creator_program_attribution_model_enum NOT NULL DEFAULT 'last_click',
+        "currency_code" TEXT NOT NULL DEFAULT 'usd',
+        "product_ids" JSONB NULL,
+        "collection_ids" JSONB NULL,
+        "category_ids" JSONB NULL,
+        "required_platforms" JSONB NULL,
+        "min_followers" INTEGER NULL,
+        "geo_allowlist" JSONB NULL,
+        "starts_at" TIMESTAMPTZ NULL,
+        "ends_at" TIMESTAMPTZ NULL,
+        "budget_cap_cents" INTEGER NULL,
+        "budget_spent_cents" INTEGER NOT NULL DEFAULT 0,
+        "requires_kyc" BOOLEAN NOT NULL DEFAULT FALSE,
+        "min_verification_level" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "creator_program_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_program_vendor" ON "creator_program" ("vendor_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_program_status" ON "creator_program" ("status");`)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_creator_program_vendor_slug"
+        ON "creator_program" ("vendor_id", "slug")
+        WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "creator_application" (
+        "id" TEXT NOT NULL,
+        "program_id" TEXT NOT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "pitch" TEXT NULL,
+        "proposed_platforms" JSONB NULL,
+        "follower_snapshot" JSONB NULL,
+        "status" creator_application_status_enum NOT NULL DEFAULT 'pending',
+        "decided_at" TIMESTAMPTZ NULL,
+        "decided_by" TEXT NULL,
+        "decision_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "creator_application_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_application_program" ON "creator_application" ("program_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_application_creator" ON "creator_application" ("creator_seller_id");`)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_creator_application"
+        ON "creator_application" ("program_id", "creator_seller_id")
+        WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "creator_deal" (
+        "id" TEXT NOT NULL,
+        "program_id" TEXT NOT NULL,
+        "application_id" TEXT NOT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "vendor_id" TEXT NOT NULL,
+        "status" creator_deal_status_enum NOT NULL DEFAULT 'active',
+        "effective_from" TIMESTAMPTZ NOT NULL,
+        "effective_until" TIMESTAMPTZ NULL,
+        "terms_snapshot" JSONB NOT NULL,
+        "total_attributed_cents" NUMERIC NOT NULL DEFAULT 0,
+        "total_paid_out_cents" NUMERIC NOT NULL DEFAULT 0,
+        "default_affiliate_link_id" TEXT NULL,
+        "violation_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "creator_deal_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_deal_creator_status" ON "creator_deal" ("creator_seller_id", "status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_deal_program" ON "creator_deal" ("program_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_creator_deal_vendor" ON "creator_deal" ("vendor_id");`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "creator_deal" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "creator_application" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "creator_program" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_deal_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_application_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_program_attribution_model_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_program_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "creator_program_type_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/creator-program/models/creator-application.ts
+++ b/backend/src/modules/creator-program/models/creator-application.ts
@@ -1,0 +1,46 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum CreatorApplicationStatus {
+  PENDING = "pending",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+  WITHDRAWN = "withdrawn",
+}
+
+const CreatorApplication = model
+  .define("creator_application", {
+    id: model.id().primaryKey(),
+
+    program_id: model.text(),
+    creator_seller_id: model.text(),
+
+    pitch: model.text().nullable(),
+    proposed_platforms: model.json().nullable(),
+    follower_snapshot: model.json().nullable(),
+
+    status: model
+      .enum(Object.values(CreatorApplicationStatus))
+      .default(CreatorApplicationStatus.PENDING),
+    decided_at: model.dateTime().nullable(),
+    decided_by: model.text().nullable(),
+    decision_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["program_id"],
+      name: "IDX_creator_application_program",
+    },
+    {
+      on: ["creator_seller_id"],
+      name: "IDX_creator_application_creator",
+    },
+    {
+      on: ["program_id", "creator_seller_id"],
+      name: "UQ_creator_application",
+      unique: true,
+    },
+  ])
+
+export default CreatorApplication

--- a/backend/src/modules/creator-program/models/creator-deal.ts
+++ b/backend/src/modules/creator-program/models/creator-deal.ts
@@ -1,0 +1,56 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum CreatorDealStatus {
+  ACTIVE = "active",
+  FULFILLED = "fulfilled",
+  VIOLATED = "violated",
+  EXPIRED = "expired",
+  CANCELED = "canceled",
+}
+
+const CreatorDeal = model
+  .define("creator_deal", {
+    id: model.id().primaryKey(),
+
+    program_id: model.text(),
+    application_id: model.text(),
+    creator_seller_id: model.text(),
+    vendor_id: model.text(),
+
+    status: model
+      .enum(Object.values(CreatorDealStatus))
+      .default(CreatorDealStatus.ACTIVE),
+
+    effective_from: model.dateTime(),
+    effective_until: model.dateTime().nullable(),
+
+    // Frozen terms snapshot so retroactive program edits don't change paid-out
+    // commissions on already-attributed orders.
+    terms_snapshot: model.json(),
+
+    total_attributed_cents: model.bigNumber().default(0),
+    total_paid_out_cents: model.bigNumber().default(0),
+
+    // Convenience back-reference to the auto-generated default link
+    default_affiliate_link_id: model.text().nullable(),
+
+    violation_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["creator_seller_id", "status"],
+      name: "IDX_creator_deal_creator_status",
+    },
+    {
+      on: ["program_id"],
+      name: "IDX_creator_deal_program",
+    },
+    {
+      on: ["vendor_id"],
+      name: "IDX_creator_deal_vendor",
+    },
+  ])
+
+export default CreatorDeal

--- a/backend/src/modules/creator-program/models/creator-program.ts
+++ b/backend/src/modules/creator-program/models/creator-program.ts
@@ -1,0 +1,89 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum CreatorProgramType {
+  AFFILIATE_OPEN = "affiliate_open",
+  AFFILIATE_INVITE = "affiliate_invite",
+  SPONSORED_BRIEF = "sponsored_brief",
+  COMMISSION_BOOST = "commission_boost",
+  ENGAGEMENT_POOL = "engagement_pool",
+}
+
+export enum CreatorProgramStatus {
+  DRAFT = "draft",
+  ACTIVE = "active",
+  PAUSED = "paused",
+  CLOSED = "closed",
+  ARCHIVED = "archived",
+}
+
+export enum CreatorProgramAttributionModel {
+  LAST_CLICK = "last_click",
+  FIRST_CLICK = "first_click",
+  LINEAR = "linear",
+}
+
+const CreatorProgram = model
+  .define("creator_program", {
+    id: model.id().primaryKey(),
+
+    vendor_id: model.text(),
+    title: model.text(),
+    slug: model.text(),
+    description: model.text().nullable(),
+    brief_markdown: model.text().nullable(),
+
+    program_type: model.enum(Object.values(CreatorProgramType)),
+    status: model
+      .enum(Object.values(CreatorProgramStatus))
+      .default(CreatorProgramStatus.DRAFT),
+
+    // Financial terms (snapshot copied to deal at acceptance time)
+    commission_percent: model.number().nullable(),
+    commission_flat_cents: model.number().nullable(),
+    sponsorship_flat_cents: model.number().nullable(),
+    pool_total_cents: model.number().nullable(),
+    pool_period: model.text().nullable(), // "weekly" | "monthly"
+    cookie_window_days: model.number().default(7),
+    hold_days: model.number().default(7),
+    attribution_model: model
+      .enum(Object.values(CreatorProgramAttributionModel))
+      .default(CreatorProgramAttributionModel.LAST_CLICK),
+    currency_code: model.text().default("usd"),
+
+    // Targeting
+    product_ids: model.json().nullable(),
+    collection_ids: model.json().nullable(),
+    category_ids: model.json().nullable(),
+    required_platforms: model.json().nullable(),
+    min_followers: model.number().nullable(),
+    geo_allowlist: model.json().nullable(),
+
+    // Lifecycle
+    starts_at: model.dateTime().nullable(),
+    ends_at: model.dateTime().nullable(),
+    budget_cap_cents: model.number().nullable(),
+    budget_spent_cents: model.number().default(0),
+
+    // Anti-fraud / KYC gating (uses vendor-verification levels)
+    requires_kyc: model.boolean().default(false),
+    min_verification_level: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["vendor_id"],
+      name: "IDX_creator_program_vendor",
+    },
+    {
+      on: ["status"],
+      name: "IDX_creator_program_status",
+    },
+    {
+      on: ["vendor_id", "slug"],
+      name: "UQ_creator_program_vendor_slug",
+      unique: true,
+    },
+  ])
+
+export default CreatorProgram

--- a/backend/src/modules/creator-program/models/index.ts
+++ b/backend/src/modules/creator-program/models/index.ts
@@ -1,0 +1,11 @@
+export { default as CreatorProgram } from "./creator-program"
+export { default as CreatorApplication } from "./creator-application"
+export { default as CreatorDeal } from "./creator-deal"
+
+export {
+  CreatorProgramType,
+  CreatorProgramStatus,
+  CreatorProgramAttributionModel,
+} from "./creator-program"
+export { CreatorApplicationStatus } from "./creator-application"
+export { CreatorDealStatus } from "./creator-deal"

--- a/backend/src/modules/creator-program/service.ts
+++ b/backend/src/modules/creator-program/service.ts
@@ -1,0 +1,321 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import CreatorProgram, {
+  CreatorProgramStatus,
+  CreatorProgramType,
+  CreatorProgramAttributionModel,
+} from "./models/creator-program"
+import CreatorApplication, {
+  CreatorApplicationStatus,
+} from "./models/creator-application"
+import CreatorDeal, { CreatorDealStatus } from "./models/creator-deal"
+
+export interface CreateProgramInput {
+  vendorId: string
+  title: string
+  slug: string
+  description?: string | null
+  briefMarkdown?: string | null
+  programType: CreatorProgramType
+  // Financial
+  commissionPercent?: number | null
+  commissionFlatCents?: number | null
+  sponsorshipFlatCents?: number | null
+  poolTotalCents?: number | null
+  poolPeriod?: string | null
+  cookieWindowDays?: number
+  holdDays?: number
+  attributionModel?: CreatorProgramAttributionModel
+  currencyCode?: string
+  // Targeting
+  productIds?: string[] | null
+  collectionIds?: string[] | null
+  categoryIds?: string[] | null
+  requiredPlatforms?: string[] | null
+  minFollowers?: number | null
+  geoAllowlist?: string[] | null
+  // Lifecycle
+  startsAt?: Date | null
+  endsAt?: Date | null
+  budgetCapCents?: number | null
+  // Gating
+  requiresKyc?: boolean
+  minVerificationLevel?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+class CreatorProgramService extends MedusaService({
+  CreatorProgram,
+  CreatorApplication,
+  CreatorDeal,
+}) {
+  async createProgram(input: CreateProgramInput): Promise<any> {
+    const existing = await this.listCreatorPrograms({
+      vendor_id: input.vendorId,
+      slug: input.slug,
+    })
+    if (existing.length > 0) {
+      throw new Error(`Program with slug "${input.slug}" already exists for this vendor`)
+    }
+
+    return (this as any).createCreatorPrograms({
+      vendor_id: input.vendorId,
+      title: input.title,
+      slug: input.slug,
+      description: input.description ?? null,
+      brief_markdown: input.briefMarkdown ?? null,
+      program_type: input.programType,
+      commission_percent: input.commissionPercent ?? null,
+      commission_flat_cents: input.commissionFlatCents ?? null,
+      sponsorship_flat_cents: input.sponsorshipFlatCents ?? null,
+      pool_total_cents: input.poolTotalCents ?? null,
+      pool_period: input.poolPeriod ?? null,
+      cookie_window_days: input.cookieWindowDays ?? 7,
+      hold_days: input.holdDays ?? 7,
+      attribution_model: input.attributionModel ?? CreatorProgramAttributionModel.LAST_CLICK,
+      currency_code: input.currencyCode ?? "usd",
+      product_ids: input.productIds ?? null,
+      collection_ids: input.collectionIds ?? null,
+      category_ids: input.categoryIds ?? null,
+      required_platforms: input.requiredPlatforms ?? null,
+      min_followers: input.minFollowers ?? null,
+      geo_allowlist: input.geoAllowlist ?? null,
+      starts_at: input.startsAt ?? null,
+      ends_at: input.endsAt ?? null,
+      budget_cap_cents: input.budgetCapCents ?? null,
+      requires_kyc: input.requiresKyc ?? false,
+      min_verification_level: input.minVerificationLevel ?? null,
+      metadata: input.metadata ?? null,
+    })
+  }
+
+  async publishProgram(programId: string): Promise<any> {
+    return (this as any).updateCreatorPrograms({
+      id: programId,
+      status: CreatorProgramStatus.ACTIVE,
+    })
+  }
+
+  async pauseProgram(programId: string): Promise<any> {
+    return (this as any).updateCreatorPrograms({
+      id: programId,
+      status: CreatorProgramStatus.PAUSED,
+    })
+  }
+
+  async closeProgram(programId: string, reason?: string): Promise<any> {
+    return (this as any).updateCreatorPrograms({
+      id: programId,
+      status: CreatorProgramStatus.CLOSED,
+      metadata: reason ? { close_reason: reason } : undefined,
+    })
+  }
+
+  /**
+   * List programs that are currently open for applications.
+   *
+   * Filters: only `ACTIVE` programs that fall within `[starts_at, ends_at]`.
+   * Optional `vendorId` / `programType` filters narrow further.
+   */
+  async listOpenPrograms(filters: {
+    vendorId?: string
+    programType?: CreatorProgramType
+    productId?: string
+  } = {}): Promise<any[]> {
+    const all = await this.listCreatorPrograms({
+      status: CreatorProgramStatus.ACTIVE,
+      ...(filters.vendorId ? { vendor_id: filters.vendorId } : {}),
+      ...(filters.programType ? { program_type: filters.programType } : {}),
+    })
+    const now = new Date()
+    return all.filter((p: any) => {
+      if (p.starts_at && new Date(p.starts_at) > now) return false
+      if (p.ends_at && new Date(p.ends_at) < now) return false
+      if (filters.productId && Array.isArray(p.product_ids)) {
+        return p.product_ids.includes(filters.productId)
+      }
+      return true
+    })
+  }
+
+  async applyToProgram(args: {
+    programId: string
+    creatorSellerId: string
+    pitch?: string | null
+    proposedPlatforms?: string[] | null
+    followerSnapshot?: Record<string, number> | null
+  }): Promise<any> {
+    const programs = await this.listCreatorPrograms({ id: args.programId })
+    const program = programs[0]
+    if (!program) throw new Error("Program not found")
+    if (program.status !== CreatorProgramStatus.ACTIVE) {
+      throw new Error(`Program is not open (status=${program.status})`)
+    }
+
+    const existing = await this.listCreatorApplications({
+      program_id: args.programId,
+      creator_seller_id: args.creatorSellerId,
+    })
+    if (existing.length > 0) {
+      // Idempotent: re-applying after withdrawal reopens; otherwise return existing
+      const e = existing[0]
+      if (e.status === CreatorApplicationStatus.WITHDRAWN) {
+        return (this as any).updateCreatorApplications({
+          id: e.id,
+          status: CreatorApplicationStatus.PENDING,
+          pitch: args.pitch ?? e.pitch,
+          proposed_platforms: args.proposedPlatforms ?? e.proposed_platforms,
+          follower_snapshot: args.followerSnapshot ?? e.follower_snapshot,
+          decided_at: null,
+          decided_by: null,
+          decision_reason: null,
+        })
+      }
+      return e
+    }
+
+    return (this as any).createCreatorApplications({
+      program_id: args.programId,
+      creator_seller_id: args.creatorSellerId,
+      pitch: args.pitch ?? null,
+      proposed_platforms: args.proposedPlatforms ?? null,
+      follower_snapshot: args.followerSnapshot ?? null,
+    })
+  }
+
+  async withdrawApplication(applicationId: string, creatorSellerId: string): Promise<any> {
+    const apps = await this.listCreatorApplications({
+      id: applicationId,
+      creator_seller_id: creatorSellerId,
+    })
+    const app = apps[0]
+    if (!app) throw new Error("Application not found")
+    if (app.status !== CreatorApplicationStatus.PENDING) {
+      throw new Error(`Cannot withdraw application in status ${app.status}`)
+    }
+    return (this as any).updateCreatorApplications({
+      id: applicationId,
+      status: CreatorApplicationStatus.WITHDRAWN,
+    })
+  }
+
+  async decideApplication(args: {
+    applicationId: string
+    decision: "approve" | "reject"
+    decidedBy: string
+    reason?: string | null
+  }): Promise<any> {
+    const apps = await this.listCreatorApplications({ id: args.applicationId })
+    const app = apps[0]
+    if (!app) throw new Error("Application not found")
+    if (app.status !== CreatorApplicationStatus.PENDING) {
+      throw new Error(`Application is already decided (status=${app.status})`)
+    }
+    return (this as any).updateCreatorApplications({
+      id: args.applicationId,
+      status:
+        args.decision === "approve"
+          ? CreatorApplicationStatus.APPROVED
+          : CreatorApplicationStatus.REJECTED,
+      decided_at: new Date(),
+      decided_by: args.decidedBy,
+      decision_reason: args.reason ?? null,
+    })
+  }
+
+  /**
+   * Open a deal for an approved application. Caller is responsible for
+   * generating the auto-default `AffiliateLink` and patching it into
+   * `default_affiliate_link_id` (this module does not depend on
+   * creator-attribution to avoid a circular module dependency).
+   */
+  async openDealForApprovedApp(applicationId: string): Promise<any> {
+    const apps = await this.listCreatorApplications({ id: applicationId })
+    const app = apps[0]
+    if (!app) throw new Error("Application not found")
+    if (app.status !== CreatorApplicationStatus.APPROVED) {
+      throw new Error(`Cannot open deal for application in status ${app.status}`)
+    }
+
+    const programs = await this.listCreatorPrograms({ id: app.program_id })
+    const program = programs[0]
+    if (!program) throw new Error("Program not found")
+
+    const existingDeals = await this.listCreatorDeals({
+      application_id: applicationId,
+    })
+    if (existingDeals.length > 0) return existingDeals[0]
+
+    const termsSnapshot = {
+      program_type: program.program_type,
+      commission_percent: program.commission_percent,
+      commission_flat_cents: program.commission_flat_cents,
+      sponsorship_flat_cents: program.sponsorship_flat_cents,
+      cookie_window_days: program.cookie_window_days,
+      hold_days: program.hold_days,
+      attribution_model: program.attribution_model,
+      currency_code: program.currency_code,
+      product_ids: program.product_ids ?? null,
+      collection_ids: program.collection_ids ?? null,
+      requires_kyc: program.requires_kyc,
+      min_verification_level: program.min_verification_level,
+      snapshot_at: new Date().toISOString(),
+    }
+
+    return (this as any).createCreatorDeals({
+      program_id: app.program_id,
+      application_id: applicationId,
+      creator_seller_id: app.creator_seller_id,
+      vendor_id: program.vendor_id,
+      status: CreatorDealStatus.ACTIVE,
+      effective_from: new Date(),
+      effective_until: program.ends_at ?? null,
+      terms_snapshot: termsSnapshot,
+    })
+  }
+
+  async attachDefaultLinkToDeal(dealId: string, affiliateLinkId: string): Promise<any> {
+    return (this as any).updateCreatorDeals({
+      id: dealId,
+      default_affiliate_link_id: affiliateLinkId,
+    })
+  }
+
+  async incrementDealAttribution(dealId: string, deltaCents: number): Promise<void> {
+    const deals = await this.listCreatorDeals({ id: dealId })
+    const deal = deals[0]
+    if (!deal) return
+    await (this as any).updateCreatorDeals({
+      id: dealId,
+      total_attributed_cents:
+        Number(deal.total_attributed_cents) + Math.max(0, deltaCents),
+    })
+  }
+
+  async incrementDealPayout(dealId: string, deltaCents: number): Promise<void> {
+    const deals = await this.listCreatorDeals({ id: dealId })
+    const deal = deals[0]
+    if (!deal) return
+    await (this as any).updateCreatorDeals({
+      id: dealId,
+      total_paid_out_cents:
+        Number(deal.total_paid_out_cents) + Math.max(0, deltaCents),
+    })
+  }
+
+  async violateDeal(dealId: string, reason: string): Promise<any> {
+    return (this as any).updateCreatorDeals({
+      id: dealId,
+      status: CreatorDealStatus.VIOLATED,
+      violation_reason: reason,
+    })
+  }
+
+  async cancelDeal(dealId: string): Promise<any> {
+    return (this as any).updateCreatorDeals({
+      id: dealId,
+      status: CreatorDealStatus.CANCELED,
+    })
+  }
+}
+
+export default CreatorProgramService

--- a/backend/src/modules/creator-rewards/index.ts
+++ b/backend/src/modules/creator-rewards/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import CreatorRewardsService from "./service"
+
+export const CREATOR_REWARDS_MODULE = "creatorRewards"
+
+export default Module(CREATOR_REWARDS_MODULE, {
+  service: CreatorRewardsService,
+})
+
+export * from "./models"
+export type { CreatorRewardsService }

--- a/backend/src/modules/creator-rewards/migrations/Migration20260710CreateCreatorRewards.ts
+++ b/backend/src/modules/creator-rewards/migrations/Migration20260710CreateCreatorRewards.ts
@@ -1,0 +1,146 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260710CreateCreatorRewards extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "content_post_verification_status_enum" AS ENUM (
+          'unverified', 'verified', 'rejected'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "reward_pool_kind_enum" AS ENUM (
+          'engagement', 'throughput'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "reward_pool_status_enum" AS ENUM (
+          'scheduled', 'accruing', 'calculating', 'distributed', 'reverted'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "reward_payout_status_enum" AS ENUM (
+          'pending', 'held', 'paid', 'reversed'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "content_post" (
+        "id" TEXT NOT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "deal_id" TEXT NULL,
+        "program_id" TEXT NULL,
+        "platform" TEXT NOT NULL,
+        "external_post_id" TEXT NOT NULL,
+        "external_url" TEXT NOT NULL,
+        "caption" TEXT NULL,
+        "thumbnail_url" TEXT NULL,
+        "affiliate_link_id" TEXT NULL,
+        "verification_status" content_post_verification_status_enum NOT NULL DEFAULT 'unverified',
+        "verified_at" TIMESTAMPTZ NULL,
+        "verified_via" TEXT NULL,
+        "qualified" BOOLEAN NOT NULL DEFAULT FALSE,
+        "disqualified_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "content_post_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_content_post_creator" ON "content_post" ("creator_seller_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_content_post_deal" ON "content_post" ("deal_id");`)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_content_post_platform_post"
+        ON "content_post" ("platform", "external_post_id")
+        WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_content_post_verification" ON "content_post" ("verification_status");`)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "engagement_snapshot" (
+        "id" TEXT NOT NULL,
+        "content_post_id" TEXT NOT NULL,
+        "captured_at" TIMESTAMPTZ NOT NULL,
+        "views" NUMERIC NOT NULL DEFAULT 0,
+        "qualified_views" NUMERIC NOT NULL DEFAULT 0,
+        "likes" NUMERIC NOT NULL DEFAULT 0,
+        "shares" NUMERIC NOT NULL DEFAULT 0,
+        "comments" NUMERIC NOT NULL DEFAULT 0,
+        "saves" NUMERIC NOT NULL DEFAULT 0,
+        "watch_time_seconds" NUMERIC NOT NULL DEFAULT 0,
+        "raw" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "engagement_snapshot_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_engagement_snapshot_post_time"
+        ON "engagement_snapshot" ("content_post_id", "captured_at");
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "reward_pool" (
+        "id" TEXT NOT NULL,
+        "program_id" TEXT NULL,
+        "funder_seller_id" TEXT NULL,
+        "kind" reward_pool_kind_enum NOT NULL DEFAULT 'engagement',
+        "period_start" TIMESTAMPTZ NOT NULL,
+        "period_end" TIMESTAMPTZ NOT NULL,
+        "total_cents" NUMERIC NOT NULL,
+        "rate_per_kqv_cents" NUMERIC NULL,
+        "currency_code" TEXT NOT NULL DEFAULT 'usd',
+        "status" reward_pool_status_enum NOT NULL DEFAULT 'scheduled',
+        "distributed_at" TIMESTAMPTZ NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "reward_pool_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_reward_pool_program" ON "reward_pool" ("program_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_reward_pool_status_end" ON "reward_pool" ("status", "period_end");`)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "reward_payout" (
+        "id" TEXT NOT NULL,
+        "pool_id" TEXT NOT NULL,
+        "creator_seller_id" TEXT NOT NULL,
+        "qualified_views" NUMERIC NOT NULL DEFAULT 0,
+        "qualified_engagement_score" DOUBLE PRECISION NOT NULL DEFAULT 0,
+        "amount_cents" NUMERIC NOT NULL,
+        "currency_code" TEXT NOT NULL DEFAULT 'usd',
+        "status" reward_payout_status_enum NOT NULL DEFAULT 'pending',
+        "ledger_entry_id" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "reward_payout_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_reward_payout_pool" ON "reward_payout" ("pool_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_reward_payout_creator_status" ON "reward_payout" ("creator_seller_id", "status");`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "reward_payout" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "reward_pool" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "engagement_snapshot" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "content_post" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "reward_payout_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "reward_pool_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "reward_pool_kind_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "content_post_verification_status_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/creator-rewards/models/content-post.ts
+++ b/backend/src/modules/creator-rewards/models/content-post.ts
@@ -1,0 +1,62 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum ContentPostVerificationStatus {
+  UNVERIFIED = "unverified",
+  VERIFIED = "verified",
+  REJECTED = "rejected",
+}
+
+export enum ContentPostVerifiedVia {
+  OAUTH = "oauth",
+  WEBHOOK = "webhook",
+  MANUAL_ADMIN = "manual_admin",
+}
+
+const ContentPost = model
+  .define("content_post", {
+    id: model.id().primaryKey(),
+
+    creator_seller_id: model.text(),
+    deal_id: model.text().nullable(),
+    program_id: model.text().nullable(),
+
+    platform: model.text(),
+    external_post_id: model.text(),
+    external_url: model.text(),
+    caption: model.text().nullable(),
+    thumbnail_url: model.text().nullable(),
+
+    affiliate_link_id: model.text().nullable(),
+
+    verification_status: model
+      .enum(Object.values(ContentPostVerificationStatus))
+      .default(ContentPostVerificationStatus.UNVERIFIED),
+    verified_at: model.dateTime().nullable(),
+    verified_via: model.text().nullable(),
+
+    qualified: model.boolean().default(false),
+    disqualified_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["creator_seller_id"],
+      name: "IDX_content_post_creator",
+    },
+    {
+      on: ["deal_id"],
+      name: "IDX_content_post_deal",
+    },
+    {
+      on: ["platform", "external_post_id"],
+      name: "UQ_content_post_platform_post",
+      unique: true,
+    },
+    {
+      on: ["verification_status"],
+      name: "IDX_content_post_verification",
+    },
+  ])
+
+export default ContentPost

--- a/backend/src/modules/creator-rewards/models/engagement-snapshot.ts
+++ b/backend/src/modules/creator-rewards/models/engagement-snapshot.ts
@@ -1,0 +1,27 @@
+import { model } from "@medusajs/framework/utils"
+
+const EngagementSnapshot = model
+  .define("engagement_snapshot", {
+    id: model.id().primaryKey(),
+
+    content_post_id: model.text(),
+    captured_at: model.dateTime(),
+
+    views: model.bigNumber().default(0),
+    qualified_views: model.bigNumber().default(0),
+    likes: model.bigNumber().default(0),
+    shares: model.bigNumber().default(0),
+    comments: model.bigNumber().default(0),
+    saves: model.bigNumber().default(0),
+    watch_time_seconds: model.bigNumber().default(0),
+
+    raw: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["content_post_id", "captured_at"],
+      name: "IDX_engagement_snapshot_post_time",
+    },
+  ])
+
+export default EngagementSnapshot

--- a/backend/src/modules/creator-rewards/models/index.ts
+++ b/backend/src/modules/creator-rewards/models/index.ts
@@ -1,0 +1,11 @@
+export { default as ContentPost } from "./content-post"
+export { default as EngagementSnapshot } from "./engagement-snapshot"
+export { default as RewardPool } from "./reward-pool"
+export { default as RewardPayout } from "./reward-payout"
+
+export {
+  ContentPostVerificationStatus,
+  ContentPostVerifiedVia,
+} from "./content-post"
+export { RewardPoolKind, RewardPoolStatus } from "./reward-pool"
+export { RewardPayoutStatus } from "./reward-payout"

--- a/backend/src/modules/creator-rewards/models/reward-payout.ts
+++ b/backend/src/modules/creator-rewards/models/reward-payout.ts
@@ -1,0 +1,40 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum RewardPayoutStatus {
+  PENDING = "pending",
+  HELD = "held",
+  PAID = "paid",
+  REVERSED = "reversed",
+}
+
+const RewardPayout = model
+  .define("reward_payout", {
+    id: model.id().primaryKey(),
+
+    pool_id: model.text(),
+    creator_seller_id: model.text(),
+
+    qualified_views: model.bigNumber().default(0),
+    qualified_engagement_score: model.float().default(0),
+    amount_cents: model.bigNumber(),
+    currency_code: model.text().default("usd"),
+
+    status: model
+      .enum(Object.values(RewardPayoutStatus))
+      .default(RewardPayoutStatus.PENDING),
+
+    ledger_entry_id: model.text().nullable(),
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["pool_id"],
+      name: "IDX_reward_payout_pool",
+    },
+    {
+      on: ["creator_seller_id", "status"],
+      name: "IDX_reward_payout_creator_status",
+    },
+  ])
+
+export default RewardPayout

--- a/backend/src/modules/creator-rewards/models/reward-pool.ts
+++ b/backend/src/modules/creator-rewards/models/reward-pool.ts
@@ -1,0 +1,50 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum RewardPoolKind {
+  ENGAGEMENT = "engagement",
+  THROUGHPUT = "throughput",
+}
+
+export enum RewardPoolStatus {
+  SCHEDULED = "scheduled",
+  ACCRUING = "accruing",
+  CALCULATING = "calculating",
+  DISTRIBUTED = "distributed",
+  REVERTED = "reverted",
+}
+
+const RewardPool = model
+  .define("reward_pool", {
+    id: model.id().primaryKey(),
+
+    program_id: model.text().nullable(),
+    funder_seller_id: model.text().nullable(),
+
+    kind: model.enum(Object.values(RewardPoolKind)).default(RewardPoolKind.ENGAGEMENT),
+
+    period_start: model.dateTime(),
+    period_end: model.dateTime(),
+
+    total_cents: model.bigNumber(),
+    rate_per_kqv_cents: model.number().nullable(),
+    currency_code: model.text().default("usd"),
+
+    status: model
+      .enum(Object.values(RewardPoolStatus))
+      .default(RewardPoolStatus.SCHEDULED),
+
+    distributed_at: model.dateTime().nullable(),
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["program_id"],
+      name: "IDX_reward_pool_program",
+    },
+    {
+      on: ["status", "period_end"],
+      name: "IDX_reward_pool_status_end",
+    },
+  ])
+
+export default RewardPool

--- a/backend/src/modules/creator-rewards/service.ts
+++ b/backend/src/modules/creator-rewards/service.ts
@@ -1,0 +1,338 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import ContentPost, {
+  ContentPostVerificationStatus,
+} from "./models/content-post"
+import EngagementSnapshot from "./models/engagement-snapshot"
+import RewardPool, {
+  RewardPoolKind,
+  RewardPoolStatus,
+} from "./models/reward-pool"
+import RewardPayout, { RewardPayoutStatus } from "./models/reward-payout"
+
+const MIN_QV_THRESHOLD = (() => {
+  const v = parseInt(process.env.CREATOR_REWARD_MIN_QV_THRESHOLD || "1000", 10)
+  return Number.isFinite(v) && v >= 0 ? v : 1000
+})()
+
+const MAX_DAILY_QV_GROWTH = (() => {
+  const v = parseInt(process.env.CREATOR_REWARD_MAX_DAILY_QV_GROWTH || "100000", 10)
+  return Number.isFinite(v) && v >= 0 ? v : 100000
+})()
+
+export interface RegisterPostInput {
+  creatorSellerId: string
+  platform: string
+  externalPostId: string
+  externalUrl: string
+  caption?: string | null
+  thumbnailUrl?: string | null
+  affiliateLinkId?: string | null
+  dealId?: string | null
+  programId?: string | null
+}
+
+export interface IngestSnapshotInput {
+  views?: number
+  qualifiedViews?: number
+  likes?: number
+  shares?: number
+  comments?: number
+  saves?: number
+  watchTimeSeconds?: number
+  raw?: Record<string, unknown>
+  capturedAt?: Date
+}
+
+export interface OpenPoolInput {
+  programId?: string | null
+  funderSellerId?: string | null
+  kind?: RewardPoolKind
+  periodStart: Date
+  periodEnd: Date
+  totalCents: number
+  ratePerKqvCents?: number | null
+  currencyCode?: string
+  metadata?: Record<string, unknown> | null
+}
+
+export interface PoolDistributionResult {
+  pool_id: string
+  total_qv: number
+  total_distributed_cents: number
+  per_creator: Array<{
+    creator_seller_id: string
+    qualified_views: number
+    amount_cents: number
+  }>
+  ineligible_below_threshold: number
+}
+
+class CreatorRewardsService extends MedusaService({
+  ContentPost,
+  EngagementSnapshot,
+  RewardPool,
+  RewardPayout,
+}) {
+  async registerPost(input: RegisterPostInput): Promise<any> {
+    const existing = await this.listContentPosts({
+      platform: input.platform,
+      external_post_id: input.externalPostId,
+    })
+    if (existing.length > 0) return existing[0]
+
+    return (this as any).createContentPosts({
+      creator_seller_id: input.creatorSellerId,
+      platform: input.platform,
+      external_post_id: input.externalPostId,
+      external_url: input.externalUrl,
+      caption: input.caption ?? null,
+      thumbnail_url: input.thumbnailUrl ?? null,
+      affiliate_link_id: input.affiliateLinkId ?? null,
+      deal_id: input.dealId ?? null,
+      program_id: input.programId ?? null,
+    })
+  }
+
+  async verifyPost(
+    postId: string,
+    via: "oauth" | "webhook" | "manual_admin"
+  ): Promise<any> {
+    return (this as any).updateContentPosts({
+      id: postId,
+      verification_status: ContentPostVerificationStatus.VERIFIED,
+      verified_at: new Date(),
+      verified_via: via,
+      qualified: true,
+    })
+  }
+
+  async rejectPost(postId: string, reason: string): Promise<any> {
+    return (this as any).updateContentPosts({
+      id: postId,
+      verification_status: ContentPostVerificationStatus.REJECTED,
+      qualified: false,
+      disqualified_reason: reason,
+    })
+  }
+
+  async disqualifyPost(postId: string, reason: string): Promise<any> {
+    return (this as any).updateContentPosts({
+      id: postId,
+      qualified: false,
+      disqualified_reason: reason,
+    })
+  }
+
+  async ingestSnapshot(
+    contentPostId: string,
+    input: IngestSnapshotInput
+  ): Promise<any> {
+    const views = Math.max(0, Math.floor(input.views ?? 0))
+    const qualifiedViews = Math.max(
+      0,
+      Math.floor(input.qualifiedViews ?? input.views ?? 0)
+    )
+    return (this as any).createEngagementSnapshots({
+      content_post_id: contentPostId,
+      captured_at: input.capturedAt ?? new Date(),
+      views,
+      qualified_views: qualifiedViews,
+      likes: Math.max(0, Math.floor(input.likes ?? 0)),
+      shares: Math.max(0, Math.floor(input.shares ?? 0)),
+      comments: Math.max(0, Math.floor(input.comments ?? 0)),
+      saves: Math.max(0, Math.floor(input.saves ?? 0)),
+      watch_time_seconds: Math.max(0, Math.floor(input.watchTimeSeconds ?? 0)),
+      raw: input.raw ?? null,
+    })
+  }
+
+  async openPool(input: OpenPoolInput): Promise<any> {
+    if (input.totalCents <= 0) throw new Error("totalCents must be > 0")
+    if (input.periodEnd <= input.periodStart)
+      throw new Error("periodEnd must be after periodStart")
+    return (this as any).createRewardPools({
+      program_id: input.programId ?? null,
+      funder_seller_id: input.funderSellerId ?? null,
+      kind: input.kind ?? RewardPoolKind.ENGAGEMENT,
+      period_start: input.periodStart,
+      period_end: input.periodEnd,
+      total_cents: input.totalCents,
+      rate_per_kqv_cents: input.ratePerKqvCents ?? null,
+      currency_code: input.currencyCode ?? "usd",
+      status:
+        input.periodStart <= new Date()
+          ? RewardPoolStatus.ACCRUING
+          : RewardPoolStatus.SCHEDULED,
+      metadata: input.metadata ?? null,
+    })
+  }
+
+  /**
+   * Compute how the pool would be split across qualifying creators based
+   * on cumulative qualified-view counts in the period. Pure read-only
+   * preview — no ledger writes, no payout rows.
+   */
+  async calculatePoolDistribution(poolId: string): Promise<PoolDistributionResult> {
+    const pools = await this.listRewardPools({ id: poolId })
+    const pool = pools[0]
+    if (!pool) throw new Error("Pool not found")
+
+    // Find content posts that count for this pool: program-scoped if the
+    // pool is program-scoped, otherwise platform-wide.
+    const postFilter: Record<string, unknown> = {
+      verification_status: ContentPostVerificationStatus.VERIFIED,
+      qualified: true,
+    }
+    if (pool.program_id) postFilter.program_id = pool.program_id
+    const posts = await this.listContentPosts(postFilter)
+
+    if (posts.length === 0) {
+      return {
+        pool_id: poolId,
+        total_qv: 0,
+        total_distributed_cents: 0,
+        per_creator: [],
+        ineligible_below_threshold: 0,
+      }
+    }
+
+    // Collect engagement snapshots within the period and pick the latest
+    // per post (snapshots are cumulative — TikTok-style monotonic counters).
+    const periodStart = new Date(pool.period_start as any)
+    const periodEnd = new Date(pool.period_end as any)
+    const postIds = posts.map((p: any) => p.id)
+    const allSnapshots = await this.listEngagementSnapshots({
+      content_post_id: postIds,
+    })
+    const inPeriod = allSnapshots.filter((s: any) => {
+      const t = new Date(s.captured_at as any)
+      return t >= periodStart && t <= periodEnd
+    })
+
+    const latestPerPost = new Map<string, any>()
+    for (const s of inPeriod) {
+      const prev = latestPerPost.get(s.content_post_id)
+      if (
+        !prev ||
+        new Date(s.captured_at as any) > new Date(prev.captured_at as any)
+      ) {
+        latestPerPost.set(s.content_post_id, s)
+      }
+    }
+
+    // Aggregate qualified views per creator.
+    const qvByCreator = new Map<string, number>()
+    for (const post of posts as any[]) {
+      const snap = latestPerPost.get(post.id)
+      if (!snap) continue
+      const qv = Math.max(0, Number(snap.qualified_views) || 0)
+      qvByCreator.set(
+        post.creator_seller_id,
+        (qvByCreator.get(post.creator_seller_id) ?? 0) + qv
+      )
+    }
+
+    // Apply threshold + daily-growth cap.
+    const eligibleEntries: Array<[string, number]> = []
+    let ineligibleBelowThreshold = 0
+    for (const [creatorId, qv] of qvByCreator.entries()) {
+      const cap = MAX_DAILY_QV_GROWTH * Math.max(1, daysBetween(periodStart, periodEnd))
+      const capped = Math.min(qv, cap)
+      if (capped < MIN_QV_THRESHOLD) {
+        ineligibleBelowThreshold++
+        continue
+      }
+      eligibleEntries.push([creatorId, capped])
+    }
+
+    const totalQv = eligibleEntries.reduce((s, [, v]) => s + v, 0)
+    if (totalQv === 0) {
+      return {
+        pool_id: poolId,
+        total_qv: 0,
+        total_distributed_cents: 0,
+        per_creator: [],
+        ineligible_below_threshold: ineligibleBelowThreshold,
+      }
+    }
+
+    const totalCents = Number(pool.total_cents)
+    const allocated = eligibleEntries
+      .map(([creatorId, qv]): {
+        creator_seller_id: string
+        qualified_views: number
+        amount_cents: number
+      } => ({
+        creator_seller_id: creatorId,
+        qualified_views: qv,
+        amount_cents: Math.floor((qv / totalQv) * totalCents),
+      }))
+      .sort((a, b) => b.amount_cents - a.amount_cents)
+
+    const distributed = allocated.reduce((s, a) => s + a.amount_cents, 0)
+
+    return {
+      pool_id: poolId,
+      total_qv: totalQv,
+      total_distributed_cents: distributed,
+      per_creator: allocated,
+      ineligible_below_threshold: ineligibleBelowThreshold,
+    }
+  }
+
+  /**
+   * Persist the distribution as `RewardPayout` rows in `pending` status.
+   * Caller is responsible for then crediting each row via
+   * `hawala-ledger.creditCreatorReward` and updating to `paid`.
+   */
+  async persistDistribution(
+    poolId: string,
+    result: PoolDistributionResult
+  ): Promise<any[]> {
+    const created: any[] = []
+    for (const entry of result.per_creator) {
+      const payout = await (this as any).createRewardPayouts({
+        pool_id: poolId,
+        creator_seller_id: entry.creator_seller_id,
+        qualified_views: entry.qualified_views,
+        amount_cents: entry.amount_cents,
+        status: RewardPayoutStatus.PENDING,
+      })
+      created.push(payout)
+    }
+    await (this as any).updateRewardPools({
+      id: poolId,
+      status: RewardPoolStatus.CALCULATING,
+    })
+    return created
+  }
+
+  async markPoolDistributed(poolId: string): Promise<any> {
+    return (this as any).updateRewardPools({
+      id: poolId,
+      status: RewardPoolStatus.DISTRIBUTED,
+      distributed_at: new Date(),
+    })
+  }
+
+  async markPayoutPaid(payoutId: string, ledgerEntryId: string): Promise<any> {
+    return (this as any).updateRewardPayouts({
+      id: payoutId,
+      status: RewardPayoutStatus.PAID,
+      ledger_entry_id: ledgerEntryId,
+    })
+  }
+
+  async listPoolsDueForDistribution(now: Date = new Date()): Promise<any[]> {
+    const pools = await this.listRewardPools({
+      status: [RewardPoolStatus.SCHEDULED, RewardPoolStatus.ACCRUING] as any,
+    })
+    return pools.filter((p: any) => new Date(p.period_end as any) <= now)
+  }
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.max(1, Math.ceil((b.getTime() - a.getTime()) / 86_400_000))
+}
+
+export default CreatorRewardsService

--- a/backend/src/modules/hawala-ledger/models/ledger-account.ts
+++ b/backend/src/modules/hawala-ledger/models/ledger-account.ts
@@ -19,12 +19,14 @@ export const LedgerAccount = model.define("hawala_ledger_account", {
   account_number: model.text().unique(), // Unique account identifier
   account_type: model.enum([
     "USER_WALLET",
-    "PRODUCER_POOL", 
+    "PRODUCER_POOL",
     "SELLER_EARNINGS",
     "PLATFORM_FEE",
     "SETTLEMENT",
     "RESERVE",
     "ESCROW",
+    "CREATOR_EARNINGS",
+    "CREATOR_REWARD_POOL",
   ]),
   
   // Currency (ISO 4217)
@@ -42,6 +44,7 @@ export const LedgerAccount = model.define("hawala_ledger_account", {
     "PRODUCER",
     "PLATFORM",
     "SYSTEM",
+    "CREATOR",
   ]).nullable(),
   owner_id: model.text().nullable(), // customer_id, seller_id, producer_id, etc.
   

--- a/backend/src/modules/hawala-ledger/models/ledger-entry.ts
+++ b/backend/src/modules/hawala-ledger/models/ledger-entry.ts
@@ -40,6 +40,8 @@ export const LedgerEntry = model.define("hawala_ledger_entry", {
     "REFUND",
     "ADJUSTMENT",
     "FEE",
+    "CREATOR_COMMISSION",
+    "CREATOR_REWARD",
   ]),
   
   // Status
@@ -60,6 +62,8 @@ export const LedgerEntry = model.define("hawala_ledger_entry", {
     "STRIPE_PAYMENT",
     "STELLAR_TX",
     "MANUAL",
+    "CREATOR_ATTRIBUTION",
+    "CREATOR_REWARD_POOL",
   ]).nullable(),
   reference_id: model.text().nullable(),
   

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -202,6 +202,108 @@ class HawalaLedgerModuleService extends MedusaService({
   }
 
   /**
+   * Get or create a CREATOR_REWARD_POOL account for a program (or
+   * platform-funded global pool when programId is null). Used to escrow
+   * funds for engagement-pool distributions.
+   */
+  async getOrCreateCreatorRewardPool(
+    poolId: string,
+    currencyCode: string = "USD"
+  ) {
+    const existing = await this.listLedgerAccounts({
+      account_type: "CREATOR_REWARD_POOL",
+      owner_type: "SYSTEM",
+      owner_id: poolId,
+    })
+    if (existing.length > 0) return existing[0]
+    return this.createAccount({
+      account_type: "CREATOR_REWARD_POOL",
+      owner_type: "SYSTEM",
+      owner_id: poolId,
+      currency_code: currencyCode,
+    })
+  }
+
+  /**
+   * Fund a creator reward pool from the funder's earnings (vendor) or the
+   * platform reserve (when funderSellerId is null). Used when a vendor
+   * opens a $X engagement pool for a program.
+   */
+  async fundCreatorRewardPool(args: {
+    poolId: string
+    funderSellerId: string | null
+    amountCents: number
+    currencyCode?: string
+    idempotencyKey?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("fundCreatorRewardPool amountCents must be > 0")
+    }
+    const currency = args.currencyCode || "USD"
+    const poolAccount = await this.getOrCreateCreatorRewardPool(args.poolId, currency)
+    let sourceAccount
+    if (args.funderSellerId) {
+      sourceAccount = await this.getOrCreateSellerEarnings(args.funderSellerId, currency)
+    } else {
+      sourceAccount = await this.getOrCreateSystemAccount("RESERVE")
+    }
+    return this.createTransfer({
+      debit_account_id: sourceAccount.id,
+      credit_account_id: poolAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "TRANSFER",
+      reference_type: "CREATOR_REWARD_POOL",
+      reference_id: args.poolId,
+      idempotency_key: args.idempotencyKey || `pool-fund-${args.poolId}`,
+      description: `Fund creator reward pool ${args.poolId}`,
+      metadata: {
+        pool_id: args.poolId,
+        funder_seller_id: args.funderSellerId,
+      },
+    })
+  }
+
+  /**
+   * Credit a creator's earnings from a funded reward pool. Reverses the
+   * usual commission flow direction: pool -> creator earnings.
+   */
+  async creditCreatorReward(args: {
+    poolId: string
+    creatorSellerId: string
+    amountCents: number
+    rewardPayoutId: string
+    currencyCode?: string
+    description?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("creditCreatorReward amountCents must be > 0")
+    }
+    const currency = args.currencyCode || "USD"
+    const poolAccount = await this.getOrCreateCreatorRewardPool(args.poolId, currency)
+    const creatorAccount = await this.getOrCreateCreatorEarnings(
+      args.creatorSellerId,
+      currency
+    )
+    return this.createTransfer({
+      debit_account_id: poolAccount.id,
+      credit_account_id: creatorAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "CREATOR_REWARD",
+      reference_type: "CREATOR_REWARD_POOL",
+      reference_id: args.poolId,
+      idempotency_key: `creator-reward-${args.rewardPayoutId}`,
+      description:
+        args.description ||
+        `Creator reward payout ${args.rewardPayoutId} from pool ${args.poolId}`,
+      metadata: {
+        pool_id: args.poolId,
+        reward_payout_id: args.rewardPayoutId,
+        creator_seller_id: args.creatorSellerId,
+      },
+    })
+  }
+
+  /**
    * Reverse a previously paid creator commission (e.g. on refund). Creates a
    * new ledger entry that flows funds creator -> vendor.
    */

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -81,6 +81,8 @@ class HawalaLedgerModuleService extends MedusaService({
       SETTLEMENT: "STL",
       RESERVE: "RSV",
       ESCROW: "ESC",
+      CREATOR_EARNINGS: "CRE",
+      CREATOR_REWARD_POOL: "CRP",
     }[accountType] || "GEN"
     
     const timestamp = Date.now().toString(36).toUpperCase()
@@ -106,6 +108,135 @@ class HawalaLedgerModuleService extends MedusaService({
       account_type: accountType,
       owner_type: "SYSTEM",
       owner_id: "system",
+    })
+  }
+
+  /**
+   * Get or create a SELLER_EARNINGS account for a vendor.
+   */
+  async getOrCreateSellerEarnings(sellerId: string, currencyCode: string = "USD") {
+    const existing = await this.listLedgerAccounts({
+      account_type: "SELLER_EARNINGS",
+      owner_type: "SELLER",
+      owner_id: sellerId,
+    })
+
+    if (existing.length > 0) {
+      return existing[0]
+    }
+
+    return this.createAccount({
+      account_type: "SELLER_EARNINGS",
+      owner_type: "SELLER",
+      owner_id: sellerId,
+      currency_code: currencyCode,
+    })
+  }
+
+  /**
+   * Get or create a CREATOR_EARNINGS account for a creator seller.
+   * Used by the creator-monetization platform to credit affiliate commissions.
+   */
+  async getOrCreateCreatorEarnings(creatorSellerId: string, currencyCode: string = "USD") {
+    const existing = await this.listLedgerAccounts({
+      account_type: "CREATOR_EARNINGS",
+      owner_type: "CREATOR",
+      owner_id: creatorSellerId,
+    })
+
+    if (existing.length > 0) {
+      return existing[0]
+    }
+
+    return this.createAccount({
+      account_type: "CREATOR_EARNINGS",
+      owner_type: "CREATOR",
+      owner_id: creatorSellerId,
+      currency_code: currencyCode,
+    })
+  }
+
+  /**
+   * Credit a creator's earnings account from a vendor's seller earnings.
+   *
+   * Hawala stores money in DOLLARS (decimal) while the creator-attribution
+   * module operates in cents. Callers MUST pass `amountCents` as integer cents;
+   * we divide by 100 to match the ledger's decimal convention (mirrors the
+   * pattern in hawala-order-payment.ts).
+   */
+  async creditCreatorCommission(args: {
+    vendorSellerId: string
+    creatorSellerId: string
+    amountCents: number
+    orderId: string
+    attributionId: string
+    currencyCode?: string
+    description?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("creditCreatorCommission amountCents must be > 0")
+    }
+
+    const currency = args.currencyCode || "USD"
+    const vendorAccount = await this.getOrCreateSellerEarnings(args.vendorSellerId, currency)
+    const creatorAccount = await this.getOrCreateCreatorEarnings(args.creatorSellerId, currency)
+
+    return this.createTransfer({
+      debit_account_id: vendorAccount.id,
+      credit_account_id: creatorAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "CREATOR_COMMISSION",
+      reference_type: "CREATOR_ATTRIBUTION",
+      reference_id: args.attributionId,
+      order_id: args.orderId,
+      idempotency_key: `creator-commission-${args.attributionId}`,
+      description:
+        args.description ||
+        `Creator commission for order ${args.orderId} (attribution ${args.attributionId})`,
+      metadata: {
+        attribution_id: args.attributionId,
+        creator_seller_id: args.creatorSellerId,
+        vendor_seller_id: args.vendorSellerId,
+      },
+    })
+  }
+
+  /**
+   * Reverse a previously paid creator commission (e.g. on refund). Creates a
+   * new ledger entry that flows funds creator -> vendor.
+   */
+  async reverseCreatorCommission(args: {
+    vendorSellerId: string
+    creatorSellerId: string
+    amountCents: number
+    orderId: string
+    attributionId: string
+    reason: string
+    currencyCode?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("reverseCreatorCommission amountCents must be > 0")
+    }
+
+    const currency = args.currencyCode || "USD"
+    const vendorAccount = await this.getOrCreateSellerEarnings(args.vendorSellerId, currency)
+    const creatorAccount = await this.getOrCreateCreatorEarnings(args.creatorSellerId, currency)
+
+    return this.createTransfer({
+      debit_account_id: creatorAccount.id,
+      credit_account_id: vendorAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "REFUND",
+      reference_type: "CREATOR_ATTRIBUTION",
+      reference_id: args.attributionId,
+      order_id: args.orderId,
+      idempotency_key: `creator-commission-reversal-${args.attributionId}`,
+      description: `Reversed creator commission for order ${args.orderId}: ${args.reason}`,
+      metadata: {
+        attribution_id: args.attributionId,
+        reversal: true,
+        reason: args.reason,
+      },
     })
   }
 

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -304,6 +304,140 @@ class HawalaLedgerModuleService extends MedusaService({
   }
 
   /**
+   * Open escrow for a service subcontract or contract: move funds from
+   * the buyer-vendor's seller-earnings into a per-subcontract ESCROW
+   * account. The funds stay there until release or refund.
+   */
+  async openSubcontractEscrow(args: {
+    subcontractId: string
+    parentSellerId: string
+    amountCents: number
+    currencyCode?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("openSubcontractEscrow amountCents must be > 0")
+    }
+    const currency = args.currencyCode || "USD"
+    const parentAccount = await this.getOrCreateSellerEarnings(
+      args.parentSellerId,
+      currency
+    )
+    // Use a dedicated escrow account scoped to the subcontract id.
+    const existing = await this.listLedgerAccounts({
+      account_type: "ESCROW",
+      owner_type: "SYSTEM",
+      owner_id: args.subcontractId,
+    })
+    const escrowAccount =
+      existing[0] ??
+      (await this.createAccount({
+        account_type: "ESCROW",
+        owner_type: "SYSTEM",
+        owner_id: args.subcontractId,
+        currency_code: currency,
+      }))
+    return this.createTransfer({
+      debit_account_id: parentAccount.id,
+      credit_account_id: escrowAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "TRANSFER",
+      reference_type: "MANUAL",
+      reference_id: args.subcontractId,
+      idempotency_key: `subcontract-escrow-${args.subcontractId}`,
+      description: `Escrow for subcontract ${args.subcontractId}`,
+      metadata: {
+        subcontract_id: args.subcontractId,
+        parent_seller_id: args.parentSellerId,
+      },
+    })
+  }
+
+  /**
+   * Release subcontract escrow to the service vendor's earnings on
+   * verified delivery + acceptance.
+   */
+  async releaseSubcontractEscrow(args: {
+    subcontractId: string
+    serviceSellerId: string
+    amountCents: number
+    currencyCode?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("releaseSubcontractEscrow amountCents must be > 0")
+    }
+    const currency = args.currencyCode || "USD"
+    const escrows = await this.listLedgerAccounts({
+      account_type: "ESCROW",
+      owner_type: "SYSTEM",
+      owner_id: args.subcontractId,
+    })
+    if (escrows.length === 0) {
+      throw new Error(`No escrow account for subcontract ${args.subcontractId}`)
+    }
+    const serviceAccount = await this.getOrCreateSellerEarnings(
+      args.serviceSellerId,
+      currency
+    )
+    return this.createTransfer({
+      debit_account_id: escrows[0].id,
+      credit_account_id: serviceAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "TRANSFER",
+      reference_type: "MANUAL",
+      reference_id: args.subcontractId,
+      idempotency_key: `subcontract-release-${args.subcontractId}`,
+      description: `Release subcontract escrow ${args.subcontractId} to service vendor`,
+      metadata: {
+        subcontract_id: args.subcontractId,
+        service_seller_id: args.serviceSellerId,
+      },
+    })
+  }
+
+  /**
+   * Refund subcontract escrow back to the buyer-vendor on dispute or
+   * cancel.
+   */
+  async refundSubcontractEscrow(args: {
+    subcontractId: string
+    parentSellerId: string
+    amountCents: number
+    reason: string
+    currencyCode?: string
+  }) {
+    if (args.amountCents <= 0) {
+      throw new Error("refundSubcontractEscrow amountCents must be > 0")
+    }
+    const currency = args.currencyCode || "USD"
+    const escrows = await this.listLedgerAccounts({
+      account_type: "ESCROW",
+      owner_type: "SYSTEM",
+      owner_id: args.subcontractId,
+    })
+    if (escrows.length === 0) {
+      throw new Error(`No escrow account for subcontract ${args.subcontractId}`)
+    }
+    const parentAccount = await this.getOrCreateSellerEarnings(
+      args.parentSellerId,
+      currency
+    )
+    return this.createTransfer({
+      debit_account_id: escrows[0].id,
+      credit_account_id: parentAccount.id,
+      amount: args.amountCents / 100,
+      entry_type: "REFUND",
+      reference_type: "MANUAL",
+      reference_id: args.subcontractId,
+      idempotency_key: `subcontract-refund-${args.subcontractId}`,
+      description: `Refund subcontract escrow ${args.subcontractId}: ${args.reason}`,
+      metadata: {
+        subcontract_id: args.subcontractId,
+        reason: args.reason,
+      },
+    })
+  }
+
+  /**
    * Reverse a previously paid creator commission (e.g. on refund). Creates a
    * new ledger entry that flows funds creator -> vendor.
    */

--- a/backend/src/modules/marketplace-webhooks/__tests__/marketplace-webhooks-service.unit.spec.ts
+++ b/backend/src/modules/marketplace-webhooks/__tests__/marketplace-webhooks-service.unit.spec.ts
@@ -11,7 +11,10 @@ describe("marketplace-webhooks service helpers", () => {
     expect(signWithSecret(secret, body)).toBe(expected)
   })
 
-  it("exports the three contract events", () => {
+  it("exports the three original contract events alongside any extensions", () => {
+    // The list grows as new modules add events (creator-attribution,
+    // creator-program, creator-rewards, service-program, etc.). Assert the
+    // original three are still present and that there are no duplicates.
     expect(MARKETPLACE_WEBHOOK_EVENTS).toEqual(
       expect.arrayContaining([
         "creator.payout.completed",
@@ -19,6 +22,7 @@ describe("marketplace-webhooks service helpers", () => {
         "creator.account.suspended",
       ])
     )
-    expect(MARKETPLACE_WEBHOOK_EVENTS.length).toBe(3)
+    const unique = new Set(MARKETPLACE_WEBHOOK_EVENTS)
+    expect(unique.size).toBe(MARKETPLACE_WEBHOOK_EVENTS.length)
   })
 })

--- a/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
+++ b/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
@@ -29,6 +29,22 @@ export const MARKETPLACE_WEBHOOK_EVENTS = [
   "creator.reward.pool_funded",
   "creator.reward.distributed",
   "content_platform.event",
+  "service.program.published",
+  "service.application.submitted",
+  "service.application.approved",
+  "service.application.rejected",
+  "service.contract.opened",
+  "service.contract.delivered",
+  "service.contract.accepted",
+  "service.contract.disputed",
+  "service.proof.submitted",
+  "service.proof.verified",
+  "service.proof.rejected",
+  "subcontract.proposed",
+  "subcontract.accepted",
+  "subcontract.delivered",
+  "subcontract.completed",
+  "subcontract.disputed",
 ] as const
 
 export type MarketplaceWebhookEvent = (typeof MARKETPLACE_WEBHOOK_EVENTS)[number]

--- a/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
+++ b/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
@@ -9,6 +9,12 @@ export const MARKETPLACE_WEBHOOK_EVENTS = [
   "creator.payout.completed",
   "listing.signed_bundle.published",
   "creator.account.suspended",
+  "creator.commission.earned",
+  "creator.commission.held",
+  "creator.commission.approved",
+  "creator.commission.reversed",
+  "creator.commission.disqualified",
+  "creator.attribution.fraud_flagged",
 ] as const
 
 export type MarketplaceWebhookEvent = (typeof MARKETPLACE_WEBHOOK_EVENTS)[number]

--- a/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
+++ b/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
@@ -22,6 +22,13 @@ export const MARKETPLACE_WEBHOOK_EVENTS = [
   "creator.deal.opened",
   "creator.deal.violated",
   "creator.deal.canceled",
+  "creator.post.registered",
+  "creator.post.verified",
+  "creator.post.rejected",
+  "creator.reward.pool_opened",
+  "creator.reward.pool_funded",
+  "creator.reward.distributed",
+  "content_platform.event",
 ] as const
 
 export type MarketplaceWebhookEvent = (typeof MARKETPLACE_WEBHOOK_EVENTS)[number]

--- a/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
+++ b/backend/src/modules/marketplace-webhooks/models/webhook-subscription.ts
@@ -15,6 +15,13 @@ export const MARKETPLACE_WEBHOOK_EVENTS = [
   "creator.commission.reversed",
   "creator.commission.disqualified",
   "creator.attribution.fraud_flagged",
+  "creator.program.published",
+  "creator.application.submitted",
+  "creator.application.approved",
+  "creator.application.rejected",
+  "creator.deal.opened",
+  "creator.deal.violated",
+  "creator.deal.canceled",
 ] as const
 
 export type MarketplaceWebhookEvent = (typeof MARKETPLACE_WEBHOOK_EVENTS)[number]

--- a/backend/src/modules/order-subcontract/index.ts
+++ b/backend/src/modules/order-subcontract/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import OrderSubcontractService from "./service"
+
+export const ORDER_SUBCONTRACT_MODULE = "orderSubcontract"
+
+export default Module(ORDER_SUBCONTRACT_MODULE, {
+  service: OrderSubcontractService,
+})
+
+export * from "./models"
+export type { OrderSubcontractService }

--- a/backend/src/modules/order-subcontract/migrations/Migration20260801CreateOrderSubcontract.ts
+++ b/backend/src/modules/order-subcontract/migrations/Migration20260801CreateOrderSubcontract.ts
@@ -1,0 +1,79 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260801CreateOrderSubcontract extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "order_subcontract_status_enum" AS ENUM (
+          'proposed', 'accepted', 'in_progress', 'delivered',
+          'accepted_by_parent', 'disputed', 'canceled'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "subcontract_event_type_enum" AS ENUM (
+          'proposed', 'accepted', 'materials_received', 'production_started',
+          'qc_passed', 'shipped', 'delivered', 'accepted_by_parent',
+          'damaged', 'rework_requested', 'disputed', 'resolved', 'canceled'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "order_subcontract" (
+        "id" TEXT NOT NULL,
+        "parent_order_id" TEXT NOT NULL,
+        "parent_seller_id" TEXT NOT NULL,
+        "subcontract_seller_id" TEXT NOT NULL,
+        "contract_id" TEXT NOT NULL,
+        "program_id" TEXT NULL,
+        "order_item_ids" JSONB NOT NULL,
+        "unit_count" INTEGER NOT NULL,
+        "unit_price_cents" INTEGER NOT NULL,
+        "currency_code" TEXT NOT NULL DEFAULT 'usd',
+        "total_cents" NUMERIC NOT NULL,
+        "status" order_subcontract_status_enum NOT NULL DEFAULT 'proposed',
+        "pickup_at" TIMESTAMPTZ NULL,
+        "deliver_to" JSONB NULL,
+        "escrow_ledger_entry_id" TEXT NULL,
+        "release_ledger_entry_id" TEXT NULL,
+        "dispute_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "order_subcontract_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_subcontract_parent_order" ON "order_subcontract" ("parent_order_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_subcontract_seller_status" ON "order_subcontract" ("subcontract_seller_id", "status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_subcontract_parent_seller_status" ON "order_subcontract" ("parent_seller_id", "status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_subcontract_contract" ON "order_subcontract" ("contract_id");`)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "subcontract_event" (
+        "id" TEXT NOT NULL,
+        "subcontract_id" TEXT NOT NULL,
+        "event_type" subcontract_event_type_enum NOT NULL,
+        "actor_seller_id" TEXT NULL,
+        "proof_id" TEXT NULL,
+        "note" TEXT NULL,
+        "occurred_at" TIMESTAMPTZ NOT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "subcontract_event_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_subcontract_event_subcontract_time" ON "subcontract_event" ("subcontract_id", "occurred_at");`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "subcontract_event" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "order_subcontract" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "subcontract_event_type_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "order_subcontract_status_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/order-subcontract/models/index.ts
+++ b/backend/src/modules/order-subcontract/models/index.ts
@@ -1,0 +1,4 @@
+export { default as OrderSubcontract } from "./order-subcontract"
+export { default as SubcontractEvent } from "./subcontract-event"
+export { OrderSubcontractStatus } from "./order-subcontract"
+export { SubcontractEventType } from "./subcontract-event"

--- a/backend/src/modules/order-subcontract/models/order-subcontract.ts
+++ b/backend/src/modules/order-subcontract/models/order-subcontract.ts
@@ -1,0 +1,68 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum OrderSubcontractStatus {
+  PROPOSED = "proposed",
+  ACCEPTED = "accepted",
+  IN_PROGRESS = "in_progress",
+  DELIVERED = "delivered",
+  ACCEPTED_BY_PARENT = "accepted_by_parent",
+  DISPUTED = "disputed",
+  CANCELED = "canceled",
+}
+
+const OrderSubcontract = model
+  .define("order_subcontract", {
+    id: model.id().primaryKey(),
+
+    // Parent order from the storefront
+    parent_order_id: model.text(),
+    parent_seller_id: model.text(),
+
+    // Service vendor doing the work
+    subcontract_seller_id: model.text(),
+
+    // Backing service contract (and program)
+    contract_id: model.text(),
+    program_id: model.text().nullable(),
+
+    // Which line items are subcontracted (json array of order item ids)
+    order_item_ids: model.json(),
+    unit_count: model.number(),
+    unit_price_cents: model.number(),
+    currency_code: model.text().default("usd"),
+    total_cents: model.bigNumber(),
+
+    status: model
+      .enum(Object.values(OrderSubcontractStatus))
+      .default(OrderSubcontractStatus.PROPOSED),
+
+    pickup_at: model.dateTime().nullable(),
+    deliver_to: model.json().nullable(), // address json — buyer's or parent's
+
+    escrow_ledger_entry_id: model.text().nullable(),
+    release_ledger_entry_id: model.text().nullable(),
+
+    dispute_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["parent_order_id"],
+      name: "IDX_subcontract_parent_order",
+    },
+    {
+      on: ["subcontract_seller_id", "status"],
+      name: "IDX_subcontract_seller_status",
+    },
+    {
+      on: ["parent_seller_id", "status"],
+      name: "IDX_subcontract_parent_seller_status",
+    },
+    {
+      on: ["contract_id"],
+      name: "IDX_subcontract_contract",
+    },
+  ])
+
+export default OrderSubcontract

--- a/backend/src/modules/order-subcontract/models/subcontract-event.ts
+++ b/backend/src/modules/order-subcontract/models/subcontract-event.ts
@@ -1,0 +1,38 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum SubcontractEventType {
+  PROPOSED = "proposed",
+  ACCEPTED = "accepted",
+  MATERIALS_RECEIVED = "materials_received",
+  PRODUCTION_STARTED = "production_started",
+  QC_PASSED = "qc_passed",
+  SHIPPED = "shipped",
+  DELIVERED = "delivered",
+  ACCEPTED_BY_PARENT = "accepted_by_parent",
+  DAMAGED = "damaged",
+  REWORK_REQUESTED = "rework_requested",
+  DISPUTED = "disputed",
+  RESOLVED = "resolved",
+  CANCELED = "canceled",
+}
+
+const SubcontractEvent = model
+  .define("subcontract_event", {
+    id: model.id().primaryKey(),
+
+    subcontract_id: model.text(),
+    event_type: model.enum(Object.values(SubcontractEventType)),
+    actor_seller_id: model.text().nullable(),
+    proof_id: model.text().nullable(),
+    note: model.text().nullable(),
+    occurred_at: model.dateTime(),
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["subcontract_id", "occurred_at"],
+      name: "IDX_subcontract_event_subcontract_time",
+    },
+  ])
+
+export default SubcontractEvent

--- a/backend/src/modules/order-subcontract/service.ts
+++ b/backend/src/modules/order-subcontract/service.ts
@@ -1,0 +1,191 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import OrderSubcontract, {
+  OrderSubcontractStatus,
+} from "./models/order-subcontract"
+import SubcontractEvent, {
+  SubcontractEventType,
+} from "./models/subcontract-event"
+
+export interface ProposeSubcontractInput {
+  parentOrderId: string
+  parentSellerId: string
+  subcontractSellerId: string
+  contractId: string
+  programId?: string | null
+  orderItemIds: string[]
+  unitCount: number
+  unitPriceCents: number
+  currencyCode?: string
+  pickupAt?: Date | null
+  deliverTo?: Record<string, unknown> | null
+  metadata?: Record<string, unknown> | null
+}
+
+class OrderSubcontractService extends MedusaService({
+  OrderSubcontract,
+  SubcontractEvent,
+}) {
+  async proposeSubcontract(input: ProposeSubcontractInput): Promise<any> {
+    const total = Math.max(0, input.unitCount * input.unitPriceCents)
+    const sub = await (this as any).createOrderSubcontracts({
+      parent_order_id: input.parentOrderId,
+      parent_seller_id: input.parentSellerId,
+      subcontract_seller_id: input.subcontractSellerId,
+      contract_id: input.contractId,
+      program_id: input.programId ?? null,
+      order_item_ids: input.orderItemIds,
+      unit_count: input.unitCount,
+      unit_price_cents: input.unitPriceCents,
+      currency_code: input.currencyCode ?? "usd",
+      total_cents: total,
+      pickup_at: input.pickupAt ?? null,
+      deliver_to: input.deliverTo ?? null,
+      metadata: input.metadata ?? null,
+    })
+    await this.recordEvent({
+      subcontractId: sub.id,
+      eventType: SubcontractEventType.PROPOSED,
+      actorSellerId: input.parentSellerId,
+    })
+    return sub
+  }
+
+  async acceptSubcontract(args: {
+    subcontractId: string
+    serviceSellerId: string
+  }): Promise<any> {
+    const list = await this.listOrderSubcontracts({
+      id: args.subcontractId,
+      subcontract_seller_id: args.serviceSellerId,
+    })
+    const sub = list[0]
+    if (!sub) throw new Error("Subcontract not found")
+    if (sub.status !== OrderSubcontractStatus.PROPOSED) {
+      throw new Error(`Cannot accept subcontract in status ${sub.status}`)
+    }
+    const updated = await (this as any).updateOrderSubcontracts({
+      id: args.subcontractId,
+      status: OrderSubcontractStatus.ACCEPTED,
+    })
+    await this.recordEvent({
+      subcontractId: args.subcontractId,
+      eventType: SubcontractEventType.ACCEPTED,
+      actorSellerId: args.serviceSellerId,
+    })
+    return updated
+  }
+
+  async attachEscrow(args: {
+    subcontractId: string
+    escrowLedgerEntryId: string
+  }): Promise<any> {
+    return (this as any).updateOrderSubcontracts({
+      id: args.subcontractId,
+      escrow_ledger_entry_id: args.escrowLedgerEntryId,
+    })
+  }
+
+  async markInProgress(subcontractId: string): Promise<any> {
+    const updated = await (this as any).updateOrderSubcontracts({
+      id: subcontractId,
+      status: OrderSubcontractStatus.IN_PROGRESS,
+    })
+    await this.recordEvent({
+      subcontractId,
+      eventType: SubcontractEventType.PRODUCTION_STARTED,
+    })
+    return updated
+  }
+
+  async markDelivered(args: {
+    subcontractId: string
+    proofId?: string | null
+    actorSellerId: string
+  }): Promise<any> {
+    const updated = await (this as any).updateOrderSubcontracts({
+      id: args.subcontractId,
+      status: OrderSubcontractStatus.DELIVERED,
+    })
+    await this.recordEvent({
+      subcontractId: args.subcontractId,
+      eventType: SubcontractEventType.DELIVERED,
+      actorSellerId: args.actorSellerId,
+      proofId: args.proofId ?? null,
+    })
+    return updated
+  }
+
+  async markAcceptedByParent(args: {
+    subcontractId: string
+    parentSellerId: string
+    releaseLedgerEntryId: string
+  }): Promise<any> {
+    const updated = await (this as any).updateOrderSubcontracts({
+      id: args.subcontractId,
+      status: OrderSubcontractStatus.ACCEPTED_BY_PARENT,
+      release_ledger_entry_id: args.releaseLedgerEntryId,
+    })
+    await this.recordEvent({
+      subcontractId: args.subcontractId,
+      eventType: SubcontractEventType.ACCEPTED_BY_PARENT,
+      actorSellerId: args.parentSellerId,
+    })
+    return updated
+  }
+
+  async dispute(args: {
+    subcontractId: string
+    actorSellerId: string
+    reason: string
+  }): Promise<any> {
+    const updated = await (this as any).updateOrderSubcontracts({
+      id: args.subcontractId,
+      status: OrderSubcontractStatus.DISPUTED,
+      dispute_reason: args.reason,
+    })
+    await this.recordEvent({
+      subcontractId: args.subcontractId,
+      eventType: SubcontractEventType.DISPUTED,
+      actorSellerId: args.actorSellerId,
+      note: args.reason,
+    })
+    return updated
+  }
+
+  async cancel(args: {
+    subcontractId: string
+    actorSellerId: string
+  }): Promise<any> {
+    const updated = await (this as any).updateOrderSubcontracts({
+      id: args.subcontractId,
+      status: OrderSubcontractStatus.CANCELED,
+    })
+    await this.recordEvent({
+      subcontractId: args.subcontractId,
+      eventType: SubcontractEventType.CANCELED,
+      actorSellerId: args.actorSellerId,
+    })
+    return updated
+  }
+
+  async recordEvent(args: {
+    subcontractId: string
+    eventType: SubcontractEventType
+    actorSellerId?: string | null
+    proofId?: string | null
+    note?: string | null
+    metadata?: Record<string, unknown> | null
+  }): Promise<any> {
+    return (this as any).createSubcontractEvents({
+      subcontract_id: args.subcontractId,
+      event_type: args.eventType,
+      actor_seller_id: args.actorSellerId ?? null,
+      proof_id: args.proofId ?? null,
+      note: args.note ?? null,
+      occurred_at: new Date(),
+      metadata: args.metadata ?? null,
+    })
+  }
+}
+
+export default OrderSubcontractService

--- a/backend/src/modules/payout-breakdown/migrations/Migration20260520AddCreatorCommission.ts
+++ b/backend/src/modules/payout-breakdown/migrations/Migration20260520AddCreatorCommission.ts
@@ -1,0 +1,24 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Add `total_creator_commission` column to `order_payout_breakdown`.
+ *
+ * The CREATOR_COMMISSION FeeType is already part of the JSON breakdown_items
+ * blob; this migration adds an indexed scalar mirror for reporting/rollups.
+ * Existing rows default to 0.
+ */
+export class Migration20260520AddCreatorCommission extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "order_payout_breakdown"
+        ADD COLUMN IF NOT EXISTS "total_creator_commission" NUMERIC NOT NULL DEFAULT 0;
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "order_payout_breakdown"
+        DROP COLUMN IF EXISTS "total_creator_commission";
+    `)
+  }
+}

--- a/backend/src/modules/payout-breakdown/models/order-payout-breakdown.ts
+++ b/backend/src/modules/payout-breakdown/models/order-payout-breakdown.ts
@@ -50,7 +50,10 @@ const OrderPayoutBreakdown = model.define("order_payout_breakdown", {
   
   // Total tip
   total_tip: model.bigNumber().default(0),
-  
+
+  // Total creator commission (affiliate share funded out of seller gross)
+  total_creator_commission: model.bigNumber().default(0),
+
   // === Per-Seller Breakdown ===
   // For multi-vendor orders
   seller_breakdown: model.json(), // Array<{ seller_id, amount, fees }>

--- a/backend/src/modules/payout-breakdown/models/payout-config.ts
+++ b/backend/src/modules/payout-breakdown/models/payout-config.ts
@@ -15,6 +15,7 @@ export enum FeeType {
   TIP = "TIP",                             // Optional tip
   COOPERATIVE_FEE = "COOPERATIVE_FEE",     // Co-op membership fee
   PICKUP_DISCOUNT = "PICKUP_DISCOUNT",     // Discount for pickup
+  CREATOR_COMMISSION = "CREATOR_COMMISSION", // Affiliate share to a creator
 }
 
 /**

--- a/backend/src/modules/payout-breakdown/service.ts
+++ b/backend/src/modules/payout-breakdown/service.ts
@@ -47,6 +47,10 @@ const DEFAULT_FEE_LABELS: Record<FeeType, { label: string; description: string }
     label: "Pickup Discount",
     description: "Savings for picking up your order",
   },
+  [FeeType.CREATOR_COMMISSION]: {
+    label: "Creator Commission",
+    description: "Affiliate share paid to the creator who referred this sale",
+  },
 }
 
 /**
@@ -67,6 +71,12 @@ export interface BreakdownInput {
   orderId?: string
   currencyCode?: string
   pickupDiscount?: number    // Discount for pickup (cents, negative)
+  // Creator-monetization extension. When set, this commission is funded out
+  // of the seller's gross (i.e. it reduces the producer's net), keeping the
+  // customer-facing total unchanged.
+  creatorCommissionCents?: number
+  creatorSellerId?: string
+  creatorName?: string
 }
 
 class PayoutBreakdownService extends MedusaService({
@@ -137,6 +147,7 @@ class PayoutBreakdownService extends MedusaService({
       communityFund: number
       tax: number
       tip: number
+      creatorCommission: number
     }
     sellerBreakdown: Array<{
       sellerId: string
@@ -159,33 +170,48 @@ class PayoutBreakdownService extends MedusaService({
     let totalSubtotal = input.subtotal
     let totalToProducers = 0
     let totalPlatformFees = 0
-    
+    let totalCreatorCommission = 0
+
     // Handle multi-seller or single-seller
     const sellers = input.sellerBreakdown || [{
       sellerId: input.sellerId || "unknown",
       subtotal: input.subtotal,
       sellerName: undefined,
     }]
-    
+
+    // Creator commission is currently single-creator-per-order and funded out
+    // of the first seller's gross. Multi-seller commission splitting can be
+    // added later — for now allocate the full commission to the first seller.
+    const creatorCommissionTotal = Math.max(0, Math.floor(input.creatorCommissionCents || 0))
+    let creatorRemaining = creatorCommissionTotal
+
     for (const seller of sellers) {
       const platformFeePercent = await this.getEffectivePlatformFee(seller.sellerId)
       const platformFee = Math.round(seller.subtotal * (platformFeePercent / 100))
-      const producerAmount = seller.subtotal - platformFee
-      
+
       // Check for additional community contribution from seller
       const sellerSettings = await this.getSellerSettings(seller.sellerId)
       const additionalCommunity = sellerSettings?.additional_community_contribution || 0
       const communityFromSeller = Math.round(seller.subtotal * (additionalCommunity / 100))
-      
-      totalToProducers += producerAmount - communityFromSeller
+
+      // Allocate creator commission against this seller's slice (capped at
+      // remaining gross after platform fee + community).
+      const sellerGrossAfterPlatform = Math.max(0, seller.subtotal - platformFee - communityFromSeller)
+      const creatorForSeller = Math.min(creatorRemaining, sellerGrossAfterPlatform)
+      creatorRemaining -= creatorForSeller
+
+      const producerAmount = seller.subtotal - platformFee - communityFromSeller - creatorForSeller
+
+      totalToProducers += producerAmount
       totalPlatformFees += platformFee
-      
+      totalCreatorCommission += creatorForSeller
+
       sellerTotals.push({
         sellerId: seller.sellerId,
         sellerName: seller.sellerName,
         gross: seller.subtotal,
-        fees: platformFee,
-        net: producerAmount - communityFromSeller,
+        fees: platformFee + creatorForSeller,
+        net: producerAmount,
       })
     }
     
@@ -222,6 +248,18 @@ class PayoutBreakdownService extends MedusaService({
         label: DEFAULT_FEE_LABELS[FeeType.PLATFORM_FEE].label,
         description: DEFAULT_FEE_LABELS[FeeType.PLATFORM_FEE].description,
         recipient: "Platform",
+      })
+    }
+
+    // Creator commission item (when an attributed creator referred this sale)
+    if (totalCreatorCommission > 0) {
+      items.push({
+        type: FeeType.CREATOR_COMMISSION,
+        amount: totalCreatorCommission,
+        percent: Math.round((totalCreatorCommission / customerPaid) * 100),
+        label: DEFAULT_FEE_LABELS[FeeType.CREATOR_COMMISSION].label,
+        description: DEFAULT_FEE_LABELS[FeeType.CREATOR_COMMISSION].description,
+        recipient: input.creatorName ?? "Creator",
       })
     }
     
@@ -293,6 +331,7 @@ class PayoutBreakdownService extends MedusaService({
         communityFund,
         tax: input.tax || 0,
         tip: input.tip || 0,
+        creatorCommission: totalCreatorCommission,
       },
       sellerBreakdown: sellerTotals,
     }
@@ -320,6 +359,7 @@ class PayoutBreakdownService extends MedusaService({
       total_community_fund: breakdown.totals.communityFund,
       total_tax: breakdown.totals.tax,
       total_tip: breakdown.totals.tip,
+      total_creator_commission: breakdown.totals.creatorCommission ?? 0,
       seller_breakdown: breakdown.sellerBreakdown as unknown as Record<string, unknown>,
     })
   }
@@ -337,6 +377,7 @@ class PayoutBreakdownService extends MedusaService({
       communityFund: number
       tax: number
       tip: number
+      creatorCommission: number
     }
     sellerBreakdown: Array<{
       sellerId: string
@@ -347,13 +388,13 @@ class PayoutBreakdownService extends MedusaService({
     }>
   } | null> {
     const breakdowns = await this.listOrderPayoutBreakdowns({ order_id: orderId })
-    
+
     if (breakdowns.length === 0) {
       return null
     }
-    
+
     const breakdown = breakdowns[0]
-    
+
     return {
       items: (breakdown.breakdown_items as Record<string, unknown>) as unknown as BreakdownItem[],
       totals: {
@@ -364,6 +405,7 @@ class PayoutBreakdownService extends MedusaService({
         communityFund: Number(breakdown.total_community_fund),
         tax: Number(breakdown.total_tax),
         tip: Number(breakdown.total_tip),
+        creatorCommission: Number((breakdown as any).total_creator_commission ?? 0),
       },
       sellerBreakdown: (breakdown.seller_breakdown as Record<string, unknown>) as unknown as Array<{
         sellerId: string

--- a/backend/src/modules/seller-extension/migrations/Migration20260601AddCreatorVendorType.ts
+++ b/backend/src/modules/seller-extension/migrations/Migration20260601AddCreatorVendorType.ts
@@ -1,0 +1,51 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Add `creator` to vendor_type_enum + creator-specific columns.
+ *
+ * Adds the `creator` value to the existing `vendor_type_enum` and creates
+ * nullable creator-profile columns on `seller_metadata` used by the creator
+ * monetization platform (creator_handle, creator_bio, creator_niches,
+ * creator_total_followers, creator_audience_geo).
+ *
+ * `creator_handle` gets a partial unique index so multiple non-creator
+ * sellers can leave it NULL but two creators cannot share the same handle.
+ */
+export class Migration20260601AddCreatorVendorType extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        ALTER TYPE "vendor_type_enum" ADD VALUE IF NOT EXISTS 'creator';
+      EXCEPTION WHEN others THEN null; END $$;
+    `)
+
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+        ADD COLUMN IF NOT EXISTS "creator_handle" TEXT NULL,
+        ADD COLUMN IF NOT EXISTS "creator_bio" TEXT NULL,
+        ADD COLUMN IF NOT EXISTS "creator_niches" JSONB NULL,
+        ADD COLUMN IF NOT EXISTS "creator_total_followers" INTEGER NOT NULL DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS "creator_audience_geo" JSONB NULL;
+    `)
+
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_seller_metadata_creator_handle"
+        ON "seller_metadata" ("creator_handle")
+        WHERE "creator_handle" IS NOT NULL AND "deleted_at" IS NULL;
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP INDEX IF EXISTS "UQ_seller_metadata_creator_handle";')
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+        DROP COLUMN IF EXISTS "creator_audience_geo",
+        DROP COLUMN IF EXISTS "creator_total_followers",
+        DROP COLUMN IF EXISTS "creator_niches",
+        DROP COLUMN IF EXISTS "creator_bio",
+        DROP COLUMN IF EXISTS "creator_handle";
+    `)
+    // Note: Postgres has no clean way to remove a value from an enum without
+    // recreating the type. We leave 'creator' in the enum on rollback.
+  }
+}

--- a/backend/src/modules/seller-extension/models/seller-metadata.ts
+++ b/backend/src/modules/seller-extension/models/seller-metadata.ts
@@ -24,6 +24,16 @@ export enum VendorType {
   MAKER = "maker",
   RESTAURANT = "restaurant",
   MUTUAL_AID = "mutual_aid",
+  CREATOR = "creator",
+}
+
+/**
+ * Creator profile fields used by the creator-monetization platform.
+ * Only meaningful when `vendor_type === CREATOR`.
+ */
+export interface CreatorAudienceGeo {
+  // ISO-3166-1 alpha-2 country code -> share (0..1) of the creator's audience
+  [countryCode: string]: number
 }
 
 /**
@@ -129,6 +139,13 @@ const SellerMetadata = model.define("seller_metadata", {
   
   // Vendor-selected dashboard extensions (feature keys)
   enabled_extensions: model.json().nullable(),
+
+  // Creator-specific fields (used when vendor_type === CREATOR)
+  creator_handle: model.text().nullable(),
+  creator_bio: model.text().nullable(),
+  creator_niches: model.json().nullable(), // string[]
+  creator_total_followers: model.number().default(0),
+  creator_audience_geo: model.json().nullable(), // CreatorAudienceGeo
 
   // Metadata for additional extensions
   metadata: model.json().nullable(),

--- a/backend/src/modules/service-program/index.ts
+++ b/backend/src/modules/service-program/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import ServiceProgramService from "./service"
+
+export const SERVICE_PROGRAM_MODULE = "serviceProgram"
+
+export default Module(SERVICE_PROGRAM_MODULE, {
+  service: ServiceProgramService,
+})
+
+export * from "./models"
+export type { ServiceProgramService }

--- a/backend/src/modules/service-program/migrations/Migration20260801CreateServiceProgram.ts
+++ b/backend/src/modules/service-program/migrations/Migration20260801CreateServiceProgram.ts
@@ -1,0 +1,166 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260801CreateServiceProgram extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "service_category_enum" AS ENUM (
+          'apparel_press', 'packaging', 'photography', 'design',
+          'fulfillment', 'courier', 'repair', 'fabrication',
+          'co_packing', 'assembly', 'custom'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "service_program_type_enum" AS ENUM (
+          'bounty_open', 'bounty_invite', 'fixed_contract',
+          'throughput_pool', 'order_subcontract'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "service_program_status_enum" AS ENUM (
+          'draft', 'active', 'paused', 'closed', 'archived'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "service_pricing_model_enum" AS ENUM (
+          'per_unit', 'per_hour', 'flat', 'tiered'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "service_application_status_enum" AS ENUM (
+          'pending', 'approved', 'rejected', 'withdrawn'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "service_contract_status_enum" AS ENUM (
+          'active', 'in_progress', 'delivered', 'accepted',
+          'disputed', 'canceled'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "service_program" (
+        "id" TEXT NOT NULL,
+        "vendor_id" TEXT NOT NULL,
+        "title" TEXT NOT NULL,
+        "slug" TEXT NOT NULL,
+        "description" TEXT NULL,
+        "deliverable_spec" JSONB NULL,
+        "acceptance_criteria" JSONB NULL,
+        "service_category" service_category_enum NOT NULL,
+        "program_type" service_program_type_enum NOT NULL,
+        "pricing_model" service_pricing_model_enum NOT NULL,
+        "status" service_program_status_enum NOT NULL DEFAULT 'draft',
+        "unit_price_cents" INTEGER NULL,
+        "hourly_rate_cents" INTEGER NULL,
+        "flat_price_cents" INTEGER NULL,
+        "pool_total_cents" INTEGER NULL,
+        "currency_code" TEXT NOT NULL DEFAULT 'usd',
+        "min_units" INTEGER NULL,
+        "max_units" INTEGER NULL,
+        "units_committed" INTEGER NOT NULL DEFAULT 0,
+        "deadline_at" TIMESTAMPTZ NULL,
+        "starts_at" TIMESTAMPTZ NULL,
+        "ends_at" TIMESTAMPTZ NULL,
+        "budget_cap_cents" INTEGER NULL,
+        "escrow_amount_cents" INTEGER NOT NULL DEFAULT 0,
+        "requires_kyc" BOOLEAN NOT NULL DEFAULT FALSE,
+        "min_verification_level" TEXT NULL,
+        "geo_allowlist" JSONB NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "service_program_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_program_vendor" ON "service_program" ("vendor_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_program_category" ON "service_program" ("service_category");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_program_status" ON "service_program" ("status");`)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_service_program_vendor_slug"
+        ON "service_program" ("vendor_id", "slug")
+        WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "service_application" (
+        "id" TEXT NOT NULL,
+        "program_id" TEXT NOT NULL,
+        "service_seller_id" TEXT NOT NULL,
+        "proposed_unit_price_cents" INTEGER NULL,
+        "proposed_capacity" INTEGER NULL,
+        "proposed_lead_time_days" INTEGER NULL,
+        "sample_portfolio_urls" JSONB NULL,
+        "pitch" TEXT NULL,
+        "status" service_application_status_enum NOT NULL DEFAULT 'pending',
+        "decided_at" TIMESTAMPTZ NULL,
+        "decided_by" TEXT NULL,
+        "decision_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "service_application_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_application_program" ON "service_application" ("program_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_application_service_seller" ON "service_application" ("service_seller_id");`)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_service_application"
+        ON "service_application" ("program_id", "service_seller_id")
+        WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "service_contract" (
+        "id" TEXT NOT NULL,
+        "program_id" TEXT NOT NULL,
+        "application_id" TEXT NOT NULL,
+        "service_seller_id" TEXT NOT NULL,
+        "vendor_id" TEXT NOT NULL,
+        "status" service_contract_status_enum NOT NULL DEFAULT 'active',
+        "effective_from" TIMESTAMPTZ NOT NULL,
+        "effective_until" TIMESTAMPTZ NULL,
+        "terms_snapshot" JSONB NOT NULL,
+        "milestones" JSONB NULL,
+        "escrow_ledger_entry_id" TEXT NULL,
+        "escrow_amount_cents" INTEGER NOT NULL DEFAULT 0,
+        "total_units_delivered" INTEGER NOT NULL DEFAULT 0,
+        "total_paid_cents" NUMERIC NOT NULL DEFAULT 0,
+        "dispute_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "service_contract_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_contract_seller_status" ON "service_contract" ("service_seller_id", "status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_contract_vendor_status" ON "service_contract" ("vendor_id", "status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_service_contract_program" ON "service_contract" ("program_id");`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "service_contract" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "service_application" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "service_program" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "service_contract_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "service_application_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "service_pricing_model_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "service_program_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "service_program_type_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "service_category_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/service-program/models/index.ts
+++ b/backend/src/modules/service-program/models/index.ts
@@ -1,0 +1,12 @@
+export { default as ServiceProgram } from "./service-program"
+export { default as ServiceApplication } from "./service-application"
+export { default as ServiceContract } from "./service-contract"
+
+export {
+  ServiceCategory,
+  ServiceProgramType,
+  ServiceProgramStatus,
+  ServicePricingModel,
+} from "./service-program"
+export { ServiceApplicationStatus } from "./service-application"
+export { ServiceContractStatus } from "./service-contract"

--- a/backend/src/modules/service-program/models/service-application.ts
+++ b/backend/src/modules/service-program/models/service-application.ts
@@ -1,0 +1,48 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum ServiceApplicationStatus {
+  PENDING = "pending",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+  WITHDRAWN = "withdrawn",
+}
+
+const ServiceApplication = model
+  .define("service_application", {
+    id: model.id().primaryKey(),
+
+    program_id: model.text(),
+    service_seller_id: model.text(), // the service-providing vendor
+
+    proposed_unit_price_cents: model.number().nullable(),
+    proposed_capacity: model.number().nullable(),
+    proposed_lead_time_days: model.number().nullable(),
+    sample_portfolio_urls: model.json().nullable(), // string[]
+    pitch: model.text().nullable(),
+
+    status: model
+      .enum(Object.values(ServiceApplicationStatus))
+      .default(ServiceApplicationStatus.PENDING),
+    decided_at: model.dateTime().nullable(),
+    decided_by: model.text().nullable(),
+    decision_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["program_id"],
+      name: "IDX_service_application_program",
+    },
+    {
+      on: ["service_seller_id"],
+      name: "IDX_service_application_service_seller",
+    },
+    {
+      on: ["program_id", "service_seller_id"],
+      name: "UQ_service_application",
+      unique: true,
+    },
+  ])
+
+export default ServiceApplication

--- a/backend/src/modules/service-program/models/service-contract.ts
+++ b/backend/src/modules/service-program/models/service-contract.ts
@@ -1,0 +1,61 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum ServiceContractStatus {
+  ACTIVE = "active",
+  IN_PROGRESS = "in_progress",
+  DELIVERED = "delivered",
+  ACCEPTED = "accepted",
+  DISPUTED = "disputed",
+  CANCELED = "canceled",
+}
+
+const ServiceContract = model
+  .define("service_contract", {
+    id: model.id().primaryKey(),
+
+    program_id: model.text(),
+    application_id: model.text(),
+    service_seller_id: model.text(),
+    vendor_id: model.text(),
+
+    status: model
+      .enum(Object.values(ServiceContractStatus))
+      .default(ServiceContractStatus.ACTIVE),
+
+    effective_from: model.dateTime(),
+    effective_until: model.dateTime().nullable(),
+
+    // Frozen terms snapshot at acceptance time
+    terms_snapshot: model.json(),
+
+    // Milestones: array of { id, title, percent_of_total, due_at, status,
+    //                       proof_id?, released_at? }
+    milestones: model.json().nullable(),
+
+    // Backing escrow (in hawala-ledger)
+    escrow_ledger_entry_id: model.text().nullable(),
+    escrow_amount_cents: model.number().default(0),
+
+    total_units_delivered: model.number().default(0),
+    total_paid_cents: model.bigNumber().default(0),
+
+    dispute_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["service_seller_id", "status"],
+      name: "IDX_service_contract_seller_status",
+    },
+    {
+      on: ["vendor_id", "status"],
+      name: "IDX_service_contract_vendor_status",
+    },
+    {
+      on: ["program_id"],
+      name: "IDX_service_contract_program",
+    },
+  ])
+
+export default ServiceContract

--- a/backend/src/modules/service-program/models/service-program.ts
+++ b/backend/src/modules/service-program/models/service-program.ts
@@ -1,0 +1,104 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum ServiceCategory {
+  APPAREL_PRESS = "apparel_press",
+  PACKAGING = "packaging",
+  PHOTOGRAPHY = "photography",
+  DESIGN = "design",
+  FULFILLMENT = "fulfillment",
+  COURIER = "courier",
+  REPAIR = "repair",
+  FABRICATION = "fabrication",
+  CO_PACKING = "co_packing",
+  ASSEMBLY = "assembly",
+  CUSTOM = "custom",
+}
+
+export enum ServiceProgramType {
+  BOUNTY_OPEN = "bounty_open",       // any qualifying service-vendor can claim
+  BOUNTY_INVITE = "bounty_invite",   // vendor pre-selects service vendors
+  FIXED_CONTRACT = "fixed_contract", // single-service-vendor contract
+  THROUGHPUT_POOL = "throughput_pool", // shared pool by output volume
+  ORDER_SUBCONTRACT = "order_subcontract", // tied to specific orders
+}
+
+export enum ServiceProgramStatus {
+  DRAFT = "draft",
+  ACTIVE = "active",
+  PAUSED = "paused",
+  CLOSED = "closed",
+  ARCHIVED = "archived",
+}
+
+export enum ServicePricingModel {
+  PER_UNIT = "per_unit",
+  PER_HOUR = "per_hour",
+  FLAT = "flat",
+  TIERED = "tiered",
+}
+
+const ServiceProgram = model
+  .define("service_program", {
+    id: model.id().primaryKey(),
+
+    vendor_id: model.text(),
+    title: model.text(),
+    slug: model.text(),
+    description: model.text().nullable(),
+    deliverable_spec: model.json().nullable(), // file specs, dimensions, materials, tolerances
+    acceptance_criteria: model.json().nullable(), // what counts as "done"
+
+    service_category: model.enum(Object.values(ServiceCategory)),
+    program_type: model.enum(Object.values(ServiceProgramType)),
+    pricing_model: model.enum(Object.values(ServicePricingModel)),
+    status: model
+      .enum(Object.values(ServiceProgramStatus))
+      .default(ServiceProgramStatus.DRAFT),
+
+    // Pricing
+    unit_price_cents: model.number().nullable(),
+    hourly_rate_cents: model.number().nullable(),
+    flat_price_cents: model.number().nullable(),
+    pool_total_cents: model.number().nullable(),
+    currency_code: model.text().default("usd"),
+
+    // Capacity
+    min_units: model.number().nullable(),
+    max_units: model.number().nullable(),
+    units_committed: model.number().default(0),
+
+    // Lifecycle
+    deadline_at: model.dateTime().nullable(),
+    starts_at: model.dateTime().nullable(),
+    ends_at: model.dateTime().nullable(),
+    budget_cap_cents: model.number().nullable(),
+    escrow_amount_cents: model.number().default(0),
+
+    // Gating
+    requires_kyc: model.boolean().default(false),
+    min_verification_level: model.text().nullable(),
+    geo_allowlist: model.json().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["vendor_id"],
+      name: "IDX_service_program_vendor",
+    },
+    {
+      on: ["service_category"],
+      name: "IDX_service_program_category",
+    },
+    {
+      on: ["status"],
+      name: "IDX_service_program_status",
+    },
+    {
+      on: ["vendor_id", "slug"],
+      name: "UQ_service_program_vendor_slug",
+      unique: true,
+    },
+  ])
+
+export default ServiceProgram

--- a/backend/src/modules/service-program/service.ts
+++ b/backend/src/modules/service-program/service.ts
@@ -1,0 +1,328 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import ServiceProgram, {
+  ServiceCategory,
+  ServiceProgramType,
+  ServiceProgramStatus,
+  ServicePricingModel,
+} from "./models/service-program"
+import ServiceApplication, {
+  ServiceApplicationStatus,
+} from "./models/service-application"
+import ServiceContract, {
+  ServiceContractStatus,
+} from "./models/service-contract"
+
+export interface CreateServiceProgramInput {
+  vendorId: string
+  title: string
+  slug: string
+  description?: string | null
+  deliverableSpec?: Record<string, unknown> | null
+  acceptanceCriteria?: Record<string, unknown> | null
+  serviceCategory: ServiceCategory
+  programType: ServiceProgramType
+  pricingModel: ServicePricingModel
+  unitPriceCents?: number | null
+  hourlyRateCents?: number | null
+  flatPriceCents?: number | null
+  poolTotalCents?: number | null
+  currencyCode?: string
+  minUnits?: number | null
+  maxUnits?: number | null
+  deadlineAt?: Date | null
+  startsAt?: Date | null
+  endsAt?: Date | null
+  budgetCapCents?: number | null
+  requiresKyc?: boolean
+  minVerificationLevel?: string | null
+  geoAllowlist?: string[] | null
+  metadata?: Record<string, unknown> | null
+}
+
+class ServiceProgramService extends MedusaService({
+  ServiceProgram,
+  ServiceApplication,
+  ServiceContract,
+}) {
+  async createProgram(input: CreateServiceProgramInput): Promise<any> {
+    const existing = await this.listServicePrograms({
+      vendor_id: input.vendorId,
+      slug: input.slug,
+    })
+    if (existing.length > 0) {
+      throw new Error(`Service program with slug "${input.slug}" already exists`)
+    }
+    return (this as any).createServicePrograms({
+      vendor_id: input.vendorId,
+      title: input.title,
+      slug: input.slug,
+      description: input.description ?? null,
+      deliverable_spec: input.deliverableSpec ?? null,
+      acceptance_criteria: input.acceptanceCriteria ?? null,
+      service_category: input.serviceCategory,
+      program_type: input.programType,
+      pricing_model: input.pricingModel,
+      unit_price_cents: input.unitPriceCents ?? null,
+      hourly_rate_cents: input.hourlyRateCents ?? null,
+      flat_price_cents: input.flatPriceCents ?? null,
+      pool_total_cents: input.poolTotalCents ?? null,
+      currency_code: input.currencyCode ?? "usd",
+      min_units: input.minUnits ?? null,
+      max_units: input.maxUnits ?? null,
+      deadline_at: input.deadlineAt ?? null,
+      starts_at: input.startsAt ?? null,
+      ends_at: input.endsAt ?? null,
+      budget_cap_cents: input.budgetCapCents ?? null,
+      requires_kyc: input.requiresKyc ?? false,
+      min_verification_level: input.minVerificationLevel ?? null,
+      geo_allowlist: input.geoAllowlist ?? null,
+      metadata: input.metadata ?? null,
+    })
+  }
+
+  async publishProgram(programId: string): Promise<any> {
+    return (this as any).updateServicePrograms({
+      id: programId,
+      status: ServiceProgramStatus.ACTIVE,
+    })
+  }
+
+  async closeProgram(programId: string, reason?: string): Promise<any> {
+    return (this as any).updateServicePrograms({
+      id: programId,
+      status: ServiceProgramStatus.CLOSED,
+      metadata: reason ? { close_reason: reason } : undefined,
+    })
+  }
+
+  async listOpenPrograms(filters: {
+    serviceCategory?: ServiceCategory
+    programType?: ServiceProgramType
+    vendorId?: string
+  } = {}): Promise<any[]> {
+    const all = await this.listServicePrograms({
+      status: ServiceProgramStatus.ACTIVE,
+      ...(filters.vendorId ? { vendor_id: filters.vendorId } : {}),
+      ...(filters.serviceCategory ? { service_category: filters.serviceCategory } : {}),
+      ...(filters.programType ? { program_type: filters.programType } : {}),
+    })
+    const now = new Date()
+    return all.filter((p: any) => {
+      if (p.starts_at && new Date(p.starts_at) > now) return false
+      if (p.ends_at && new Date(p.ends_at) < now) return false
+      return true
+    })
+  }
+
+  async applyToProgram(args: {
+    programId: string
+    serviceSellerId: string
+    proposedUnitPriceCents?: number | null
+    proposedCapacity?: number | null
+    proposedLeadTimeDays?: number | null
+    samplePortfolioUrls?: string[] | null
+    pitch?: string | null
+  }): Promise<any> {
+    const programs = await this.listServicePrograms({ id: args.programId })
+    const program = programs[0]
+    if (!program) throw new Error("Program not found")
+    if (program.status !== ServiceProgramStatus.ACTIVE) {
+      throw new Error(`Program not open (status=${program.status})`)
+    }
+    const existing = await this.listServiceApplications({
+      program_id: args.programId,
+      service_seller_id: args.serviceSellerId,
+    })
+    if (existing.length > 0) {
+      const e = existing[0]
+      if (e.status === ServiceApplicationStatus.WITHDRAWN) {
+        return (this as any).updateServiceApplications({
+          id: e.id,
+          status: ServiceApplicationStatus.PENDING,
+          proposed_unit_price_cents: args.proposedUnitPriceCents ?? e.proposed_unit_price_cents,
+          proposed_capacity: args.proposedCapacity ?? e.proposed_capacity,
+          proposed_lead_time_days: args.proposedLeadTimeDays ?? e.proposed_lead_time_days,
+          sample_portfolio_urls: args.samplePortfolioUrls ?? e.sample_portfolio_urls,
+          pitch: args.pitch ?? e.pitch,
+          decided_at: null,
+          decided_by: null,
+          decision_reason: null,
+        })
+      }
+      return e
+    }
+    return (this as any).createServiceApplications({
+      program_id: args.programId,
+      service_seller_id: args.serviceSellerId,
+      proposed_unit_price_cents: args.proposedUnitPriceCents ?? null,
+      proposed_capacity: args.proposedCapacity ?? null,
+      proposed_lead_time_days: args.proposedLeadTimeDays ?? null,
+      sample_portfolio_urls: args.samplePortfolioUrls ?? null,
+      pitch: args.pitch ?? null,
+    })
+  }
+
+  async withdrawApplication(applicationId: string, serviceSellerId: string): Promise<any> {
+    const apps = await this.listServiceApplications({
+      id: applicationId,
+      service_seller_id: serviceSellerId,
+    })
+    const app = apps[0]
+    if (!app) throw new Error("Application not found")
+    if (app.status !== ServiceApplicationStatus.PENDING) {
+      throw new Error(`Cannot withdraw application in status ${app.status}`)
+    }
+    return (this as any).updateServiceApplications({
+      id: applicationId,
+      status: ServiceApplicationStatus.WITHDRAWN,
+    })
+  }
+
+  async decideApplication(args: {
+    applicationId: string
+    decision: "approve" | "reject"
+    decidedBy: string
+    reason?: string | null
+  }): Promise<any> {
+    const apps = await this.listServiceApplications({ id: args.applicationId })
+    const app = apps[0]
+    if (!app) throw new Error("Application not found")
+    if (app.status !== ServiceApplicationStatus.PENDING) {
+      throw new Error(`Application already decided (status=${app.status})`)
+    }
+    return (this as any).updateServiceApplications({
+      id: args.applicationId,
+      status:
+        args.decision === "approve"
+          ? ServiceApplicationStatus.APPROVED
+          : ServiceApplicationStatus.REJECTED,
+      decided_at: new Date(),
+      decided_by: args.decidedBy,
+      decision_reason: args.reason ?? null,
+    })
+  }
+
+  /**
+   * Open a service contract for an approved application. Caller is
+   * responsible for funding the escrow via hawala-ledger and patching
+   * `escrow_ledger_entry_id` + `escrow_amount_cents` back via
+   * `attachEscrowToContract`.
+   */
+  async openContractForApprovedApp(applicationId: string): Promise<any> {
+    const apps = await this.listServiceApplications({ id: applicationId })
+    const app = apps[0]
+    if (!app) throw new Error("Application not found")
+    if (app.status !== ServiceApplicationStatus.APPROVED) {
+      throw new Error(`Cannot open contract for application in status ${app.status}`)
+    }
+    const programs = await this.listServicePrograms({ id: app.program_id })
+    const program = programs[0]
+    if (!program) throw new Error("Program not found")
+
+    const existing = await this.listServiceContracts({ application_id: applicationId })
+    if (existing.length > 0) return existing[0]
+
+    const termsSnapshot = {
+      service_category: program.service_category,
+      program_type: program.program_type,
+      pricing_model: program.pricing_model,
+      unit_price_cents:
+        app.proposed_unit_price_cents ?? program.unit_price_cents ?? null,
+      hourly_rate_cents: program.hourly_rate_cents,
+      flat_price_cents: program.flat_price_cents,
+      currency_code: program.currency_code,
+      min_units: program.min_units,
+      max_units: program.max_units,
+      deadline_at: program.deadline_at,
+      acceptance_criteria: program.acceptance_criteria ?? null,
+      deliverable_spec: program.deliverable_spec ?? null,
+      proposed_capacity: app.proposed_capacity,
+      proposed_lead_time_days: app.proposed_lead_time_days,
+      requires_kyc: program.requires_kyc,
+      min_verification_level: program.min_verification_level,
+      snapshot_at: new Date().toISOString(),
+    }
+
+    return (this as any).createServiceContracts({
+      program_id: app.program_id,
+      application_id: applicationId,
+      service_seller_id: app.service_seller_id,
+      vendor_id: program.vendor_id,
+      status: ServiceContractStatus.ACTIVE,
+      effective_from: new Date(),
+      effective_until: program.deadline_at ?? program.ends_at ?? null,
+      terms_snapshot: termsSnapshot,
+    })
+  }
+
+  async attachEscrowToContract(args: {
+    contractId: string
+    escrowLedgerEntryId: string
+    escrowAmountCents: number
+  }): Promise<any> {
+    return (this as any).updateServiceContracts({
+      id: args.contractId,
+      escrow_ledger_entry_id: args.escrowLedgerEntryId,
+      escrow_amount_cents: args.escrowAmountCents,
+    })
+  }
+
+  async markContractInProgress(contractId: string): Promise<any> {
+    return (this as any).updateServiceContracts({
+      id: contractId,
+      status: ServiceContractStatus.IN_PROGRESS,
+    })
+  }
+
+  async markContractDelivered(args: {
+    contractId: string
+    unitsDelivered?: number
+  }): Promise<any> {
+    const updates: Record<string, unknown> = {
+      id: args.contractId,
+      status: ServiceContractStatus.DELIVERED,
+    }
+    if (args.unitsDelivered !== undefined) {
+      const list = await this.listServiceContracts({ id: args.contractId })
+      const c = list[0]
+      if (c) {
+        updates.total_units_delivered = Number(c.total_units_delivered) + args.unitsDelivered
+      }
+    }
+    return (this as any).updateServiceContracts(updates)
+  }
+
+  async markContractAccepted(contractId: string): Promise<any> {
+    return (this as any).updateServiceContracts({
+      id: contractId,
+      status: ServiceContractStatus.ACCEPTED,
+    })
+  }
+
+  async markContractDisputed(contractId: string, reason: string): Promise<any> {
+    return (this as any).updateServiceContracts({
+      id: contractId,
+      status: ServiceContractStatus.DISPUTED,
+      dispute_reason: reason,
+    })
+  }
+
+  async cancelContract(contractId: string): Promise<any> {
+    return (this as any).updateServiceContracts({
+      id: contractId,
+      status: ServiceContractStatus.CANCELED,
+    })
+  }
+
+  async incrementContractPayout(contractId: string, deltaCents: number): Promise<void> {
+    const list = await this.listServiceContracts({ id: contractId })
+    const c = list[0]
+    if (!c) return
+    await (this as any).updateServiceContracts({
+      id: contractId,
+      total_paid_cents: Number(c.total_paid_cents) + Math.max(0, deltaCents),
+    })
+  }
+}
+
+export default ServiceProgramService

--- a/backend/src/modules/work-verification/index.ts
+++ b/backend/src/modules/work-verification/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import WorkVerificationService from "./service"
+
+export const WORK_VERIFICATION_MODULE = "workVerification"
+
+export default Module(WORK_VERIFICATION_MODULE, {
+  service: WorkVerificationService,
+})
+
+export * from "./models"
+export type { WorkVerificationService }

--- a/backend/src/modules/work-verification/migrations/Migration20260801CreateWorkVerification.ts
+++ b/backend/src/modules/work-verification/migrations/Migration20260801CreateWorkVerification.ts
@@ -1,0 +1,67 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260801CreateWorkVerification extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "proof_artifact_kind_enum" AS ENUM (
+          'photo', 'video', 'document', 'shipping_label', 'tracking_event',
+          'iot_sensor_log', 'signed_manifest', 'third_party_attestation',
+          'onchain_receipt'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "proof_verification_status_enum" AS ENUM (
+          'unverified', 'auto_verified', 'manually_verified',
+          'disputed', 'rejected'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "proof_context_type_enum" AS ENUM (
+          'service_contract', 'service_milestone', 'order_subcontract',
+          'creator_post', 'harvest_batch', 'pick_pack_batch'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "proof_artifact" (
+        "id" TEXT NOT NULL,
+        "owner_seller_id" TEXT NOT NULL,
+        "context_type" proof_context_type_enum NOT NULL,
+        "context_id" TEXT NOT NULL,
+        "context_secondary_id" TEXT NULL,
+        "kind" proof_artifact_kind_enum NOT NULL,
+        "storage_url" TEXT NULL,
+        "storage_provider" TEXT NULL,
+        "sha256" TEXT NULL,
+        "captured_at" TIMESTAMPTZ NULL,
+        "signature_envelope" JSONB NULL,
+        "verification_status" proof_verification_status_enum NOT NULL DEFAULT 'unverified',
+        "verification_method" TEXT NULL,
+        "verifier_id" TEXT NULL,
+        "verified_at" TIMESTAMPTZ NULL,
+        "rejection_reason" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "proof_artifact_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_proof_artifact_owner" ON "proof_artifact" ("owner_seller_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_proof_artifact_context" ON "proof_artifact" ("context_type", "context_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_proof_artifact_status" ON "proof_artifact" ("verification_status");`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "proof_artifact" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "proof_context_type_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "proof_verification_status_enum" CASCADE;')
+    this.addSql('DROP TYPE IF EXISTS "proof_artifact_kind_enum" CASCADE;')
+  }
+}

--- a/backend/src/modules/work-verification/models/index.ts
+++ b/backend/src/modules/work-verification/models/index.ts
@@ -1,0 +1,7 @@
+export { default as ProofArtifact } from "./proof-artifact"
+export {
+  ProofArtifactKind,
+  ProofVerificationStatus,
+  ProofVerificationMethod,
+  ProofContextType,
+} from "./proof-artifact"

--- a/backend/src/modules/work-verification/models/proof-artifact.ts
+++ b/backend/src/modules/work-verification/models/proof-artifact.ts
@@ -1,0 +1,89 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum ProofArtifactKind {
+  PHOTO = "photo",
+  VIDEO = "video",
+  DOCUMENT = "document",
+  SHIPPING_LABEL = "shipping_label",
+  TRACKING_EVENT = "tracking_event",
+  IOT_SENSOR_LOG = "iot_sensor_log",
+  SIGNED_MANIFEST = "signed_manifest",
+  THIRD_PARTY_ATTESTATION = "third_party_attestation",
+  ONCHAIN_RECEIPT = "onchain_receipt",
+}
+
+export enum ProofVerificationStatus {
+  UNVERIFIED = "unverified",
+  AUTO_VERIFIED = "auto_verified",
+  MANUALLY_VERIFIED = "manually_verified",
+  DISPUTED = "disputed",
+  REJECTED = "rejected",
+}
+
+export enum ProofVerificationMethod {
+  SIGNATURE = "signature",
+  CARRIER_WEBHOOK = "carrier_webhook",
+  ADMIN_REVIEW = "admin_review",
+  PEER_ATTESTATION = "peer_attestation",
+  ORACLE = "oracle",
+  CUSTOMER_CONFIRMATION = "customer_confirmation",
+}
+
+export enum ProofContextType {
+  SERVICE_CONTRACT = "service_contract",
+  SERVICE_MILESTONE = "service_milestone",
+  ORDER_SUBCONTRACT = "order_subcontract",
+  CREATOR_POST = "creator_post",
+  HARVEST_BATCH = "harvest_batch",
+  PICK_PACK_BATCH = "pick_pack_batch",
+}
+
+const ProofArtifact = model
+  .define("proof_artifact", {
+    id: model.id().primaryKey(),
+
+    owner_seller_id: model.text(),
+
+    // Polymorphic context: what work this proves.
+    context_type: model.enum(Object.values(ProofContextType)),
+    context_id: model.text(),
+    context_secondary_id: model.text().nullable(), // e.g. milestone id
+
+    kind: model.enum(Object.values(ProofArtifactKind)),
+
+    // Storage references
+    storage_url: model.text().nullable(),
+    storage_provider: model.text().nullable(), // "minio", "s3", etc.
+    sha256: model.text().nullable(),
+    captured_at: model.dateTime().nullable(),
+
+    // Cryptographic envelope (mirrors marketplace-signing schema)
+    signature_envelope: model.json().nullable(),
+
+    // Verification state
+    verification_status: model
+      .enum(Object.values(ProofVerificationStatus))
+      .default(ProofVerificationStatus.UNVERIFIED),
+    verification_method: model.text().nullable(),
+    verifier_id: model.text().nullable(),
+    verified_at: model.dateTime().nullable(),
+    rejection_reason: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["owner_seller_id"],
+      name: "IDX_proof_artifact_owner",
+    },
+    {
+      on: ["context_type", "context_id"],
+      name: "IDX_proof_artifact_context",
+    },
+    {
+      on: ["verification_status"],
+      name: "IDX_proof_artifact_status",
+    },
+  ])
+
+export default ProofArtifact

--- a/backend/src/modules/work-verification/service.ts
+++ b/backend/src/modules/work-verification/service.ts
@@ -1,0 +1,137 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { createHash } from "crypto"
+import ProofArtifact, {
+  ProofArtifactKind,
+  ProofVerificationStatus,
+  ProofVerificationMethod,
+  ProofContextType,
+} from "./models/proof-artifact"
+
+export interface SubmitProofInput {
+  ownerSellerId: string
+  contextType: ProofContextType
+  contextId: string
+  contextSecondaryId?: string | null
+  kind: ProofArtifactKind
+  storageUrl?: string | null
+  storageProvider?: string | null
+  sha256?: string | null
+  capturedAt?: Date | null
+  metadata?: Record<string, unknown> | null
+}
+
+class WorkVerificationService extends MedusaService({ ProofArtifact }) {
+  async submitProof(input: SubmitProofInput): Promise<any> {
+    return (this as any).createProofArtifacts({
+      owner_seller_id: input.ownerSellerId,
+      context_type: input.contextType,
+      context_id: input.contextId,
+      context_secondary_id: input.contextSecondaryId ?? null,
+      kind: input.kind,
+      storage_url: input.storageUrl ?? null,
+      storage_provider: input.storageProvider ?? null,
+      sha256: input.sha256 ?? null,
+      captured_at: input.capturedAt ?? new Date(),
+      metadata: input.metadata ?? null,
+    })
+  }
+
+  /**
+   * Attach a signed bundle to a proof. The envelope shape mirrors
+   * `marketplace-signing.CreatorListingSignatureEnvelope` so the same
+   * verification toolchain works for content bundles AND service work.
+   */
+  async signProof(args: {
+    proofId: string
+    keyId: string
+    manifestHash: string
+    signature: string
+    assetHashes?: Record<string, string>
+  }): Promise<any> {
+    const envelope = {
+      keyId: args.keyId,
+      alg: "ed25519",
+      manifestHash: args.manifestHash,
+      assetHashes: args.assetHashes ?? {},
+      signedAt: new Date().toISOString(),
+      signature: args.signature,
+    }
+    return (this as any).updateProofArtifacts({
+      id: args.proofId,
+      signature_envelope: envelope,
+    })
+  }
+
+  async autoVerify(args: {
+    proofId: string
+    method: ProofVerificationMethod
+    verifierId?: string | null
+  }): Promise<any> {
+    return (this as any).updateProofArtifacts({
+      id: args.proofId,
+      verification_status: ProofVerificationStatus.AUTO_VERIFIED,
+      verification_method: args.method,
+      verifier_id: args.verifierId ?? null,
+      verified_at: new Date(),
+    })
+  }
+
+  async manuallyVerify(args: {
+    proofId: string
+    verifierId: string
+    method?: ProofVerificationMethod
+  }): Promise<any> {
+    return (this as any).updateProofArtifacts({
+      id: args.proofId,
+      verification_status: ProofVerificationStatus.MANUALLY_VERIFIED,
+      verification_method: args.method ?? ProofVerificationMethod.ADMIN_REVIEW,
+      verifier_id: args.verifierId,
+      verified_at: new Date(),
+    })
+  }
+
+  async rejectProof(args: {
+    proofId: string
+    verifierId: string
+    reason: string
+  }): Promise<any> {
+    return (this as any).updateProofArtifacts({
+      id: args.proofId,
+      verification_status: ProofVerificationStatus.REJECTED,
+      verifier_id: args.verifierId,
+      verified_at: new Date(),
+      rejection_reason: args.reason,
+    })
+  }
+
+  async disputeProof(proofId: string, reason: string): Promise<any> {
+    return (this as any).updateProofArtifacts({
+      id: proofId,
+      verification_status: ProofVerificationStatus.DISPUTED,
+      rejection_reason: reason,
+    })
+  }
+
+  async listProofsForContext(
+    contextType: ProofContextType,
+    contextId: string
+  ): Promise<any[]> {
+    return this.listProofArtifacts({
+      context_type: contextType,
+      context_id: contextId,
+    })
+  }
+
+  /**
+   * Compute a deterministic manifest hash for a set of asset hashes. Used
+   * by callers who want to sign a multi-asset proof without uploading a
+   * pre-built manifest file.
+   */
+  static computeManifestHash(assetHashes: Record<string, string>): string {
+    const sorted = Object.keys(assetHashes).sort()
+    const lines = sorted.map((k) => `${k}=${assetHashes[k]}`).join("\n")
+    return createHash("sha256").update(lines).digest("hex")
+  }
+}
+
+export default WorkVerificationService

--- a/backend/src/subscribers/attribute-order-on-placed.ts
+++ b/backend/src/subscribers/attribute-order-on-placed.ts
@@ -1,0 +1,129 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
+import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
+import CreatorAttributionService from "../modules/creator-attribution/service"
+import { CommissionStatus } from "../modules/creator-attribution/models"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
+
+/**
+ * Subscriber: attribute the order to a creator (if applicable) and emit
+ * `creator.commission.earned` webhook. The storefront stamps the visitor's
+ * `_fbm_visitor` cookie value into `order.metadata.fbm_visitor_token` at
+ * cart-completion time, so we read it from there.
+ *
+ * This subscriber transitions the new attribution from `pending` -> `held`
+ * with a hold window (default 7 days) so refunds can short-circuit payout.
+ */
+export default async function attributeOrderOnPlacedSubscriber({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const orderId = data.id
+
+  const attributionService = container.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  let webhooksService: MarketplaceWebhooksService | null = null
+  try {
+    webhooksService = container.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+  } catch {
+    webhooksService = null
+  }
+
+  try {
+    const query = container.resolve("query") as any
+
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: [
+        "id",
+        "subtotal",
+        "total",
+        "currency_code",
+        "customer_id",
+        "metadata",
+        "promotions.code",
+      ],
+      filters: { id: orderId },
+    })
+
+    const order = orders?.[0]
+    if (!order) {
+      return
+    }
+
+    const md = (order.metadata || {}) as Record<string, unknown>
+    const visitorToken = (md.fbm_visitor_token as string) || null
+    const shortCode = (md.fbm_short_code as string) || null
+    const promotions = (order.promotions || []) as Array<{ code?: string | null }>
+    const appliedPromoCodes = promotions.map((p) => p.code).filter((c): c is string => !!c)
+
+    const subtotalCents = Number(order.subtotal ?? order.total ?? 0)
+    if (!Number.isFinite(subtotalCents) || subtotalCents <= 0) {
+      return
+    }
+
+    const attribution = await attributionService.attributeOrder({
+      orderId,
+      customerId: order.customer_id ?? null,
+      visitorToken: visitorToken ?? null,
+      shortCode,
+      appliedPromoCodes,
+      subtotalCents,
+      currencyCode: order.currency_code || "usd",
+    })
+
+    if (!attribution) return
+
+    // Transition pending -> held with the configured window
+    const holdDays = Number(process.env.CREATOR_ATTRIBUTION_DEFAULT_HOLD_DAYS || 7)
+    let attributionAfter = attribution
+    if (attribution.commission_status === CommissionStatus.PENDING) {
+      attributionAfter = await attributionService.holdAttribution(attribution.id, holdDays)
+    }
+
+    // Emit `creator.commission.earned` webhook to both sides if subscribed
+    if (webhooksService) {
+      const payload = {
+        attribution_id: attributionAfter.id,
+        order_id: orderId,
+        creator_seller_id: attributionAfter.creator_seller_id,
+        vendor_id: attributionAfter.vendor_id,
+        program_id: attributionAfter.program_id,
+        deal_id: attributionAfter.deal_id,
+        source: attributionAfter.source,
+        commission_amount_cents: Number(attributionAfter.commission_amount_cents),
+        commission_basis_cents: Number(attributionAfter.commission_basis_cents),
+        currency_code: attributionAfter.currency_code,
+        commission_status: attributionAfter.commission_status,
+        hold_until: attributionAfter.hold_until,
+      }
+      try {
+        await webhooksService.dispatch(
+          "creator.commission.earned",
+          attributionAfter.creator_seller_id,
+          payload
+        )
+        if (attributionAfter.vendor_id) {
+          await webhooksService.dispatch(
+            "creator.commission.earned",
+            attributionAfter.vendor_id,
+            payload
+          )
+        }
+      } catch (err) {
+        console.error("[attribute-order-on-placed] webhook dispatch failed", err)
+      }
+    }
+  } catch (err) {
+    // Never fail the order placement because attribution failed.
+    console.error(`[attribute-order-on-placed] failed for order ${orderId}:`, err)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}

--- a/backend/src/subscribers/hawala-order-payment.ts
+++ b/backend/src/subscribers/hawala-order-payment.ts
@@ -3,6 +3,8 @@ import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
 import { PAYOUT_BREAKDOWN_MODULE } from "../modules/payout-breakdown"
 import PayoutBreakdownService from "../modules/payout-breakdown/service"
+import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
+import type CreatorAttributionService from "../modules/creator-attribution/service"
 
 /**
  * Convert cents (integer) to dollars (decimal)
@@ -108,6 +110,27 @@ export default async function hawalaOrderPaymentSubscriber({
     const platformFeePercent = await payoutService.getEffectivePlatformFee(sellerId)
     const platformFeeAmount = totalAmount * (platformFeePercent / 100)
 
+    // Look up creator attribution (idempotent — created earlier by
+    // attribute-order-on-placed subscriber, but we look it up rather than
+    // depending on subscriber ordering).
+    let creatorCommissionCents = 0
+    let creatorSellerId: string | undefined
+    try {
+      const attributionService = container.resolve<CreatorAttributionService>(
+        CREATOR_ATTRIBUTION_MODULE
+      )
+      const attributions = await attributionService.listOrderAttributions({
+        order_id: orderId,
+      })
+      const attribution = attributions[0]
+      if (attribution) {
+        creatorCommissionCents = Number(attribution.commission_amount_cents) || 0
+        creatorSellerId = attribution.creator_seller_id
+      }
+    } catch (attributionError) {
+      console.warn(`[Hawala] Could not look up creator attribution for order ${orderId}:`, attributionError)
+    }
+
     // Store the breakdown for this order (for transparency reporting)
     try {
       const breakdown = await payoutService.calculateBreakdown({
@@ -115,6 +138,8 @@ export default async function hawalaOrderPaymentSubscriber({
         sellerId,
         orderId,
         currencyCode: order.currency_code,
+        creatorCommissionCents,
+        creatorSellerId,
       })
       await payoutService.storeOrderBreakdown(
         orderId,

--- a/backend/src/subscribers/process-refund-reverses-commission.ts
+++ b/backend/src/subscribers/process-refund-reverses-commission.ts
@@ -1,0 +1,114 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
+import CreatorAttributionService from "../modules/creator-attribution/service"
+import { CommissionStatus } from "../modules/creator-attribution/models"
+import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
+import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
+import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
+
+/**
+ * Subscriber: when an order is canceled or refunded, reverse any creator
+ * commission attached to it.
+ *
+ * - If the attribution is still `held` (commission has not yet been moved
+ *   to creator earnings), simply mark `reversed`.
+ * - If the attribution is `approved` or `paid` (the ledger entry exists),
+ *   create a reversing ledger entry (creator -> vendor) AND mark the
+ *   attribution `reversed`.
+ *
+ * Subscribes to the same events as the existing `hawala-order-refund`
+ * subscriber so the two stay in sync.
+ */
+export default async function processRefundReversesCommission({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const orderId = data.id
+
+  const attributionService = container.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+
+  let webhooksService: MarketplaceWebhooksService | null = null
+  try {
+    webhooksService = container.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+  } catch {
+    webhooksService = null
+  }
+
+  try {
+    const list = await attributionService.listOrderAttributions({ order_id: orderId })
+    const attribution = list[0]
+    if (!attribution) return
+
+    if (
+      attribution.commission_status === CommissionStatus.REVERSED ||
+      attribution.commission_status === CommissionStatus.DISQUALIFIED
+    ) {
+      return
+    }
+
+    const reason = "order_refund_or_cancel"
+    const wasCredited =
+      attribution.commission_status === CommissionStatus.APPROVED ||
+      attribution.commission_status === CommissionStatus.PAID
+
+    if (wasCredited && attribution.vendor_id) {
+      try {
+        const hawalaService = container.resolve<HawalaLedgerModuleService>(
+          HAWALA_LEDGER_MODULE
+        )
+        await hawalaService.reverseCreatorCommission({
+          vendorSellerId: attribution.vendor_id,
+          creatorSellerId: attribution.creator_seller_id,
+          amountCents: Number(attribution.commission_amount_cents),
+          orderId,
+          attributionId: attribution.id,
+          reason,
+          currencyCode: attribution.currency_code,
+        })
+      } catch (err) {
+        console.error(`[refund-reverses-commission] ledger reversal failed for ${attribution.id}:`, err)
+      }
+    }
+
+    const updated = await attributionService.reverseCommission(attribution.id, reason)
+
+    if (webhooksService) {
+      const payload = {
+        attribution_id: attribution.id,
+        order_id: orderId,
+        creator_seller_id: attribution.creator_seller_id,
+        vendor_id: attribution.vendor_id,
+        commission_amount_cents: Number(attribution.commission_amount_cents),
+        reason,
+        commission_status: updated.commission_status,
+      }
+      try {
+        await webhooksService.dispatch(
+          "creator.commission.reversed",
+          attribution.creator_seller_id,
+          payload
+        )
+        if (attribution.vendor_id) {
+          await webhooksService.dispatch(
+            "creator.commission.reversed",
+            attribution.vendor_id,
+            payload
+          )
+        }
+      } catch (err) {
+        console.error("[refund-reverses-commission] webhook dispatch failed", err)
+      }
+    }
+  } catch (err) {
+    console.error(`[refund-reverses-commission] failed for order ${orderId}:`, err)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["order.canceled", "order.refund_created"],
+}

--- a/storefront/next.config.ts
+++ b/storefront/next.config.ts
@@ -17,6 +17,7 @@ const nextConfig: NextConfig = {
   // Security headers
   async headers() {
     return [
+      // Default: deny iframe embedding for the whole site.
       {
         source: "/:path*",
         headers: [
@@ -39,6 +40,39 @@ const nextConfig: NextConfig = {
           {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+      // Creator embeddable widget: explicitly relax frame-ancestors so any
+      // origin can iframe `/creators/[handle]/widget`. Origin allowlisting is
+      // enforced on the backend via the AffiliateLink.allowed_origins field
+      // when the widget redirects back through /r/:shortCode.
+      {
+        source: "/:locale/creators/:handle/widget",
+        headers: [
+          {
+            key: "X-Frame-Options",
+            value: "ALLOWALL",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors *",
+          },
+        ],
+      },
+      // Embed JS bundle: served as a static asset; allow CORS so any site
+      // can <script src="..."> it. The bundle itself is the same origin as
+      // the iframe target so X-Frame-Options doesn't apply.
+      {
+        source: "/embed/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "*",
+          },
+          {
+            key: "Cache-Control",
+            value: "public, max-age=300",
           },
         ],
       },

--- a/storefront/public/embed/fbm-shop.js
+++ b/storefront/public/embed/fbm-shop.js
@@ -1,0 +1,91 @@
+/*!
+ * Free Black Market shoppable embed widget
+ *
+ * Drop into any third-party HTML page:
+ *
+ *   <script src="https://your-storefront/embed/fbm-shop.js"
+ *           data-creator="alex"
+ *           data-locale="us"
+ *           data-deal="deal_..."  (optional)
+ *           data-width="480"     (optional, px)
+ *           data-height="320"    (optional, px)
+ *   ></script>
+ *
+ * Renders an iframe pointing at /[locale]/creators/[handle]/widget on the
+ * storefront origin. The widget itself is a server-rendered Next page; this
+ * bootstrap script just inserts the iframe at the script tag's location.
+ *
+ * No authentication, no cookies set from this script. All attribution
+ * happens via /r/<short_code> redirects on the storefront origin once the
+ * customer clicks through.
+ */
+(function () {
+  "use strict"
+
+  // Find the <script> tag that loaded us so we know where to insert the
+  // iframe and where to read data-* attributes from.
+  var scripts = document.getElementsByTagName("script")
+  var self = null
+  for (var i = scripts.length - 1; i >= 0; i--) {
+    var src = scripts[i].src || ""
+    if (src.indexOf("/embed/fbm-shop.js") !== -1) {
+      self = scripts[i]
+      break
+    }
+  }
+  if (!self) return
+
+  function attr(name, fallback) {
+    var v = self.getAttribute("data-" + name)
+    return v == null || v === "" ? fallback : v
+  }
+
+  var handle = attr("creator", null)
+  if (!handle) {
+    console.warn("[fbm-shop] missing data-creator attribute")
+    return
+  }
+  var locale = attr("locale", "us")
+  var dealId = attr("deal", null)
+  var width = attr("width", "480")
+  var height = attr("height", "320")
+
+  // Storefront origin = origin the script was served from.
+  var srcUrl
+  try {
+    srcUrl = new URL(self.src, window.location.href)
+  } catch (e) {
+    console.warn("[fbm-shop] could not parse script src", e)
+    return
+  }
+  var origin = srcUrl.origin
+
+  var widgetUrl =
+    origin +
+    "/" +
+    encodeURIComponent(locale) +
+    "/creators/" +
+    encodeURIComponent(handle) +
+    "/widget"
+  if (dealId) widgetUrl += "?deal=" + encodeURIComponent(dealId)
+
+  var iframe = document.createElement("iframe")
+  iframe.src = widgetUrl
+  iframe.setAttribute("title", "@" + handle + " — shoppable widget")
+  iframe.setAttribute("loading", "lazy")
+  iframe.setAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation"
+  )
+  iframe.style.border = "0"
+  iframe.style.width = /^\d+$/.test(width) ? width + "px" : width
+  iframe.style.height = /^\d+$/.test(height) ? height + "px" : height
+  iframe.style.maxWidth = "100%"
+  iframe.style.display = "block"
+
+  if (self.parentNode) {
+    self.parentNode.insertBefore(iframe, self.nextSibling)
+  } else {
+    document.body.appendChild(iframe)
+  }
+})()

--- a/storefront/src/app/[locale]/(embed)/creators/[handle]/widget/page.tsx
+++ b/storefront/src/app/[locale]/(embed)/creators/[handle]/widget/page.tsx
@@ -1,0 +1,111 @@
+import { notFound } from "next/navigation"
+import { getCreatorByHandle } from "@/lib/data/creator"
+
+/**
+ * Embeddable creator widget.
+ *
+ * Designed to be iframed into third-party sites (TikTok bio link pages,
+ * blogs, podcasts, Blackout). Rendered without site chrome. The
+ * `frame-ancestors *` header is set on `/[locale]/creators/[handle]/widget`
+ * via `next.config.ts`. Origin allowlisting can be enforced per affiliate
+ * link via `AffiliateLink.allowed_origins`.
+ */
+export default async function CreatorWidgetPage({
+  params,
+}: {
+  params: Promise<{ handle: string; locale: string }>
+}) {
+  const { handle, locale } = await params
+  const creator = await getCreatorByHandle(handle)
+  if (!creator) return notFound()
+
+  return (
+    <div
+      style={{
+        margin: 0,
+        padding: 0,
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+        background: "transparent",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          padding: 16,
+          background: "#fff",
+          color: "#111",
+          borderRadius: 12,
+          border: "1px solid #e5e5e5",
+          maxWidth: 480,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 24,
+              background: "#f3f3f3",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontWeight: 600,
+              fontSize: 18,
+            }}
+          >
+            {creator.handle.slice(0, 2).toUpperCase()}
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <strong style={{ fontSize: 16 }}>@{creator.handle}</strong>
+              {creator.verified ? (
+                <span
+                  style={{
+                    background: "#3b82f6",
+                    color: "#fff",
+                    padding: "2px 6px",
+                    borderRadius: 4,
+                    fontSize: 10,
+                  }}
+                >
+                  Verified
+                </span>
+              ) : null}
+            </div>
+            <div style={{ fontSize: 12, color: "#666" }}>
+              {creator.total_followers.toLocaleString()} followers
+              {creator.niches.length > 0
+                ? ` · ${creator.niches.slice(0, 3).join(", ")}`
+                : ""}
+            </div>
+          </div>
+        </div>
+
+        {creator.bio ? (
+          <div style={{ fontSize: 14, lineHeight: 1.4 }}>{creator.bio}</div>
+        ) : null}
+
+        <a
+          href={`/${locale}/creators/${creator.handle}`}
+          target="_top"
+          style={{
+            display: "block",
+            textAlign: "center",
+            padding: "10px 16px",
+            background: "#111",
+            color: "#fff",
+            textDecoration: "none",
+            borderRadius: 8,
+            fontWeight: 500,
+            fontSize: 14,
+          }}
+        >
+          Shop my picks →
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/storefront/src/app/[locale]/(embed)/layout.tsx
+++ b/storefront/src/app/[locale]/(embed)/layout.tsx
@@ -1,0 +1,13 @@
+/**
+ * Embed-only layout group: strips storefront chrome (Header/Footer/etc.) so
+ * pages under this group render as standalone widgets suitable for being
+ * iframed into third-party sites. Frame-ancestors is relaxed at the
+ * `next.config.ts` headers() level for the matching path.
+ */
+export default function EmbedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/storefront/src/app/[locale]/(main)/creators/[handle]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/creators/[handle]/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { getCreatorByHandle } from "@/lib/data/creator"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ handle: string }>
+}): Promise<Metadata> {
+  const { handle } = await params
+  const creator = await getCreatorByHandle(handle)
+  if (!creator) return { title: "Creator Not Found" }
+  return {
+    title: `@${creator.handle} | Creator on FreeBlackMarket`,
+    description:
+      creator.bio ||
+      `Shop products curated by @${creator.handle} on FreeBlackMarket.`,
+  }
+}
+
+const SOCIAL_LABELS: Record<string, string> = {
+  instagram: "Instagram",
+  tiktok: "TikTok",
+  youtube: "YouTube",
+  twitter: "Twitter",
+  facebook: "Facebook",
+  linkedin: "LinkedIn",
+  pinterest: "Pinterest",
+}
+
+export default async function CreatorPage({
+  params,
+}: {
+  params: Promise<{ handle: string; locale: string }>
+}) {
+  const { handle } = await params
+  const creator = await getCreatorByHandle(handle)
+  if (!creator) return notFound()
+
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-4xl">
+      <header className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <h1 className="text-3xl font-semibold">@{creator.handle}</h1>
+          {creator.verified ? (
+            <span className="inline-block bg-blue-500 text-white text-xs px-2 py-1 rounded">
+              Verified
+            </span>
+          ) : null}
+        </div>
+        {creator.bio ? <p className="text-gray-700 mb-4">{creator.bio}</p> : null}
+        <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+          <span>
+            <strong>{creator.total_followers.toLocaleString()}</strong>{" "}
+            followers
+          </span>
+          {creator.niches.length > 0 ? (
+            <span>
+              {creator.niches.map((n) => (
+                <span
+                  key={n}
+                  className="inline-block bg-gray-100 px-2 py-1 rounded mr-1"
+                >
+                  {n}
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </div>
+        {creator.social_links ? (
+          <div className="flex gap-4 mt-4">
+            {Object.entries(creator.social_links)
+              .filter(([_, v]) => !!v)
+              .map(([k, v]) => (
+                <a
+                  key={k}
+                  href={v as string}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {SOCIAL_LABELS[k] ?? k}
+                </a>
+              ))}
+          </div>
+        ) : null}
+      </header>
+
+      <section className="border-t border-gray-200 pt-6">
+        <h2 className="text-xl font-medium mb-4">Shop my picks</h2>
+        <p className="text-gray-500 italic">
+          Featured products coming soon. Follow this creator to see their
+          shoppable content as it goes live.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/storefront/src/lib/data/creator.ts
+++ b/storefront/src/lib/data/creator.ts
@@ -1,0 +1,32 @@
+import { sdk } from "../config"
+
+export interface CreatorProfile {
+  seller_id: string
+  handle: string
+  bio: string | null
+  niches: string[]
+  total_followers: number
+  audience_geo: Record<string, number> | null
+  social_links: Record<string, string> | null
+  verified: boolean
+  featured: boolean
+  rating: number | null
+  review_count: number
+}
+
+/**
+ * Fetch a creator's public profile by handle. Returns null if not found.
+ *
+ * Hits the marketplace public API at `/v1/marketplace/creators/:handle`
+ * (no auth, only verified creator-vendor-type sellers are returned).
+ */
+export const getCreatorByHandle = async (
+  handle: string
+): Promise<CreatorProfile | null> => {
+  return sdk.client
+    .fetch<{ creator: CreatorProfile }>(`/v1/marketplace/creators/${handle}`, {
+      cache: "no-cache",
+    })
+    .then(({ creator }) => creator ?? null)
+    .catch(() => null)
+}

--- a/storefront/src/middleware.ts
+++ b/storefront/src/middleware.ts
@@ -98,6 +98,38 @@ async function getCountryCode(
   }
 }
 
+/**
+ * Apply creator-attribution cookies (visitor token + affiliate code) to the
+ * given response. Idempotent: existing visitor cookies are reused; the
+ * affiliate cookie is only refreshed when `?fbm_ref=<code>` is present.
+ */
+function applyAttributionCookies(request: NextRequest, response: NextResponse) {
+  const VISITOR_COOKIE = "_fbm_visitor"
+  const AFF_COOKIE = "_fbm_aff"
+  const COOKIE_MAX_AGE_DAYS = 90
+  const AFF_MAX_AGE_DAYS =
+    parseInt(process.env.NEXT_PUBLIC_CREATOR_ATTRIBUTION_DEFAULT_COOKIE_DAYS || "7", 10) || 7
+
+  // Visitor cookie: ensure one exists and is 90 days fresh.
+  if (!request.cookies.get(VISITOR_COOKIE)) {
+    response.cookies.set(VISITOR_COOKIE, crypto.randomUUID(), {
+      maxAge: COOKIE_MAX_AGE_DAYS * 24 * 60 * 60,
+      sameSite: "lax",
+      path: "/",
+    })
+  }
+
+  // Affiliate cookie: pin if `?fbm_ref=<short_code>` present in the URL.
+  const fbmRef = request.nextUrl.searchParams.get("fbm_ref")
+  if (fbmRef) {
+    response.cookies.set(AFF_COOKIE, `${fbmRef}.${Date.now()}`, {
+      maxAge: AFF_MAX_AGE_DAYS * 24 * 60 * 60,
+      sameSite: "lax",
+      path: "/",
+    })
+  }
+}
+
 export async function middleware(request: NextRequest) {
   // Short-circuit static assets
   if (request.nextUrl.pathname.includes(".")) {
@@ -108,9 +140,13 @@ export async function middleware(request: NextRequest) {
   const urlSegment = request.nextUrl.pathname.split("/")[1]
   const looksLikeLocale = /^[a-z]{2}$/i.test(urlSegment || "")
 
-  // Fast path: URL already has a locale segment and cache cookie exists
+  // Fast path: URL already has a locale segment and cache cookie exists.
+  // Still apply creator attribution cookies so /r/* redirects through the
+  // backend redirector or any direct ?fbm_ref= param keeps attributing.
   if (looksLikeLocale && cacheIdCookie) {
-    return NextResponse.next()
+    const fastResponse = NextResponse.next()
+    applyAttributionCookies(request, fastResponse)
+    return fastResponse
   }
 
   let response = NextResponse.next()
@@ -122,6 +158,8 @@ export async function middleware(request: NextRequest) {
       maxAge: 60 * 60 * 24,
     })
   }
+
+  applyAttributionCookies(request, response)
 
   const regionMap = await getRegionMap(cacheId)
   if (!regionMap.size) {

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -97,6 +97,14 @@ function getVendorNavigationConfig({
       // Always visible
     },
     {
+      icon: <Star />,
+      label: "Creator Studio",
+      to: "/creator-studio",
+      // Visible to all sellers; the page itself surfaces only the creator's
+      // own attributions and links so non-creator vendors will see empty
+      // panels until they opt in by setting vendor_type=creator.
+    },
+    {
       icon: <ShoppingCart />,
       label: t("orders.domain"),
       to: "/orders",

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -111,6 +111,14 @@ function getVendorNavigationConfig({
       showFor: (_, type) => type !== "creator",
     },
     {
+      icon: <SquaresPlus />,
+      label: "Services",
+      to: "/services",
+      // Visible to all sellers — both buyers (who post bounties / subcontract
+      // order line items) and service providers (who claim bounties and
+      // submit proofs of work) use this surface.
+    },
+    {
       icon: <ShoppingCart />,
       label: t("orders.domain"),
       to: "/orders",

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -105,6 +105,12 @@ function getVendorNavigationConfig({
       // panels until they opt in by setting vendor_type=creator.
     },
     {
+      icon: <Star />,
+      label: "Creator Programs",
+      to: "/programs",
+      showFor: (_, type) => type !== "creator",
+    },
+    {
       icon: <ShoppingCart />,
       label: t("orders.domain"),
       to: "/orders",

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -86,6 +86,14 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/programs"),
           },
           {
+            path: "services",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Services",
+            },
+            lazy: () => import("../../routes/services"),
+          },
+          {
             path: "/requests",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -70,6 +70,14 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/sales-report"),
           },
           {
+            path: "creator-studio",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Creator Studio",
+            },
+            lazy: () => import("../../routes/creator-studio"),
+          },
+          {
             path: "/requests",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -78,6 +78,14 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/creator-studio"),
           },
           {
+            path: "programs",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Creator Programs",
+            },
+            lazy: () => import("../../routes/programs"),
+          },
+          {
             path: "/requests",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/routes/creator-studio/creator-studio.tsx
+++ b/vendor-panel/src/routes/creator-studio/creator-studio.tsx
@@ -43,6 +43,41 @@ interface Attribution {
   hold_until: string | null
 }
 
+interface OpenProgram {
+  id: string
+  vendor_id: string
+  title: string
+  program_type: string
+  commission_percent: number | null
+  commission_flat_cents: number | null
+  sponsorship_flat_cents: number | null
+  pool_total_cents: number | null
+  cookie_window_days: number
+  currency_code: string
+  requires_kyc: boolean
+  min_followers: number | null
+  ends_at: string | null
+}
+
+interface MyApplication {
+  id: string
+  program_id: string
+  status: string
+  pitch: string | null
+  decided_at: string | null
+  decision_reason: string | null
+}
+
+interface MyDeal {
+  id: string
+  program_id: string
+  status: string
+  total_attributed_cents: number
+  total_paid_out_cents: number
+  default_affiliate_link_id: string | null
+  effective_until: string | null
+}
+
 const formatCents = (cents: number, currency = "USD") =>
   new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -75,10 +110,16 @@ async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export const CreatorStudioPage = () => {
-  const [tab, setTab] = useState<"dashboard" | "links" | "earnings">("dashboard")
+  const [tab, setTab] = useState<
+    "dashboard" | "links" | "earnings" | "programs" | "deals"
+  >("dashboard")
   const [links, setLinks] = useState<AffiliateLink[]>([])
   const [rollup, setRollup] = useState<Rollup | null>(null)
   const [attributions, setAttributions] = useState<Attribution[]>([])
+  const [openPrograms, setOpenPrograms] = useState<OpenProgram[]>([])
+  const [myApplications, setMyApplications] = useState<MyApplication[]>([])
+  const [myDeals, setMyDeals] = useState<MyDeal[]>([])
+  const [pitchByProgram, setPitchByProgram] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
 
   // Generate-link form
@@ -89,21 +130,64 @@ export const CreatorStudioPage = () => {
   const reload = async () => {
     setLoading(true)
     try {
-      const [{ links: l }, { rollup: r, attributions: a }] = await Promise.all([
+      const [
+        { links: l },
+        { rollup: r, attributions: a },
+        { open, applications, deals },
+      ] = await Promise.all([
         authedFetch<{ links: AffiliateLink[] }>("/v1/seller/creator/links?limit=50"),
         authedFetch<{ rollup: Rollup; attributions: Attribution[] }>(
           "/v1/seller/creator/earnings?limit=20"
         ),
+        authedFetch<{
+          open: OpenProgram[]
+          applications: MyApplication[]
+          deals: MyDeal[]
+        }>("/v1/seller/creator/programs"),
       ])
       setLinks(l)
       setRollup(r)
       setAttributions(a)
+      setOpenPrograms(open)
+      setMyApplications(applications)
+      setMyDeals(deals)
     } catch (err) {
       toast.error("Failed to load creator studio data", {
         description: (err as Error).message,
       })
     } finally {
       setLoading(false)
+    }
+  }
+
+  const applyToProgram = async (programId: string) => {
+    const pitch = pitchByProgram[programId]?.trim() || null
+    try {
+      await authedFetch(`/v1/seller/creator/programs/${programId}/apply`, {
+        method: "POST",
+        body: JSON.stringify({ pitch }),
+      })
+      toast.success("Application submitted")
+      setPitchByProgram((m) => {
+        const next = { ...m }
+        delete next[programId]
+        return next
+      })
+      await reload()
+    } catch (err) {
+      toast.error("Apply failed", { description: (err as Error).message })
+    }
+  }
+
+  const withdrawApplication = async (programId: string) => {
+    try {
+      await authedFetch(`/v1/seller/creator/programs/${programId}/apply`, {
+        method: "DELETE",
+      })
+      toast.success("Application withdrawn")
+      await reload()
+    } catch (err) {
+      toast.error("Withdraw failed", { description: (err as Error).message })
     }
   }
 
@@ -147,15 +231,29 @@ export const CreatorStudioPage = () => {
 
   return (
     <Container className="p-6 flex flex-col gap-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <Heading level="h1">Creator Studio</Heading>
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-wrap">
           <Button
             variant={tab === "dashboard" ? "primary" : "secondary"}
             size="small"
             onClick={() => setTab("dashboard")}
           >
             Dashboard
+          </Button>
+          <Button
+            variant={tab === "programs" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("programs")}
+          >
+            Find programs ({openPrograms.length})
+          </Button>
+          <Button
+            variant={tab === "deals" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("deals")}
+          >
+            Deals ({myDeals.length})
           </Button>
           <Button
             variant={tab === "links" ? "primary" : "secondary"}
@@ -295,6 +393,135 @@ export const CreatorStudioPage = () => {
               </table>
             )}
           </div>
+        </div>
+      )}
+
+      {tab === "programs" && (
+        <div className="flex flex-col gap-3">
+          {openPrograms.length === 0 ? (
+            <Text className="text-ui-fg-subtle italic">
+              No open programs available right now. Check back later.
+            </Text>
+          ) : null}
+          {openPrograms.map((p) => {
+            const myApp = myApplications.find((a) => a.program_id === p.id)
+            return (
+              <div
+                key={p.id}
+                className="border border-ui-border-base rounded-md p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1">
+                    <Heading level="h3">{p.title}</Heading>
+                    <Text className="text-xs text-ui-fg-subtle">
+                      {p.program_type} ·{" "}
+                      {p.commission_percent
+                        ? `${p.commission_percent}% commission`
+                        : p.sponsorship_flat_cents
+                        ? `flat ${formatCents(p.sponsorship_flat_cents)}`
+                        : p.pool_total_cents
+                        ? `pool ${formatCents(p.pool_total_cents)}`
+                        : "—"}{" "}
+                      · {p.cookie_window_days}d cookie
+                      {p.requires_kyc ? " · KYC required" : ""}
+                      {p.min_followers
+                        ? ` · ${p.min_followers.toLocaleString()}+ followers`
+                        : ""}
+                      {p.ends_at ? ` · ends ${formatDate(p.ends_at)}` : ""}
+                    </Text>
+                  </div>
+                </div>
+                {myApp ? (
+                  <div className="mt-2 flex items-center justify-between">
+                    <Text className="text-sm">
+                      Application status:{" "}
+                      <strong>{myApp.status}</strong>
+                      {myApp.decision_reason ? ` — ${myApp.decision_reason}` : ""}
+                    </Text>
+                    {myApp.status === "pending" ? (
+                      <Button
+                        size="small"
+                        variant="secondary"
+                        onClick={() => void withdrawApplication(p.id)}
+                      >
+                        Withdraw
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : (
+                  <div className="mt-3 flex flex-col gap-2">
+                    <Textarea
+                      rows={2}
+                      placeholder="Why this fits your audience (optional pitch)"
+                      value={pitchByProgram[p.id] ?? ""}
+                      onChange={(e) =>
+                        setPitchByProgram((m) => ({
+                          ...m,
+                          [p.id]: e.target.value,
+                        }))
+                      }
+                    />
+                    <div>
+                      <Button
+                        size="small"
+                        onClick={() => void applyToProgram(p.id)}
+                      >
+                        Apply
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {tab === "deals" && (
+        <div className="border border-ui-border-base rounded-md p-4">
+          <Heading level="h2" className="mb-3">
+            My deals
+          </Heading>
+          {myDeals.length === 0 ? (
+            <Text className="text-ui-fg-subtle italic">
+              No active deals. Apply to a program to open one.
+            </Text>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-ui-fg-subtle border-b">
+                  <th className="py-2">Deal</th>
+                  <th className="py-2">Program</th>
+                  <th className="py-2">Status</th>
+                  <th className="py-2 text-right">Attributed</th>
+                  <th className="py-2 text-right">Paid out</th>
+                  <th className="py-2">Default link</th>
+                  <th className="py-2">Until</th>
+                </tr>
+              </thead>
+              <tbody>
+                {myDeals.map((d) => (
+                  <tr key={d.id} className="border-b">
+                    <td className="py-2 font-mono text-xs">{d.id}</td>
+                    <td className="py-2 font-mono text-xs">{d.program_id}</td>
+                    <td className="py-2">{d.status}</td>
+                    <td className="py-2 text-right">
+                      {formatCents(Number(d.total_attributed_cents))}
+                    </td>
+                    <td className="py-2 text-right">
+                      {formatCents(Number(d.total_paid_out_cents))}
+                    </td>
+                    <td className="py-2 font-mono text-xs">
+                      {d.default_affiliate_link_id ?? "—"}
+                    </td>
+                    <td className="py-2">
+                      {d.effective_until ? formatDate(d.effective_until) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       )}
 

--- a/vendor-panel/src/routes/creator-studio/creator-studio.tsx
+++ b/vendor-panel/src/routes/creator-studio/creator-studio.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useState } from "react"
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+interface AffiliateLink {
+  id: string
+  short_code: string
+  destination_path: string
+  utm_medium: string | null
+  utm_campaign: string | null
+  click_count: number
+  attributed_order_count: number
+  status: string
+  created_at: string
+}
+
+interface Rollup {
+  pending_cents: number
+  held_cents: number
+  approved_cents: number
+  paid_cents: number
+  reversed_cents: number
+  disqualified_cents: number
+  total_orders: number
+}
+
+interface Attribution {
+  id: string
+  order_id: string
+  source: string
+  commission_amount_cents: number
+  commission_status: string
+  attribution_decided_at: string
+  hold_until: string | null
+}
+
+const formatCents = (cents: number, currency = "USD") =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(cents / 100)
+
+const formatDate = (s: string) =>
+  new Date(s).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+
+async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const CreatorStudioPage = () => {
+  const [tab, setTab] = useState<"dashboard" | "links" | "earnings">("dashboard")
+  const [links, setLinks] = useState<AffiliateLink[]>([])
+  const [rollup, setRollup] = useState<Rollup | null>(null)
+  const [attributions, setAttributions] = useState<Attribution[]>([])
+  const [loading, setLoading] = useState(false)
+
+  // Generate-link form
+  const [productId, setProductId] = useState("")
+  const [utmMedium, setUtmMedium] = useState("")
+  const [utmCampaign, setUtmCampaign] = useState("")
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const [{ links: l }, { rollup: r, attributions: a }] = await Promise.all([
+        authedFetch<{ links: AffiliateLink[] }>("/v1/seller/creator/links?limit=50"),
+        authedFetch<{ rollup: Rollup; attributions: Attribution[] }>(
+          "/v1/seller/creator/earnings?limit=20"
+        ),
+      ])
+      setLinks(l)
+      setRollup(r)
+      setAttributions(a)
+    } catch (err) {
+      toast.error("Failed to load creator studio data", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+  }, [])
+
+  const handleGenerate = async () => {
+    try {
+      const body: Record<string, unknown> = {}
+      if (productId.trim()) body.product_id = productId.trim()
+      if (utmMedium.trim()) body.utm_medium = utmMedium.trim()
+      if (utmCampaign.trim()) body.utm_campaign = utmCampaign.trim()
+      const { link } = await authedFetch<{ link: AffiliateLink }>(
+        "/v1/seller/creator/links",
+        { method: "POST", body: JSON.stringify(body) }
+      )
+      toast.success("Link created", {
+        description: `Code: ${link.short_code}`,
+      })
+      setProductId("")
+      setUtmMedium("")
+      setUtmCampaign("")
+      await reload()
+    } catch (err) {
+      toast.error("Could not create link", {
+        description: (err as Error).message,
+      })
+    }
+  }
+
+  const copyShare = async (link: AffiliateLink) => {
+    const url = `${backendUrl.replace(/\/$/, "")}/r/${link.short_code}`
+    try {
+      await navigator.clipboard.writeText(url)
+      toast.success("Share URL copied to clipboard")
+    } catch {
+      toast.error("Could not copy", { description: url })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Heading level="h1">Creator Studio</Heading>
+        <div className="flex gap-2">
+          <Button
+            variant={tab === "dashboard" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("dashboard")}
+          >
+            Dashboard
+          </Button>
+          <Button
+            variant={tab === "links" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("links")}
+          >
+            Links
+          </Button>
+          <Button
+            variant={tab === "earnings" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("earnings")}
+          >
+            Earnings
+          </Button>
+        </div>
+      </div>
+
+      {tab === "dashboard" && (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <KpiCard label="Pending" value={formatCents(rollup?.pending_cents ?? 0)} />
+          <KpiCard label="Held" value={formatCents(rollup?.held_cents ?? 0)} />
+          <KpiCard
+            label="Approved (unpaid)"
+            value={formatCents(rollup?.approved_cents ?? 0)}
+          />
+          <KpiCard label="Paid" value={formatCents(rollup?.paid_cents ?? 0)} />
+          <KpiCard
+            label="Total attributed orders"
+            value={String(rollup?.total_orders ?? 0)}
+          />
+          <KpiCard
+            label="Active links"
+            value={String(
+              links.filter((l) => l.status === "active").length
+            )}
+          />
+          <KpiCard
+            label="Total clicks"
+            value={String(
+              links.reduce((sum, l) => sum + Number(l.click_count), 0)
+            )}
+          />
+          <KpiCard
+            label="Reversed"
+            value={formatCents(rollup?.reversed_cents ?? 0)}
+          />
+        </div>
+      )}
+
+      {tab === "links" && (
+        <div className="flex flex-col gap-4">
+          <div className="border border-ui-border-base rounded-md p-4 flex flex-col gap-3">
+            <Heading level="h2">Generate a new link</Heading>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <Label htmlFor="product_id">Product ID (optional)</Label>
+                <Input
+                  id="product_id"
+                  value={productId}
+                  onChange={(e) => setProductId(e.target.value)}
+                  placeholder="prod_..."
+                />
+              </div>
+              <div>
+                <Label htmlFor="utm_medium">UTM medium</Label>
+                <Input
+                  id="utm_medium"
+                  value={utmMedium}
+                  onChange={(e) => setUtmMedium(e.target.value)}
+                  placeholder="tiktok, instagram, blog"
+                />
+              </div>
+              <div>
+                <Label htmlFor="utm_campaign">UTM campaign</Label>
+                <Input
+                  id="utm_campaign"
+                  value={utmCampaign}
+                  onChange={(e) => setUtmCampaign(e.target.value)}
+                  placeholder="spring-launch"
+                />
+              </div>
+            </div>
+            <div>
+              <Button onClick={handleGenerate} disabled={loading}>
+                Create link
+              </Button>
+            </div>
+          </div>
+
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              My links
+            </Heading>
+            {links.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">
+                No links yet. Generate one above to get started.
+              </Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Code</th>
+                    <th className="py-2">Destination</th>
+                    <th className="py-2">UTM</th>
+                    <th className="py-2 text-right">Clicks</th>
+                    <th className="py-2 text-right">Attributed orders</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {links.map((l) => (
+                    <tr key={l.id} className="border-b">
+                      <td className="py-2 font-mono">{l.short_code}</td>
+                      <td className="py-2">{l.destination_path}</td>
+                      <td className="py-2 text-ui-fg-subtle">
+                        {[l.utm_medium, l.utm_campaign].filter(Boolean).join(" / ")}
+                      </td>
+                      <td className="py-2 text-right">{Number(l.click_count)}</td>
+                      <td className="py-2 text-right">
+                        {Number(l.attributed_order_count)}
+                      </td>
+                      <td className="py-2">{l.status}</td>
+                      <td className="py-2 text-right">
+                        <Button
+                          size="small"
+                          variant="secondary"
+                          onClick={() => copyShare(l)}
+                        >
+                          Copy share URL
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === "earnings" && (
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <KpiCard label="Pending" value={formatCents(rollup?.pending_cents ?? 0)} />
+            <KpiCard label="Held" value={formatCents(rollup?.held_cents ?? 0)} />
+            <KpiCard label="Approved" value={formatCents(rollup?.approved_cents ?? 0)} />
+            <KpiCard label="Paid" value={formatCents(rollup?.paid_cents ?? 0)} />
+            <KpiCard label="Reversed" value={formatCents(rollup?.reversed_cents ?? 0)} />
+            <KpiCard
+              label="Disqualified"
+              value={formatCents(rollup?.disqualified_cents ?? 0)}
+            />
+          </div>
+
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              Recent attributions
+            </Heading>
+            {attributions.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">
+                No attributed orders yet.
+              </Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Order</th>
+                    <th className="py-2">Source</th>
+                    <th className="py-2 text-right">Commission</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2">Decided</th>
+                    <th className="py-2">Hold until</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {attributions.map((a) => (
+                    <tr key={a.id} className="border-b">
+                      <td className="py-2 font-mono">{a.order_id}</td>
+                      <td className="py-2">{a.source}</td>
+                      <td className="py-2 text-right">
+                        {formatCents(Number(a.commission_amount_cents))}
+                      </td>
+                      <td className="py-2">{a.commission_status}</td>
+                      <td className="py-2">
+                        {formatDate(a.attribution_decided_at)}
+                      </td>
+                      <td className="py-2">
+                        {a.hold_until ? formatDate(a.hold_until) : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+const KpiCard = ({ label, value }: { label: string; value: string }) => (
+  <div className="border border-ui-border-base rounded-md p-4">
+    <Text className="text-ui-fg-subtle text-xs uppercase">{label}</Text>
+    <div className="text-2xl font-medium mt-1">{value}</div>
+  </div>
+)

--- a/vendor-panel/src/routes/creator-studio/creator-studio.tsx
+++ b/vendor-panel/src/routes/creator-studio/creator-studio.tsx
@@ -78,6 +78,30 @@ interface MyDeal {
   effective_until: string | null
 }
 
+interface ContentPostRow {
+  id: string
+  platform: string
+  external_post_id: string
+  external_url: string
+  caption: string | null
+  affiliate_link_id: string | null
+  verification_status: string
+  verified_at: string | null
+  qualified: boolean
+  disqualified_reason: string | null
+}
+
+interface PlatformAccountRow {
+  id: string
+  platform: string
+  external_account_id: string
+  handle: string | null
+  follower_count: number
+  status: string
+  inbound_webhook_secret: string | null
+  last_synced_at: string | null
+}
+
 const formatCents = (cents: number, currency = "USD") =>
   new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -111,7 +135,7 @@ async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
 
 export const CreatorStudioPage = () => {
   const [tab, setTab] = useState<
-    "dashboard" | "links" | "earnings" | "programs" | "deals"
+    "dashboard" | "links" | "earnings" | "programs" | "deals" | "posts" | "platforms"
   >("dashboard")
   const [links, setLinks] = useState<AffiliateLink[]>([])
   const [rollup, setRollup] = useState<Rollup | null>(null)
@@ -120,12 +144,28 @@ export const CreatorStudioPage = () => {
   const [myApplications, setMyApplications] = useState<MyApplication[]>([])
   const [myDeals, setMyDeals] = useState<MyDeal[]>([])
   const [pitchByProgram, setPitchByProgram] = useState<Record<string, string>>({})
+  const [posts, setPosts] = useState<ContentPostRow[]>([])
+  const [platformAccounts, setPlatformAccounts] = useState<PlatformAccountRow[]>([])
+  const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
 
   // Generate-link form
   const [productId, setProductId] = useState("")
   const [utmMedium, setUtmMedium] = useState("")
   const [utmCampaign, setUtmCampaign] = useState("")
+
+  // Register-post form
+  const [postPlatform, setPostPlatform] = useState("custom")
+  const [postExternalId, setPostExternalId] = useState("")
+  const [postExternalUrl, setPostExternalUrl] = useState("")
+  const [postAffiliateLinkId, setPostAffiliateLinkId] = useState("")
+  const [postDealId, setPostDealId] = useState("")
+
+  // Connect-account form
+  const [connectPlatform, setConnectPlatform] = useState("custom")
+  const [connectExternalId, setConnectExternalId] = useState("")
+  const [connectHandle, setConnectHandle] = useState("")
+  const [connectFeedUrl, setConnectFeedUrl] = useState("")
 
   const reload = async () => {
     setLoading(true)
@@ -134,6 +174,8 @@ export const CreatorStudioPage = () => {
         { links: l },
         { rollup: r, attributions: a },
         { open, applications, deals },
+        { posts: ps },
+        { accounts, available_platforms },
       ] = await Promise.all([
         authedFetch<{ links: AffiliateLink[] }>("/v1/seller/creator/links?limit=50"),
         authedFetch<{ rollup: Rollup; attributions: Attribution[] }>(
@@ -144,6 +186,11 @@ export const CreatorStudioPage = () => {
           applications: MyApplication[]
           deals: MyDeal[]
         }>("/v1/seller/creator/programs"),
+        authedFetch<{ posts: ContentPostRow[] }>("/v1/seller/creator/posts"),
+        authedFetch<{
+          accounts: PlatformAccountRow[]
+          available_platforms: string[]
+        }>("/v1/seller/creator/platform-accounts"),
       ])
       setLinks(l)
       setRollup(r)
@@ -151,12 +198,106 @@ export const CreatorStudioPage = () => {
       setOpenPrograms(open)
       setMyApplications(applications)
       setMyDeals(deals)
+      setPosts(ps)
+      setPlatformAccounts(accounts)
+      setAvailablePlatforms(available_platforms)
     } catch (err) {
       toast.error("Failed to load creator studio data", {
         description: (err as Error).message,
       })
     } finally {
       setLoading(false)
+    }
+  }
+
+  const registerPost = async () => {
+    if (!postExternalId || !postExternalUrl) {
+      toast.error("External post id and URL required")
+      return
+    }
+    try {
+      const body: Record<string, unknown> = {
+        platform: postPlatform,
+        external_post_id: postExternalId,
+        external_url: postExternalUrl,
+      }
+      if (postAffiliateLinkId.trim()) body.affiliate_link_id = postAffiliateLinkId.trim()
+      if (postDealId.trim()) body.deal_id = postDealId.trim()
+      const { post } = await authedFetch<{ post: ContentPostRow }>(
+        "/v1/seller/creator/posts",
+        { method: "POST", body: JSON.stringify(body) }
+      )
+      toast.success(
+        post.verification_status === "verified"
+          ? "Post registered and auto-verified"
+          : "Post registered (verification pending)"
+      )
+      setPostExternalId("")
+      setPostExternalUrl("")
+      setPostAffiliateLinkId("")
+      setPostDealId("")
+      await reload()
+    } catch (err) {
+      toast.error("Register post failed", {
+        description: (err as Error).message,
+      })
+    }
+  }
+
+  const connectAccount = async () => {
+    if (!connectExternalId.trim()) {
+      toast.error("External account id required")
+      return
+    }
+    try {
+      const body: Record<string, unknown> = {
+        platform: connectPlatform,
+        external_account_id: connectExternalId.trim(),
+        handle: connectHandle.trim() || null,
+      }
+      if (connectPlatform === "rss" && connectFeedUrl.trim()) {
+        body.metadata = { feed_url: connectFeedUrl.trim() }
+      }
+      await authedFetch("/v1/seller/creator/platform-accounts", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+      toast.success("Platform account connected")
+      setConnectExternalId("")
+      setConnectHandle("")
+      setConnectFeedUrl("")
+      await reload()
+    } catch (err) {
+      toast.error("Connect failed", { description: (err as Error).message })
+    }
+  }
+
+  const beginOAuth = async (platform: string) => {
+    try {
+      const redirectUri = `${window.location.origin}/creator-studio?oauth_platform=${platform}`
+      const result = await authedFetch<{ authUrl: string; state: string }>(
+        "/v1/seller/creator/platform-accounts/connect",
+        {
+          method: "POST",
+          body: JSON.stringify({ platform, redirect_uri: redirectUri }),
+        }
+      )
+      window.location.href = result.authUrl
+    } catch (err) {
+      toast.error("OAuth start failed", { description: (err as Error).message })
+    }
+  }
+
+  const revokeAccount = async (id: string) => {
+    if (!window.confirm("Revoke this platform connection?")) return
+    try {
+      await authedFetch(`/v1/seller/creator/platform-accounts/${id}`, {
+        method: "DELETE",
+      })
+      toast.success("Account revoked")
+      await reload()
+    } catch (err) {
+      toast.error("Revoke failed", { description: (err as Error).message })
     }
   }
 
@@ -261,6 +402,20 @@ export const CreatorStudioPage = () => {
             onClick={() => setTab("links")}
           >
             Links
+          </Button>
+          <Button
+            variant={tab === "posts" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("posts")}
+          >
+            Posts ({posts.length})
+          </Button>
+          <Button
+            variant={tab === "platforms" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("platforms")}
+          >
+            Platforms ({platformAccounts.length})
           </Button>
           <Button
             variant={tab === "earnings" ? "primary" : "secondary"}
@@ -522,6 +677,257 @@ export const CreatorStudioPage = () => {
               </tbody>
             </table>
           )}
+        </div>
+      )}
+
+      {tab === "posts" && (
+        <div className="flex flex-col gap-4">
+          <div className="border border-ui-border-base rounded-md p-4 flex flex-col gap-3">
+            <Heading level="h2">Register a post</Heading>
+            <Text className="text-ui-fg-subtle text-xs">
+              Paste the URL of a video, photo, blog post, or podcast episode
+              you've published. If you've connected the matching platform
+              account, ownership is auto-verified.
+            </Text>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <Label htmlFor="post-platform">Platform</Label>
+                <select
+                  id="post-platform"
+                  className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base w-full"
+                  value={postPlatform}
+                  onChange={(e) => setPostPlatform(e.target.value)}
+                >
+                  {availablePlatforms.length === 0 ? (
+                    <option value="custom">custom</option>
+                  ) : (
+                    availablePlatforms.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+              <div>
+                <Label htmlFor="post-id">External post id</Label>
+                <Input
+                  id="post-id"
+                  value={postExternalId}
+                  onChange={(e) => setPostExternalId(e.target.value)}
+                  placeholder="video_12345"
+                />
+              </div>
+              <div>
+                <Label htmlFor="post-url">Public URL</Label>
+                <Input
+                  id="post-url"
+                  value={postExternalUrl}
+                  onChange={(e) => setPostExternalUrl(e.target.value)}
+                  placeholder="https://www.tiktok.com/@me/video/123"
+                />
+              </div>
+              <div>
+                <Label htmlFor="post-link">Affiliate link id (optional)</Label>
+                <Input
+                  id="post-link"
+                  value={postAffiliateLinkId}
+                  onChange={(e) => setPostAffiliateLinkId(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="post-deal">Deal id (optional)</Label>
+                <Input
+                  id="post-deal"
+                  value={postDealId}
+                  onChange={(e) => setPostDealId(e.target.value)}
+                />
+              </div>
+            </div>
+            <div>
+              <Button onClick={registerPost} disabled={loading}>
+                Register post
+              </Button>
+            </div>
+          </div>
+
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              My posts
+            </Heading>
+            {posts.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">
+                No posts registered yet.
+              </Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Platform</th>
+                    <th className="py-2">URL</th>
+                    <th className="py-2">Verification</th>
+                    <th className="py-2">Qualified</th>
+                    <th className="py-2">Verified at</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {posts.map((p) => (
+                    <tr key={p.id} className="border-b">
+                      <td className="py-2">{p.platform}</td>
+                      <td className="py-2">
+                        <a
+                          href={p.external_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 underline truncate block max-w-xs"
+                        >
+                          {p.external_url}
+                        </a>
+                      </td>
+                      <td className="py-2">{p.verification_status}</td>
+                      <td className="py-2">{p.qualified ? "Yes" : "No"}</td>
+                      <td className="py-2">{formatDate(p.verified_at)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === "platforms" && (
+        <div className="flex flex-col gap-4">
+          <div className="border border-ui-border-base rounded-md p-4 flex flex-col gap-3">
+            <Heading level="h2">Connect a platform</Heading>
+            <Text className="text-ui-fg-subtle text-xs">
+              For TikTok / Instagram / YouTube / Twitch / Blackout, click
+              the OAuth button below. For RSS blogs and custom webhook
+              integrations, fill in the form.
+            </Text>
+            <div className="flex flex-wrap gap-2">
+              {availablePlatforms
+                .filter((p) =>
+                  ["tiktok", "instagram", "youtube", "twitch", "blackout"].includes(p)
+                )
+                .map((p) => (
+                  <Button
+                    key={p}
+                    size="small"
+                    variant="secondary"
+                    onClick={() => void beginOAuth(p)}
+                  >
+                    Connect {p}
+                  </Button>
+                ))}
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mt-3">
+              <div>
+                <Label htmlFor="conn-platform">Non-OAuth platform</Label>
+                <select
+                  id="conn-platform"
+                  className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base w-full"
+                  value={connectPlatform}
+                  onChange={(e) => setConnectPlatform(e.target.value)}
+                >
+                  <option value="rss">rss</option>
+                  <option value="custom">custom (webhook)</option>
+                  <option value="podcast">podcast</option>
+                </select>
+              </div>
+              <div>
+                <Label htmlFor="conn-id">Account id</Label>
+                <Input
+                  id="conn-id"
+                  value={connectExternalId}
+                  onChange={(e) => setConnectExternalId(e.target.value)}
+                  placeholder="my-blog or username"
+                />
+              </div>
+              <div>
+                <Label htmlFor="conn-handle">Handle (optional)</Label>
+                <Input
+                  id="conn-handle"
+                  value={connectHandle}
+                  onChange={(e) => setConnectHandle(e.target.value)}
+                />
+              </div>
+              {connectPlatform === "rss" && (
+                <div>
+                  <Label htmlFor="conn-feed">RSS feed URL</Label>
+                  <Input
+                    id="conn-feed"
+                    value={connectFeedUrl}
+                    onChange={(e) => setConnectFeedUrl(e.target.value)}
+                    placeholder="https://blog.example.com/feed.xml"
+                  />
+                </div>
+              )}
+            </div>
+            <div>
+              <Button onClick={connectAccount} disabled={loading}>
+                Connect
+              </Button>
+            </div>
+          </div>
+
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              Connected platforms
+            </Heading>
+            {platformAccounts.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">
+                No platforms connected yet.
+              </Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Platform</th>
+                    <th className="py-2">Account</th>
+                    <th className="py-2">Handle</th>
+                    <th className="py-2 text-right">Followers</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2">Webhook secret</th>
+                    <th className="py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {platformAccounts.map((a) => (
+                    <tr key={a.id} className="border-b">
+                      <td className="py-2">{a.platform}</td>
+                      <td className="py-2 font-mono text-xs">
+                        {a.external_account_id}
+                      </td>
+                      <td className="py-2">{a.handle ?? "—"}</td>
+                      <td className="py-2 text-right">
+                        {Number(a.follower_count).toLocaleString()}
+                      </td>
+                      <td className="py-2">{a.status}</td>
+                      <td className="py-2 font-mono text-xs">
+                        {a.inbound_webhook_secret ? (
+                          <span className="text-ui-fg-subtle">
+                            {a.inbound_webhook_secret.slice(0, 12)}…
+                          </span>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="py-2 text-right">
+                        <Button
+                          size="small"
+                          variant="danger"
+                          onClick={() => void revokeAccount(a.id)}
+                        >
+                          Revoke
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
         </div>
       )}
 

--- a/vendor-panel/src/routes/creator-studio/index.ts
+++ b/vendor-panel/src/routes/creator-studio/index.ts
@@ -1,0 +1,1 @@
+export { CreatorStudioPage as Component } from "./creator-studio"

--- a/vendor-panel/src/routes/programs/index.ts
+++ b/vendor-panel/src/routes/programs/index.ts
@@ -1,0 +1,1 @@
+export { ProgramsPage as Component } from "./programs"

--- a/vendor-panel/src/routes/programs/programs.tsx
+++ b/vendor-panel/src/routes/programs/programs.tsx
@@ -1,0 +1,629 @@
+import { useEffect, useMemo, useState } from "react"
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+type ProgramType =
+  | "affiliate_open"
+  | "affiliate_invite"
+  | "sponsored_brief"
+  | "commission_boost"
+  | "engagement_pool"
+
+interface Program {
+  id: string
+  vendor_id: string
+  title: string
+  slug: string
+  description: string | null
+  brief_markdown: string | null
+  program_type: ProgramType
+  status: string
+  commission_percent: number | null
+  commission_flat_cents: number | null
+  sponsorship_flat_cents: number | null
+  pool_total_cents: number | null
+  pool_period: string | null
+  cookie_window_days: number
+  hold_days: number
+  currency_code: string
+  starts_at: string | null
+  ends_at: string | null
+  budget_cap_cents: number | null
+  budget_spent_cents: number
+  requires_kyc: boolean
+  min_verification_level: string | null
+  product_ids: string[] | null
+  min_followers: number | null
+  created_at: string
+}
+
+interface Application {
+  id: string
+  program_id: string
+  creator_seller_id: string
+  pitch: string | null
+  proposed_platforms: string[] | null
+  follower_snapshot: Record<string, number> | null
+  status: string
+  decided_at: string | null
+  decision_reason: string | null
+  created_at: string
+}
+
+interface Deal {
+  id: string
+  program_id: string
+  application_id: string
+  creator_seller_id: string
+  status: string
+  effective_from: string
+  effective_until: string | null
+  total_attributed_cents: number
+  total_paid_out_cents: number
+  default_affiliate_link_id: string | null
+  violation_reason: string | null
+}
+
+const formatCents = (cents: number | null | undefined, currency = "USD") =>
+  cents == null
+    ? "—"
+    : new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+        Number(cents) / 100
+      )
+
+const formatDate = (s: string | null) =>
+  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—"
+
+async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const ProgramsPage = () => {
+  const [programs, setPrograms] = useState<Program[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [applications, setApplications] = useState<Application[]>([])
+  const [deals, setDeals] = useState<Deal[]>([])
+  const [showCreate, setShowCreate] = useState(false)
+  const [reasonByApp, setReasonByApp] = useState<Record<string, string>>({})
+
+  const reload = async () => {
+    try {
+      const { programs } = await authedFetch<{ programs: Program[] }>(
+        "/v1/seller/programs"
+      )
+      setPrograms(programs)
+      if (selectedId === null && programs.length > 0) {
+        setSelectedId(programs[0].id)
+      }
+    } catch (err) {
+      toast.error("Failed to load programs", {
+        description: (err as Error).message,
+      })
+    }
+  }
+
+  const loadDetails = async (programId: string) => {
+    try {
+      const [{ applications: a }, { deals: d }] = await Promise.all([
+        authedFetch<{ applications: Application[] }>(
+          `/v1/seller/programs/${programId}/applications`
+        ),
+        authedFetch<{ deals: Deal[] }>(`/v1/seller/programs/${programId}/deals`),
+      ])
+      setApplications(a)
+      setDeals(d)
+    } catch (err) {
+      toast.error("Failed to load program details", {
+        description: (err as Error).message,
+      })
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (selectedId) void loadDetails(selectedId)
+  }, [selectedId])
+
+  const selectedProgram = useMemo(
+    () => programs.find((p) => p.id === selectedId) ?? null,
+    [programs, selectedId]
+  )
+
+  const decide = async (
+    programId: string,
+    appId: string,
+    decision: "approve" | "reject"
+  ) => {
+    const reason = reasonByApp[appId]?.trim() || null
+    try {
+      await authedFetch(
+        `/v1/seller/programs/${programId}/applications/${appId}/decide`,
+        {
+          method: "POST",
+          body: JSON.stringify({ decision, reason }),
+        }
+      )
+      toast.success(
+        decision === "approve"
+          ? "Application approved — deal opened with default link"
+          : "Application rejected"
+      )
+      setReasonByApp((m) => {
+        const next = { ...m }
+        delete next[appId]
+        return next
+      })
+      await loadDetails(programId)
+    } catch (err) {
+      toast.error("Decision failed", { description: (err as Error).message })
+    }
+  }
+
+  const violateDeal = async (programId: string, dealId: string) => {
+    const reason = window.prompt("Reason for marking this deal violated:")
+    if (!reason) return
+    try {
+      await authedFetch(
+        `/v1/seller/programs/${programId}/deals/${dealId}/violate`,
+        {
+          method: "POST",
+          body: JSON.stringify({ reason, pause_links: true }),
+        }
+      )
+      toast.success("Deal marked violated and links paused")
+      await loadDetails(programId)
+    } catch (err) {
+      toast.error("Violate failed", { description: (err as Error).message })
+    }
+  }
+
+  const publishProgram = async (programId: string) => {
+    try {
+      await authedFetch(`/v1/seller/programs/${programId}/publish`, {
+        method: "POST",
+      })
+      toast.success("Program published")
+      await reload()
+    } catch (err) {
+      toast.error("Publish failed", { description: (err as Error).message })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Heading level="h1">Creator Programs</Heading>
+        <Button onClick={() => setShowCreate(true)}>+ New program</Button>
+      </div>
+
+      {showCreate && (
+        <CreateProgramForm
+          onCancel={() => setShowCreate(false)}
+          onCreated={async () => {
+            setShowCreate(false)
+            await reload()
+          }}
+        />
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="border border-ui-border-base rounded-md p-4 lg:col-span-1">
+          <Heading level="h2" className="mb-3">
+            My programs ({programs.length})
+          </Heading>
+          {programs.length === 0 ? (
+            <Text className="text-ui-fg-subtle italic">
+              No programs yet. Create one to start recruiting creators.
+            </Text>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {programs.map((p) => (
+                <li key={p.id}>
+                  <button
+                    className={`w-full text-left p-3 rounded border ${
+                      p.id === selectedId
+                        ? "border-ui-border-interactive bg-ui-bg-base-hover"
+                        : "border-ui-border-base"
+                    }`}
+                    onClick={() => setSelectedId(p.id)}
+                  >
+                    <div className="font-medium">{p.title}</div>
+                    <div className="text-xs text-ui-fg-subtle">
+                      {p.program_type} · {p.status}
+                    </div>
+                    <div className="text-xs text-ui-fg-subtle">
+                      {p.commission_percent
+                        ? `${p.commission_percent}% commission`
+                        : p.sponsorship_flat_cents
+                        ? `Flat ${formatCents(p.sponsorship_flat_cents)}`
+                        : p.pool_total_cents
+                        ? `Pool ${formatCents(p.pool_total_cents)}`
+                        : "—"}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="lg:col-span-2 flex flex-col gap-4">
+          {selectedProgram ? (
+            <>
+              <div className="border border-ui-border-base rounded-md p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <Heading level="h2">{selectedProgram.title}</Heading>
+                    <Text className="text-ui-fg-subtle">
+                      {selectedProgram.program_type} · status:{" "}
+                      <strong>{selectedProgram.status}</strong>
+                    </Text>
+                    {selectedProgram.description ? (
+                      <Text className="mt-2">{selectedProgram.description}</Text>
+                    ) : null}
+                  </div>
+                  <div className="flex gap-2">
+                    {selectedProgram.status === "draft" ? (
+                      <Button
+                        size="small"
+                        onClick={() => void publishProgram(selectedProgram.id)}
+                      >
+                        Publish
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 text-sm">
+                  <KV
+                    label="Cookie window"
+                    value={`${selectedProgram.cookie_window_days}d`}
+                  />
+                  <KV label="Hold" value={`${selectedProgram.hold_days}d`} />
+                  <KV
+                    label="KYC gated"
+                    value={selectedProgram.requires_kyc ? "Yes" : "No"}
+                  />
+                  <KV
+                    label="Min KYC"
+                    value={selectedProgram.min_verification_level ?? "—"}
+                  />
+                  <KV
+                    label="Budget cap"
+                    value={formatCents(selectedProgram.budget_cap_cents)}
+                  />
+                  <KV
+                    label="Budget spent"
+                    value={formatCents(selectedProgram.budget_spent_cents)}
+                  />
+                  <KV
+                    label="Min followers"
+                    value={
+                      selectedProgram.min_followers != null
+                        ? selectedProgram.min_followers.toLocaleString()
+                        : "—"
+                    }
+                  />
+                  <KV label="Ends" value={formatDate(selectedProgram.ends_at)} />
+                </div>
+              </div>
+
+              <div className="border border-ui-border-base rounded-md p-4">
+                <Heading level="h2" className="mb-3">
+                  Applications ({applications.length})
+                </Heading>
+                {applications.length === 0 ? (
+                  <Text className="text-ui-fg-subtle italic">
+                    No applications yet.
+                  </Text>
+                ) : (
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-ui-fg-subtle border-b">
+                        <th className="py-2">Creator</th>
+                        <th className="py-2">Pitch</th>
+                        <th className="py-2">Status</th>
+                        <th className="py-2">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {applications.map((a) => (
+                        <tr key={a.id} className="border-b align-top">
+                          <td className="py-2 font-mono text-xs">
+                            {a.creator_seller_id}
+                          </td>
+                          <td className="py-2">
+                            {a.pitch ? (
+                              <span>{a.pitch}</span>
+                            ) : (
+                              <span className="text-ui-fg-subtle italic">
+                                no pitch
+                              </span>
+                            )}
+                          </td>
+                          <td className="py-2">{a.status}</td>
+                          <td className="py-2">
+                            {a.status === "pending" ? (
+                              <div className="flex flex-col gap-1">
+                                <Textarea
+                                  rows={2}
+                                  placeholder="Reason (optional for approve, recommended for reject)"
+                                  value={reasonByApp[a.id] ?? ""}
+                                  onChange={(e) =>
+                                    setReasonByApp((m) => ({
+                                      ...m,
+                                      [a.id]: e.target.value,
+                                    }))
+                                  }
+                                />
+                                <div className="flex gap-2">
+                                  <Button
+                                    size="small"
+                                    onClick={() =>
+                                      void decide(
+                                        selectedProgram.id,
+                                        a.id,
+                                        "approve"
+                                      )
+                                    }
+                                  >
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    size="small"
+                                    variant="danger"
+                                    onClick={() =>
+                                      void decide(
+                                        selectedProgram.id,
+                                        a.id,
+                                        "reject"
+                                      )
+                                    }
+                                  >
+                                    Reject
+                                  </Button>
+                                </div>
+                              </div>
+                            ) : (
+                              <Text className="text-ui-fg-subtle italic">
+                                {a.decision_reason ?? "—"}
+                              </Text>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+
+              <div className="border border-ui-border-base rounded-md p-4">
+                <Heading level="h2" className="mb-3">
+                  Active deals ({deals.length})
+                </Heading>
+                {deals.length === 0 ? (
+                  <Text className="text-ui-fg-subtle italic">
+                    No deals yet.
+                  </Text>
+                ) : (
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-ui-fg-subtle border-b">
+                        <th className="py-2">Creator</th>
+                        <th className="py-2">Status</th>
+                        <th className="py-2 text-right">Attributed</th>
+                        <th className="py-2 text-right">Paid out</th>
+                        <th className="py-2">Default link</th>
+                        <th className="py-2"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {deals.map((d) => (
+                        <tr key={d.id} className="border-b">
+                          <td className="py-2 font-mono text-xs">
+                            {d.creator_seller_id}
+                          </td>
+                          <td className="py-2">{d.status}</td>
+                          <td className="py-2 text-right">
+                            {formatCents(d.total_attributed_cents)}
+                          </td>
+                          <td className="py-2 text-right">
+                            {formatCents(d.total_paid_out_cents)}
+                          </td>
+                          <td className="py-2 font-mono text-xs">
+                            {d.default_affiliate_link_id ?? "—"}
+                          </td>
+                          <td className="py-2 text-right">
+                            {d.status === "active" ? (
+                              <Button
+                                size="small"
+                                variant="danger"
+                                onClick={() =>
+                                  void violateDeal(selectedProgram.id, d.id)
+                                }
+                              >
+                                Mark violated
+                              </Button>
+                            ) : null}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </>
+          ) : (
+            <Text className="text-ui-fg-subtle italic">
+              Select a program from the list to see applications and deals.
+            </Text>
+          )}
+        </div>
+      </div>
+    </Container>
+  )
+}
+
+const KV = ({ label, value }: { label: string; value: string }) => (
+  <div>
+    <Text className="text-ui-fg-subtle text-xs uppercase">{label}</Text>
+    <div className="text-sm font-medium">{value}</div>
+  </div>
+)
+
+const CreateProgramForm = ({
+  onCancel,
+  onCreated,
+}: {
+  onCancel: () => void
+  onCreated: () => Promise<void>
+}) => {
+  const [title, setTitle] = useState("")
+  const [slug, setSlug] = useState("")
+  const [description, setDescription] = useState("")
+  const [programType, setProgramType] =
+    useState<ProgramType>("affiliate_open")
+  const [commissionPercent, setCommissionPercent] = useState("10")
+  const [requiresKyc, setRequiresKyc] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async () => {
+    if (!title || !slug) {
+      toast.error("Title and slug required")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const body: Record<string, unknown> = {
+        title,
+        slug,
+        description: description || null,
+        program_type: programType,
+        requires_kyc: requiresKyc,
+      }
+      const pct = parseFloat(commissionPercent)
+      if (Number.isFinite(pct)) body.commission_percent = pct
+
+      await authedFetch("/v1/seller/programs", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+      toast.success("Program created (draft) — click Publish on its detail to activate")
+      await onCreated()
+    } catch (err) {
+      toast.error("Failed to create program", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="border border-ui-border-base rounded-md p-4 flex flex-col gap-3">
+      <Heading level="h2">New program</Heading>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <Label htmlFor="np-title">Title</Label>
+          <Input
+            id="np-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Spring launch — 10% to creators"
+          />
+        </div>
+        <div>
+          <Label htmlFor="np-slug">Slug</Label>
+          <Input
+            id="np-slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value.toLowerCase())}
+            placeholder="spring-launch"
+          />
+        </div>
+        <div className="md:col-span-2">
+          <Label htmlFor="np-desc">Description</Label>
+          <Textarea
+            id="np-desc"
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Brief for creators: what you want them to share, restrictions, hashtags."
+          />
+        </div>
+        <div>
+          <Label htmlFor="np-type">Program type</Label>
+          <select
+            id="np-type"
+            className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base w-full"
+            value={programType}
+            onChange={(e) => setProgramType(e.target.value as ProgramType)}
+          >
+            <option value="affiliate_open">Affiliate (open to all)</option>
+            <option value="affiliate_invite">Affiliate (invite-only)</option>
+            <option value="sponsored_brief">Sponsored brief (flat fee)</option>
+            <option value="commission_boost">Commission boost</option>
+            <option value="engagement_pool">Engagement reward pool</option>
+          </select>
+        </div>
+        <div>
+          <Label htmlFor="np-pct">Commission %</Label>
+          <Input
+            id="np-pct"
+            type="number"
+            min="0"
+            max="100"
+            step="0.5"
+            value={commissionPercent}
+            onChange={(e) => setCommissionPercent(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center gap-2 mt-6">
+          <input
+            id="np-kyc"
+            type="checkbox"
+            checked={requiresKyc}
+            onChange={(e) => setRequiresKyc(e.target.checked)}
+          />
+          <Label htmlFor="np-kyc">Require creator KYC verification</Label>
+        </div>
+      </div>
+      <div className="flex gap-2 justify-end">
+        <Button variant="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button onClick={submit} disabled={submitting}>
+          {submitting ? "Creating..." : "Create draft"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/vendor-panel/src/routes/services/index.ts
+++ b/vendor-panel/src/routes/services/index.ts
@@ -1,0 +1,1 @@
+export { ServicesPage as Component } from "./services"

--- a/vendor-panel/src/routes/services/services.tsx
+++ b/vendor-panel/src/routes/services/services.tsx
@@ -1,0 +1,1050 @@
+import { useEffect, useMemo, useState } from "react"
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+const CATEGORIES = [
+  "apparel_press",
+  "packaging",
+  "photography",
+  "design",
+  "fulfillment",
+  "courier",
+  "repair",
+  "fabrication",
+  "co_packing",
+  "assembly",
+  "custom",
+] as const
+
+const PROGRAM_TYPES = [
+  "bounty_open",
+  "bounty_invite",
+  "fixed_contract",
+  "throughput_pool",
+  "order_subcontract",
+] as const
+
+const PRICING_MODELS = ["per_unit", "per_hour", "flat", "tiered"] as const
+
+const PROOF_KINDS = [
+  "photo",
+  "video",
+  "document",
+  "shipping_label",
+  "tracking_event",
+  "iot_sensor_log",
+  "signed_manifest",
+  "third_party_attestation",
+  "onchain_receipt",
+] as const
+
+interface ServiceProgramRow {
+  id: string
+  vendor_id: string
+  title: string
+  slug: string
+  description: string | null
+  service_category: string
+  program_type: string
+  pricing_model: string
+  status: string
+  unit_price_cents: number | null
+  currency_code: string
+  requires_kyc: boolean
+}
+
+interface ServiceApplicationRow {
+  id: string
+  program_id: string
+  service_seller_id: string
+  pitch: string | null
+  proposed_unit_price_cents: number | null
+  proposed_capacity: number | null
+  status: string
+  decided_at: string | null
+  decision_reason: string | null
+}
+
+interface ServiceContractRow {
+  id: string
+  program_id: string
+  service_seller_id: string
+  vendor_id: string
+  status: string
+  total_paid_cents: number
+  effective_until: string | null
+}
+
+interface OpenServiceProgram {
+  id: string
+  vendor_id: string
+  title: string
+  service_category: string
+  program_type: string
+  pricing_model: string
+  unit_price_cents: number | null
+  flat_price_cents: number | null
+  pool_total_cents: number | null
+  currency_code: string
+  deadline_at: string | null
+  requires_kyc: boolean
+}
+
+interface SubcontractRow {
+  id: string
+  parent_order_id: string
+  parent_seller_id: string
+  subcontract_seller_id: string
+  contract_id: string
+  status: string
+  unit_count: number
+  unit_price_cents: number
+  total_cents: number
+  currency_code: string
+  dispute_reason: string | null
+}
+
+const formatCents = (cents: number | null | undefined, currency = "USD") =>
+  cents == null
+    ? "—"
+    : new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+        Number(cents) / 100
+      )
+
+const formatDate = (s: string | null) =>
+  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—"
+
+async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const ServicesPage = () => {
+  const [tab, setTab] = useState<
+    "buying" | "providing" | "marketplace" | "subcontracts"
+  >("buying")
+  const [myPrograms, setMyPrograms] = useState<ServiceProgramRow[]>([])
+  const [myApplications, setMyApplications] = useState<ServiceApplicationRow[]>([])
+  const [contractsAsBuyer, setContractsAsBuyer] = useState<ServiceContractRow[]>([])
+  const [contractsAsProvider, setContractsAsProvider] = useState<ServiceContractRow[]>([])
+  const [openMarketplace, setOpenMarketplace] = useState<OpenServiceProgram[]>([])
+  const [subcontractsAsParent, setSubcontractsAsParent] = useState<SubcontractRow[]>([])
+  const [subcontractsAsProvider, setSubcontractsAsProvider] = useState<SubcontractRow[]>([])
+  const [showCreate, setShowCreate] = useState(false)
+  const [showSubcontract, setShowSubcontract] = useState<string | null>(null) // contract_id
+  const [loading, setLoading] = useState(false)
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const [
+        { programs },
+        { applications },
+        { as_buyer, as_provider },
+        { programs: openPrograms },
+        { as_parent, as_provider: subAsProvider },
+      ] = await Promise.all([
+        authedFetch<{ programs: ServiceProgramRow[] }>(
+          "/v1/seller/services/programs"
+        ),
+        authedFetch<{ applications: ServiceApplicationRow[] }>(
+          "/v1/seller/services/applications"
+        ),
+        authedFetch<{ as_buyer: ServiceContractRow[]; as_provider: ServiceContractRow[] }>(
+          "/v1/seller/services/contracts"
+        ),
+        authedFetch<{ programs: OpenServiceProgram[] }>(
+          "/v1/marketplace/services?limit=100"
+        ),
+        authedFetch<{ as_parent: SubcontractRow[]; as_provider: SubcontractRow[] }>(
+          "/v1/seller/services/subcontracts"
+        ),
+      ])
+      setMyPrograms(programs)
+      setMyApplications(applications)
+      setContractsAsBuyer(as_buyer)
+      setContractsAsProvider(as_provider)
+      setOpenMarketplace(openPrograms)
+      setSubcontractsAsParent(as_parent)
+      setSubcontractsAsProvider(subAsProvider)
+    } catch (err) {
+      toast.error("Failed to load services data", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+  }, [])
+
+  const publishProgram = async (id: string) => {
+    try {
+      await authedFetch(`/v1/seller/services/programs/${id}/publish`, {
+        method: "POST",
+      })
+      toast.success("Program published")
+      await reload()
+    } catch (err) {
+      toast.error("Publish failed", { description: (err as Error).message })
+    }
+  }
+
+  const apply = async (programId: string, pitch: string, unitPriceCents?: number) => {
+    try {
+      const body: Record<string, unknown> = { program_id: programId, pitch }
+      if (unitPriceCents !== undefined && Number.isFinite(unitPriceCents)) {
+        body.proposed_unit_price_cents = unitPriceCents
+      }
+      await authedFetch("/v1/seller/services/applications", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+      toast.success("Application submitted")
+      await reload()
+    } catch (err) {
+      toast.error("Apply failed", { description: (err as Error).message })
+    }
+  }
+
+  const acceptSubcontract = async (id: string) => {
+    try {
+      await authedFetch(`/v1/seller/services/subcontracts/${id}/accept`, {
+        method: "POST",
+      })
+      toast.success("Subcontract accepted")
+      await reload()
+    } catch (err) {
+      toast.error("Accept failed", { description: (err as Error).message })
+    }
+  }
+
+  const acceptDelivery = async (id: string) => {
+    if (!window.confirm("Accept delivery and release escrow?")) return
+    try {
+      await authedFetch(`/v1/seller/services/subcontracts/${id}/accept-delivery`, {
+        method: "POST",
+      })
+      toast.success("Escrow released to service vendor")
+      await reload()
+    } catch (err) {
+      toast.error("Accept-delivery failed", { description: (err as Error).message })
+    }
+  }
+
+  const dispute = async (id: string) => {
+    const reason = window.prompt("Dispute reason:")
+    if (!reason || reason.trim().length < 2) return
+    try {
+      await authedFetch(`/v1/seller/services/subcontracts/${id}/dispute`, {
+        method: "POST",
+        body: JSON.stringify({ reason }),
+      })
+      toast.success("Dispute filed; admin will review")
+      await reload()
+    } catch (err) {
+      toast.error("Dispute failed", { description: (err as Error).message })
+    }
+  }
+
+  return (
+    <Container className="p-6 flex flex-col gap-6">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <Heading level="h1">Services</Heading>
+        <div className="flex gap-2 flex-wrap">
+          <Button
+            variant={tab === "buying" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("buying")}
+          >
+            I need services
+          </Button>
+          <Button
+            variant={tab === "providing" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("providing")}
+          >
+            I provide services
+          </Button>
+          <Button
+            variant={tab === "marketplace" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("marketplace")}
+          >
+            Open bounties ({openMarketplace.length})
+          </Button>
+          <Button
+            variant={tab === "subcontracts" ? "primary" : "secondary"}
+            size="small"
+            onClick={() => setTab("subcontracts")}
+          >
+            Subcontracts
+          </Button>
+        </div>
+      </div>
+
+      {tab === "buying" && (
+        <div className="flex flex-col gap-4">
+          <div className="flex justify-end">
+            <Button onClick={() => setShowCreate(true)}>+ Post a service program</Button>
+          </div>
+          {showCreate && (
+            <CreateServiceProgramForm
+              onCancel={() => setShowCreate(false)}
+              onCreated={async () => {
+                setShowCreate(false)
+                await reload()
+              }}
+            />
+          )}
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              My service programs ({myPrograms.length})
+            </Heading>
+            {myPrograms.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">
+                No service programs yet. Post one to recruit specialists for press / packaging / fulfillment / etc.
+              </Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Title</th>
+                    <th className="py-2">Category</th>
+                    <th className="py-2">Type</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2 text-right">Unit price</th>
+                    <th className="py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {myPrograms.map((p) => (
+                    <tr key={p.id} className="border-b">
+                      <td className="py-2">
+                        <div className="font-medium">{p.title}</div>
+                        <div className="text-xs text-ui-fg-subtle font-mono">{p.slug}</div>
+                      </td>
+                      <td className="py-2">{p.service_category}</td>
+                      <td className="py-2">{p.program_type}</td>
+                      <td className="py-2">{p.status}</td>
+                      <td className="py-2 text-right">
+                        {formatCents(p.unit_price_cents, p.currency_code.toUpperCase())}
+                      </td>
+                      <td className="py-2 text-right">
+                        {p.status === "draft" ? (
+                          <Button
+                            size="small"
+                            onClick={() => void publishProgram(p.id)}
+                          >
+                            Publish
+                          </Button>
+                        ) : null}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              Active service contracts (work I'm buying)
+            </Heading>
+            <ContractsTable rows={contractsAsBuyer} onSubcontract={setShowSubcontract} />
+          </div>
+          {showSubcontract && (
+            <CreateSubcontractForm
+              contractId={showSubcontract}
+              onCancel={() => setShowSubcontract(null)}
+              onCreated={async () => {
+                setShowSubcontract(null)
+                setTab("subcontracts")
+                await reload()
+              }}
+            />
+          )}
+        </div>
+      )}
+
+      {tab === "providing" && (
+        <div className="flex flex-col gap-4">
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              My applications
+            </Heading>
+            {myApplications.length === 0 ? (
+              <Text className="text-ui-fg-subtle italic">
+                You haven't applied to any service programs. Browse "Open bounties" to find work.
+              </Text>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-ui-fg-subtle border-b">
+                    <th className="py-2">Program</th>
+                    <th className="py-2">Status</th>
+                    <th className="py-2 text-right">Proposed price</th>
+                    <th className="py-2 text-right">Capacity</th>
+                    <th className="py-2">Decision</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {myApplications.map((a) => (
+                    <tr key={a.id} className="border-b">
+                      <td className="py-2 font-mono text-xs">{a.program_id}</td>
+                      <td className="py-2">{a.status}</td>
+                      <td className="py-2 text-right">
+                        {formatCents(a.proposed_unit_price_cents)}
+                      </td>
+                      <td className="py-2 text-right">{a.proposed_capacity ?? "—"}</td>
+                      <td className="py-2 text-xs text-ui-fg-subtle">
+                        {a.decision_reason ?? "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              Active contracts (work I'm doing)
+            </Heading>
+            <ContractsTable rows={contractsAsProvider} />
+          </div>
+        </div>
+      )}
+
+      {tab === "marketplace" && (
+        <div className="flex flex-col gap-3">
+          {openMarketplace.length === 0 ? (
+            <Text className="text-ui-fg-subtle italic">
+              No open bounties available right now. Check back later.
+            </Text>
+          ) : null}
+          {openMarketplace.map((p) => {
+            const myApp = myApplications.find((a) => a.program_id === p.id)
+            return (
+              <OpenBountyCard
+                key={p.id}
+                program={p}
+                myApplication={myApp}
+                onApply={apply}
+              />
+            )
+          })}
+        </div>
+      )}
+
+      {tab === "subcontracts" && (
+        <div className="flex flex-col gap-4">
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              Subcontracts I'm running ({subcontractsAsParent.length})
+            </Heading>
+            <SubcontractsTable
+              rows={subcontractsAsParent}
+              perspective="parent"
+              onAcceptDelivery={acceptDelivery}
+              onDispute={dispute}
+            />
+          </div>
+          <div className="border border-ui-border-base rounded-md p-4">
+            <Heading level="h2" className="mb-3">
+              Subcontracts assigned to me ({subcontractsAsProvider.length})
+            </Heading>
+            <SubcontractsTable
+              rows={subcontractsAsProvider}
+              perspective="provider"
+              onAccept={acceptSubcontract}
+              onDispute={dispute}
+            />
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+const ContractsTable = ({
+  rows,
+  onSubcontract,
+}: {
+  rows: ServiceContractRow[]
+  onSubcontract?: (contractId: string) => void
+}) =>
+  rows.length === 0 ? (
+    <Text className="text-ui-fg-subtle italic">No active contracts.</Text>
+  ) : (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-ui-fg-subtle border-b">
+          <th className="py-2">Contract</th>
+          <th className="py-2">Program</th>
+          <th className="py-2">Counterparty</th>
+          <th className="py-2">Status</th>
+          <th className="py-2 text-right">Paid out</th>
+          <th className="py-2">Until</th>
+          <th className="py-2"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((c) => (
+          <tr key={c.id} className="border-b">
+            <td className="py-2 font-mono text-xs">{c.id}</td>
+            <td className="py-2 font-mono text-xs">{c.program_id}</td>
+            <td className="py-2 font-mono text-xs">{c.service_seller_id}</td>
+            <td className="py-2">{c.status}</td>
+            <td className="py-2 text-right">{formatCents(c.total_paid_cents)}</td>
+            <td className="py-2">{formatDate(c.effective_until)}</td>
+            <td className="py-2 text-right">
+              {onSubcontract && c.status !== "canceled" ? (
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => onSubcontract(c.id)}
+                >
+                  + Subcontract
+                </Button>
+              ) : null}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+
+const SubcontractsTable = ({
+  rows,
+  perspective,
+  onAccept,
+  onAcceptDelivery,
+  onDispute,
+}: {
+  rows: SubcontractRow[]
+  perspective: "parent" | "provider"
+  onAccept?: (id: string) => void
+  onAcceptDelivery?: (id: string) => void
+  onDispute?: (id: string) => void
+}) =>
+  rows.length === 0 ? (
+    <Text className="text-ui-fg-subtle italic">No subcontracts.</Text>
+  ) : (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-ui-fg-subtle border-b">
+          <th className="py-2">Subcontract</th>
+          <th className="py-2">Order</th>
+          <th className="py-2">Status</th>
+          <th className="py-2 text-right">Units</th>
+          <th className="py-2 text-right">Total</th>
+          <th className="py-2">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((s) => (
+          <tr key={s.id} className="border-b align-top">
+            <td className="py-2 font-mono text-xs">{s.id}</td>
+            <td className="py-2 font-mono text-xs">{s.parent_order_id}</td>
+            <td className="py-2">
+              {s.status}
+              {s.dispute_reason ? (
+                <div className="text-xs text-ui-fg-subtle italic mt-1">
+                  {s.dispute_reason}
+                </div>
+              ) : null}
+            </td>
+            <td className="py-2 text-right">{s.unit_count}</td>
+            <td className="py-2 text-right">
+              {formatCents(s.total_cents, s.currency_code.toUpperCase())}
+            </td>
+            <td className="py-2">
+              <div className="flex flex-col gap-1">
+                {perspective === "provider" && s.status === "proposed" && onAccept ? (
+                  <Button
+                    size="small"
+                    onClick={() => onAccept(s.id)}
+                  >
+                    Accept
+                  </Button>
+                ) : null}
+                {perspective === "provider" && (s.status === "accepted" || s.status === "in_progress") ? (
+                  <DeliverButton subcontractId={s.id} />
+                ) : null}
+                {perspective === "parent" && s.status === "delivered" && onAcceptDelivery ? (
+                  <Button
+                    size="small"
+                    onClick={() => onAcceptDelivery(s.id)}
+                  >
+                    Accept delivery & release
+                  </Button>
+                ) : null}
+                {onDispute && s.status !== "accepted_by_parent" && s.status !== "canceled" ? (
+                  <Button
+                    size="small"
+                    variant="danger"
+                    onClick={() => onDispute(s.id)}
+                  >
+                    Dispute
+                  </Button>
+                ) : null}
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+
+const DeliverButton = ({ subcontractId }: { subcontractId: string }) => {
+  const [showForm, setShowForm] = useState(false)
+  return showForm ? (
+    <DeliverForm
+      subcontractId={subcontractId}
+      onClose={() => setShowForm(false)}
+    />
+  ) : (
+    <Button size="small" onClick={() => setShowForm(true)}>
+      Deliver
+    </Button>
+  )
+}
+
+const DeliverForm = ({
+  subcontractId,
+  onClose,
+}: {
+  subcontractId: string
+  onClose: () => void
+}) => {
+  const [proofKind, setProofKind] = useState("photo")
+  const [proofUrl, setProofUrl] = useState("")
+  const [proofSha, setProofSha] = useState("")
+  const [unitsDelivered, setUnitsDelivered] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async () => {
+    setSubmitting(true)
+    try {
+      const body: Record<string, unknown> = {
+        proofs: [
+          {
+            kind: proofKind,
+            storage_url: proofUrl || null,
+            sha256: proofSha || null,
+            captured_at: new Date().toISOString(),
+          },
+        ],
+      }
+      const u = parseInt(unitsDelivered, 10)
+      if (Number.isFinite(u) && u >= 0) body.units_delivered = u
+      await authedFetch(`/v1/seller/services/subcontracts/${subcontractId}/deliver`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+      toast.success("Delivered; awaiting buyer acceptance")
+      onClose()
+      window.location.reload()
+    } catch (err) {
+      toast.error("Deliver failed", { description: (err as Error).message })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-2 border border-ui-border-base rounded">
+      <select
+        className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base text-xs"
+        value={proofKind}
+        onChange={(e) => setProofKind(e.target.value)}
+      >
+        {PROOF_KINDS.map((k) => (
+          <option key={k} value={k}>
+            {k}
+          </option>
+        ))}
+      </select>
+      <Input
+        placeholder="Proof URL (e.g. uploaded photo URL)"
+        value={proofUrl}
+        onChange={(e) => setProofUrl(e.target.value)}
+      />
+      <Input
+        placeholder="sha256 of proof file (hex, optional)"
+        value={proofSha}
+        onChange={(e) => setProofSha(e.target.value)}
+      />
+      <Input
+        placeholder="Units delivered (optional)"
+        value={unitsDelivered}
+        onChange={(e) => setUnitsDelivered(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <Button size="small" onClick={submit} disabled={submitting}>
+          Submit
+        </Button>
+        <Button size="small" variant="secondary" onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+const OpenBountyCard = ({
+  program,
+  myApplication,
+  onApply,
+}: {
+  program: OpenServiceProgram
+  myApplication?: ServiceApplicationRow
+  onApply: (id: string, pitch: string, unitPriceCents?: number) => Promise<void>
+}) => {
+  const [pitch, setPitch] = useState("")
+  const [unitPrice, setUnitPrice] = useState("")
+  return (
+    <div className="border border-ui-border-base rounded-md p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1">
+          <Heading level="h3">{program.title}</Heading>
+          <Text className="text-xs text-ui-fg-subtle">
+            {program.service_category} · {program.program_type} ·{" "}
+            {program.pricing_model}
+            {program.unit_price_cents
+              ? ` · ${formatCents(program.unit_price_cents, program.currency_code.toUpperCase())} / unit`
+              : program.flat_price_cents
+              ? ` · flat ${formatCents(program.flat_price_cents, program.currency_code.toUpperCase())}`
+              : ""}
+            {program.requires_kyc ? " · KYC required" : ""}
+            {program.deadline_at
+              ? ` · deadline ${formatDate(program.deadline_at)}`
+              : ""}
+          </Text>
+        </div>
+      </div>
+      {myApplication ? (
+        <Text className="text-sm mt-2">
+          Application status: <strong>{myApplication.status}</strong>
+          {myApplication.decision_reason ? ` — ${myApplication.decision_reason}` : ""}
+        </Text>
+      ) : (
+        <div className="mt-3 flex flex-col gap-2">
+          <Textarea
+            rows={2}
+            placeholder="Pitch (capacity, lead time, portfolio links)"
+            value={pitch}
+            onChange={(e) => setPitch(e.target.value)}
+          />
+          <Input
+            placeholder="Proposed unit price in cents (optional)"
+            value={unitPrice}
+            onChange={(e) => setUnitPrice(e.target.value)}
+          />
+          <div>
+            <Button
+              size="small"
+              onClick={() => {
+                const cents = parseInt(unitPrice, 10)
+                void onApply(
+                  program.id,
+                  pitch,
+                  Number.isFinite(cents) ? cents : undefined
+                )
+              }}
+            >
+              Apply
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const CreateServiceProgramForm = ({
+  onCancel,
+  onCreated,
+}: {
+  onCancel: () => void
+  onCreated: () => Promise<void>
+}) => {
+  const [title, setTitle] = useState("")
+  const [slug, setSlug] = useState("")
+  const [description, setDescription] = useState("")
+  const [serviceCategory, setServiceCategory] = useState("apparel_press")
+  const [programType, setProgramType] = useState("bounty_open")
+  const [pricingModel, setPricingModel] = useState("per_unit")
+  const [unitPriceCents, setUnitPriceCents] = useState("500")
+  const [requiresKyc, setRequiresKyc] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async () => {
+    if (!title || !slug) {
+      toast.error("Title and slug required")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const body: Record<string, unknown> = {
+        title,
+        slug,
+        description: description || null,
+        service_category: serviceCategory,
+        program_type: programType,
+        pricing_model: pricingModel,
+        requires_kyc: requiresKyc,
+      }
+      const cents = parseInt(unitPriceCents, 10)
+      if (Number.isFinite(cents) && cents >= 0) {
+        if (pricingModel === "per_unit") body.unit_price_cents = cents
+        else if (pricingModel === "flat") body.flat_price_cents = cents
+        else if (pricingModel === "per_hour") body.hourly_rate_cents = cents
+      }
+      await authedFetch("/v1/seller/services/programs", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+      toast.success("Service program created (draft) — click Publish to activate")
+      await onCreated()
+    } catch (err) {
+      toast.error("Failed to create program", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="border border-ui-border-base rounded-md p-4 flex flex-col gap-3">
+      <Heading level="h2">Post a service program</Heading>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <Label htmlFor="sp-title">Title</Label>
+          <Input
+            id="sp-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="T-shirt press capacity for spring orders"
+          />
+        </div>
+        <div>
+          <Label htmlFor="sp-slug">Slug</Label>
+          <Input
+            id="sp-slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value.toLowerCase())}
+            placeholder="apparel-press-spring"
+          />
+        </div>
+        <div className="md:col-span-2">
+          <Label htmlFor="sp-desc">Description / brief</Label>
+          <Textarea
+            id="sp-desc"
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Spec sheet, materials, tolerances, deadline expectations."
+          />
+        </div>
+        <div>
+          <Label htmlFor="sp-cat">Category</Label>
+          <select
+            id="sp-cat"
+            className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base w-full"
+            value={serviceCategory}
+            onChange={(e) => setServiceCategory(e.target.value)}
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <Label htmlFor="sp-type">Program type</Label>
+          <select
+            id="sp-type"
+            className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base w-full"
+            value={programType}
+            onChange={(e) => setProgramType(e.target.value)}
+          >
+            {PROGRAM_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <Label htmlFor="sp-pricing">Pricing model</Label>
+          <select
+            id="sp-pricing"
+            className="border border-ui-border-base rounded px-2 py-1 bg-ui-bg-base w-full"
+            value={pricingModel}
+            onChange={(e) => setPricingModel(e.target.value)}
+          >
+            {PRICING_MODELS.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <Label htmlFor="sp-price">Unit/flat/hour price (cents)</Label>
+          <Input
+            id="sp-price"
+            type="number"
+            min="0"
+            value={unitPriceCents}
+            onChange={(e) => setUnitPriceCents(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center gap-2 mt-6">
+          <input
+            id="sp-kyc"
+            type="checkbox"
+            checked={requiresKyc}
+            onChange={(e) => setRequiresKyc(e.target.checked)}
+          />
+          <Label htmlFor="sp-kyc">Require KYC verification</Label>
+        </div>
+      </div>
+      <div className="flex gap-2 justify-end">
+        <Button variant="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button onClick={submit} disabled={submitting}>
+          {submitting ? "Creating..." : "Create draft"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+const CreateSubcontractForm = ({
+  contractId,
+  onCancel,
+  onCreated,
+}: {
+  contractId: string
+  onCancel: () => void
+  onCreated: () => Promise<void>
+}) => {
+  const [orderId, setOrderId] = useState("")
+  const [orderItemIds, setOrderItemIds] = useState("")
+  const [unitCount, setUnitCount] = useState("1")
+  const [unitPriceCents, setUnitPriceCents] = useState("500")
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async () => {
+    if (!orderId || !orderItemIds) {
+      toast.error("Order id and item ids required")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const ids = orderItemIds
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+      await authedFetch("/v1/seller/services/subcontracts", {
+        method: "POST",
+        body: JSON.stringify({
+          parent_order_id: orderId,
+          contract_id: contractId,
+          order_item_ids: ids,
+          unit_count: parseInt(unitCount, 10) || 1,
+          unit_price_cents: parseInt(unitPriceCents, 10) || 500,
+        }),
+      })
+      toast.success("Subcontract proposed; escrow opened")
+      await onCreated()
+    } catch (err) {
+      toast.error("Subcontract failed", {
+        description: (err as Error).message,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="border border-ui-border-base rounded-md p-4 flex flex-col gap-3">
+      <Heading level="h2">Subcontract on contract {contractId}</Heading>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <Label htmlFor="sc-order">Parent order id</Label>
+          <Input
+            id="sc-order"
+            value={orderId}
+            onChange={(e) => setOrderId(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="sc-items">Order item ids (comma-separated)</Label>
+          <Input
+            id="sc-items"
+            value={orderItemIds}
+            onChange={(e) => setOrderItemIds(e.target.value)}
+            placeholder="ord_item_1,ord_item_2"
+          />
+        </div>
+        <div>
+          <Label htmlFor="sc-units">Unit count</Label>
+          <Input
+            id="sc-units"
+            type="number"
+            min="1"
+            value={unitCount}
+            onChange={(e) => setUnitCount(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="sc-price">Unit price (cents)</Label>
+          <Input
+            id="sc-price"
+            type="number"
+            min="1"
+            value={unitPriceCents}
+            onChange={(e) => setUnitPriceCents(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex gap-2 justify-end">
+        <Button variant="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button onClick={submit} disabled={submitting}>
+          {submitting ? "Opening escrow..." : "Propose subcontract"}
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds the core "creator gets paid for an attributed sale" loop on top of the
existing hawala-ledger / payout-breakdown / marketplace-webhooks primitives.

New backend module `creator-attribution` with four models:
- AffiliateLink: short-coded shareable URLs per creator/product
- PromoCodeBinding: wraps Medusa promotion codes for creator attribution
- AttributionClickEvent: write-heavy click log with bot detection hooks
- OrderAttribution: per-order commission state machine (pending -> held ->
  approved -> paid, with reversed/disqualified terminal states)

Extensions to existing modules:
- seller-extension: add CREATOR vendor type + creator profile fields
  (handle, bio, niches, follower count, audience geo) with partial unique
  index on creator_handle
- payout-breakdown: add CREATOR_COMMISSION FeeType; calculateBreakdown now
  threads creatorCommissionCents through, funded out of seller gross so
  customer-facing total stays unchanged
- hawala-ledger: add CREATOR_EARNINGS / CREATOR_REWARD_POOL account types,
  CREATOR_COMMISSION / CREATOR_REWARD entry types, plus new helpers
  creditCreatorCommission and reverseCreatorCommission with idempotency
- marketplace-webhooks: add creator.commission.{earned,held,approved,
  reversed,disqualified} and attribution.fraud_flagged event keys

Public APIs:
- GET /r/:shortCode redirector — 302s to destination, sets signed
  _fbm_visitor and _fbm_aff cookies, async-records click event
- POST /v1/marketplace/attribution/click for SPA/iframe widgets
- GET /v1/marketplace/creators/:handle public profile

Seller APIs (creator-side):
- GET/POST /v1/seller/creator/links and GET/PATCH .../links/:id
- GET /v1/seller/creator/earnings (rollup + drill-down)
- GET/POST /v1/seller/creator/promo-codes

Admin APIs:
- GET /v1/admin/marketplace/creators
- GET /v1/admin/marketplace/attributions (moderation queue)
- POST /v1/admin/marketplace/attributions/:id/disqualify

Subscribers + jobs:
- attribute-order-on-placed: attributes orders, transitions pending -> held,
  emits creator.commission.earned
- hawala-order-payment (modified): reads OrderAttribution, passes
  creatorCommissionCents into the breakdown calculation
- process-refund-reverses-commission: reverses commission on
  order.canceled / order.refund_created, with ledger reversal when needed
- creator-attribution-approve-held: hourly cron that credits creator
  earnings via creditCreatorCommission once hold expires

Storefront:
- middleware extended to mint/refresh first-party visitor cookie and pin
  affiliate cookie when ?fbm_ref=<short_code> is present, on both fast and
  slow paths
- /creators/[handle] public profile page

UI:
- vendor-panel: new Creator Studio route with dashboard / links /
  earnings tabs, generates affiliate links and shows commission rollup
- admin-panel: new /creators page with creator list and attribution
  moderation queue with disqualify action

https://claude.ai/code/session_01BNY5WhC4KACu7ibyJDqXum