### PR TITLE
fix(docker): drop pnpm cache-mount to unblock Railway

### DIFF
--- a/admin-panel/Dockerfile
+++ b/admin-panel/Dockerfile
@@ -15,8 +15,7 @@ ENV NODE_ENV=production
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod=false
+RUN pnpm install --frozen-lockfile --prod=false
 
 COPY . .
 RUN pnpm run build

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,8 +16,7 @@ RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
 COPY restaurant-marketplace ./restaurant-marketplace
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod=false
+RUN pnpm install --frozen-lockfile --prod=false
 
 # --- build stage -------------------------------------------------------------
 FROM node:${NODE_VERSION} AS build

--- a/storefront/Dockerfile
+++ b/storefront/Dockerfile
@@ -14,8 +14,7 @@ WORKDIR /app
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod=false
+RUN pnpm install --frozen-lockfile --prod=false
 
 # --- build stage -------------------------------------------------------------
 FROM node:${NODE_VERSION} AS build

--- a/vendor-panel/Dockerfile
+++ b/vendor-panel/Dockerfile
@@ -15,8 +15,7 @@ ENV NODE_ENV=production
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod=false
+RUN pnpm install --frozen-lockfile --prod=false
 
 COPY . .
 # build:preview emits the SPA bundle without the (heavier) tsup library output.


### PR DESCRIPTION
Railway's Dockerfile validator requires `--mount=type=cache` ids to be in
the form `id=s/<service-id>-<name>` (the literal `s/<service-id>` prefix
is mandatory and cannot be supplied via env vars / build args, since the
validator parses the Dockerfile statically). Two prior fixes
(6b046e6 set `id=<app>-pnpm-store`, 84e5c71 dropped `id=` entirely) both
bounced because neither used the `s/` prefix.

Rather than hardcode Railway service IDs into the Dockerfiles (which
would couple them to one specific Railway environment), drop the cache
mounts. BuildKit layer caching still invalidates the `pnpm install`
layer only when package.json / pnpm-lock.yaml change, and the GHA
remote cache (cache-from / cache-to: type=gha,scope=<app> in
.github/workflows/docker-build.yml) is independent of the in-Dockerfile
mount and continues to scope per app.