### PR TITLE
fix(docker): prefix pnpm cache-mount ids with cacheKey scope

### DIFF
--- a/admin-panel/Dockerfile
+++ b/admin-panel/Dockerfile
@@ -15,7 +15,7 @@ ENV NODE_ENV=production
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,id=pnpm-store-admin,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=admin-panel-pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prod=false
 
 COPY . .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
 COPY restaurant-marketplace ./restaurant-marketplace
-RUN --mount=type=cache,id=pnpm-store-backend,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=backend-pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prod=false
 
 # --- build stage -------------------------------------------------------------

--- a/storefront/Dockerfile
+++ b/storefront/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,id=pnpm-store-storefront,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=storefront-pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prod=false
 
 # --- build stage -------------------------------------------------------------

--- a/vendor-panel/Dockerfile
+++ b/vendor-panel/Dockerfile
@@ -15,7 +15,7 @@ ENV NODE_ENV=production
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,id=pnpm-store-vendor,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=vendor-panel-pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prod=false
 
 COPY . .


### PR DESCRIPTION
Dockerfile validator rejects --mount=type=cache ids that lack the
cacheKey prefix. Align each id with the GHA cache scope used in
.github/workflows/docker-build.yml (matrix.app), so the cache-mount
id and the remote cache scope share a namespace:

  pnpm-store-backend    -> backend-pnpm-store
  pnpm-store-storefront -> storefront-pnpm-store
  pnpm-store-admin      -> admin-panel-pnpm-store
  pnpm-store-vendor     -> vendor-panel-pnpm-store

https://claude.ai/code/session_01VpQkqHtKzaF7e3onELy3ys