### PR TITLE
feat(entitlement,seller): MXID-keyed vendor roles for §5.1 foundation milestone

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -172,6 +172,14 @@ NEXT_PUBLIC_STRIPE_KEY=
 REVALIDATE_SECRET=
 NEXT_PUBLIC_SITE_NAME="Black Market Coalition"
 NEXT_PUBLIC_SITE_DESCRIPTION="Black Market Coalition"
+
+# Capacitor / in-app webview embed allowlist per
+# AGGRESSIVE_OPERATIONS_GUIDE.md §2.8 and §5.1. Comma-separated list
+# of origins that are allowed to embed the storefront. The Blackout
+# Capacitor wrapper passes its origin in X-FBM-Embed-Origin; only
+# origins listed here get the relaxed frame-ancestors CSP.
+# Example: capacitor://localhost,https://blackout.bmc.example
+BLACKOUT_EMBED_ALLOWED_ORIGINS=
 NEXT_PUBLIC_ALGOLIA_ID=
 NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=
 NEXT_PUBLIC_VENDOR_URL=https://vendor.freeblackmarket.com

--- a/.env.production.example
+++ b/.env.production.example
@@ -134,6 +134,31 @@ FBM_BLACKOUT_INTEGRATION=0
 FBM_BLACKSTAR_INTEGRATION=0
 # FBM_BLACKSTAR_API_KEY=
 
+# =============================================================================
+# Stellar / USDC settlement bridge
+# (Foundation milestone §5.1; see docs/runbooks/STELLAR_USDC_BRIDGE.md)
+# Default config below targets testnet. Mainnet cutover requires:
+#   1. Provisioning a fresh signer keypair in the secrets manager (do NOT
+#      commit any secret here).
+#   2. Switching STELLAR_NETWORK to "mainnet".
+#   3. Pointing STELLAR_HORIZON_URL at a production Horizon endpoint.
+#   4. Setting STELLAR_USDC_ISSUER to Circle's mainnet issuer
+#      (GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN).
+#   5. Funding the signer account with XLM for fees and a USDC trustline.
+#   6. Running the smoke check in the runbook against testnet first.
+# Until that cutover, ENABLE_STELLAR_SETTLEMENT stays false.
+# =============================================================================
+STELLAR_NETWORK=testnet
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+# STELLAR_HORIZON_URL=https://horizon.stellar.org   # uncomment for mainnet
+STELLAR_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+# STELLAR_USDC_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN  # mainnet Circle USDC
+# STELLAR_SIGNER_SECRET=  # NEVER commit; load from secrets manager only
+# Dual-rail selector tuning (defaults applied if unset):
+# STELLAR_DUAL_RAIL_MIN_AMOUNT=1.00       # below this, force Stripe-ACH
+# STELLAR_RETRY_MAX_ATTEMPTS=3            # Horizon submission retry cap
+# STELLAR_RETRY_BASE_DELAY_MS=250         # exponential backoff base
+
 
 # =============================================================================
 # Storefront (Next.js)

--- a/STOREFRONT_AUDIT.md
+++ b/STOREFRONT_AUDIT.md
@@ -132,3 +132,19 @@ The storefront uses `DOMPurify` to sanitize seller descriptions and product deta
 ---
 
 *Report generated as part of the storefront audit - February 2026*
+
+---
+
+## Addendum — May 2026 — Unified retail/marketplace presentation (§5.1)
+
+The storefront now ships an explicit retail vs marketplace presentation split per AGGRESSIVE_OPERATIONS_GUIDE.md §1.1. Same listing data, different chrome:
+
+- `src/lib/listing/presentation.ts` — pure `selectPresentation()` selector. Inputs: `routeKind`, storefront context, seller handle, optional coalition-membership flag. Outputs: `"retail"` or `"marketplace"`.
+- `src/components/sections/ProductDetailsPage/ProductDetailsPage.tsx` — accepts a `presentation` prop. Marketplace renders the "More from this seller" section; retail omits it.
+- `src/app/[locale]/(main)/products/[handle]/page.tsx` — `routeKind: "products"`, defaults to marketplace.
+- `src/app/[locale]/(main)/shop/[handle]/page.tsx` — `routeKind: "shop"`, defaults to retail. Coalition-storefront-context cookie still forces marketplace.
+- `src/app/[locale]/(main)/shop/page.tsx` — public retail landing.
+
+Tests: `src/__tests__/presentation.test.ts` covers the seven branches of the selector.
+
+This addendum closes the §5.1 unified-presentation workstream; downstream styling work on the retail browse experience is deferred to differentiation milestone.

--- a/STOREFRONT_AUDIT.md
+++ b/STOREFRONT_AUDIT.md
@@ -148,3 +148,18 @@ The storefront now ships an explicit retail vs marketplace presentation split pe
 Tests: `src/__tests__/presentation.test.ts` covers the seven branches of the selector.
 
 This addendum closes the §5.1 unified-presentation workstream; downstream styling work on the retail browse experience is deferred to differentiation milestone.
+
+---
+
+## Addendum — May 2026 — Capacitor / in-app webview embed (§5.1)
+
+The storefront now accepts embedding from the Blackout Capacitor wrapper per AGGRESSIVE_OPERATIONS_GUIDE.md §2.8. Origin-allowlisted, opt-in only:
+
+- `src/lib/runtime/embed-context.ts` — `detectEmbedContext(headers)` returns `{ isEmbedded, origin, isAllowedOrigin }` based on the `X-FBM-Embed-Origin` header and the `BLACKOUT_EMBED_ALLOWED_ORIGINS` env var.
+- `src/middleware.ts` — `applyEmbedHeaders` swaps `X-Frame-Options: SAMEORIGIN` for `Content-Security-Policy: frame-ancestors <origin>` when (and only when) the request comes from an allowlisted embed origin.
+- `src/app/api/auth/embed-bootstrap/route.ts` — POST endpoint accepting a Blackout-issued JWT, sets `_medusa_jwt` cookie scoped to the webview session. JWS verification deferred until Blackout publishes the signing pubkey to pin.
+- `.env.production.example` — `BLACKOUT_EMBED_ALLOWED_ORIGINS` slot added.
+
+Tests: `src/__tests__/embed-context.test.ts` covers the detector's six branches.
+
+Runbook: `docs/runbooks/STOREFRONT_CAPACITOR_EMBED.md` documents the handshake, allowlist, bootstrap, manual test path, and known limitations.

--- a/admin-panel/package.json
+++ b/admin-panel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@medusajs/dashboard",
   "version": "2.12.5",
+  "packageManager": "pnpm@10.13.1",
   "pnpm": {
     "overrides": {
       "glob": ">=10.5.0",

--- a/admin-panel/src/routes/coalition-credits/index.ts
+++ b/admin-panel/src/routes/coalition-credits/index.ts
@@ -1,0 +1,1 @@
+export { Component } from "./page"

--- a/admin-panel/src/routes/coalition-credits/page.tsx
+++ b/admin-panel/src/routes/coalition-credits/page.tsx
@@ -1,0 +1,138 @@
+import { useQuery } from "@tanstack/react-query"
+import { Container, Heading, Text } from "@medusajs/ui"
+import { sdk } from "@lib/client"
+
+type LedgerSummary = {
+  accounts: {
+    total_accounts: number
+    by_type: Record<string, { count: number; total_balance: number }>
+    total_balance: number
+  }
+  investments: {
+    total_pools: number
+    total_invested: number
+    total_distributed: number
+  }
+  settlements: {
+    total_batches: number
+    completed_batches: number
+    total_settled_volume: number
+  }
+  recent_entries: Array<{
+    id: string
+    entry_type?: string
+    amount?: number
+    description?: string | null
+    created_at?: string
+  }>
+}
+
+export const CoalitionCreditsPage = () => {
+  const { data, isLoading, error } = useQuery<LedgerSummary>({
+    queryKey: ["coalition-credits-summary"],
+    queryFn: () => sdk.client.fetch<LedgerSummary>("/admin/hawala/summary"),
+  })
+
+  return (
+    <Container>
+      <Heading>Coalition Credits</Heading>
+      <Text size="small" className="text-ui-fg-subtle">
+        Cross-coalition Coalition Credits volume on the
+        <code className="mx-1">hawala-ledger</code>
+        substrate. Backs the Blackout-side balance widget through the
+        entitlements service.
+      </Text>
+
+      {isLoading && <Text className="mt-4">Loading…</Text>}
+      {error && (
+        <Text className="mt-4 text-ui-fg-error">
+          Failed to load summary: {(error as Error).message}
+        </Text>
+      )}
+
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Total accounts</Text>
+          <Text size="large">{data?.accounts?.total_accounts ?? 0}</Text>
+        </div>
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Total balance</Text>
+          <Text size="large">
+            {(data?.accounts?.total_balance ?? 0).toLocaleString()}
+          </Text>
+        </div>
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Settlement batches</Text>
+          <Text size="large">
+            {data?.settlements?.completed_batches ?? 0}
+            <span className="text-ui-fg-subtle">
+              {" "}/ {data?.settlements?.total_batches ?? 0}
+            </span>
+          </Text>
+        </div>
+      </div>
+
+      <Heading level="h2" className="mt-6">By account type</Heading>
+      <div className="mt-2 space-y-2">
+        {data?.accounts?.by_type &&
+          Object.entries(data.accounts.by_type).map(([type, summary]) => (
+            <div key={type} className="border rounded p-3 flex justify-between">
+              <Text>{type}</Text>
+              <Text>
+                {summary.count} accounts · {summary.total_balance.toLocaleString()} total balance
+              </Text>
+            </div>
+          ))}
+      </div>
+
+      <Heading level="h2" className="mt-6">Investment pools</Heading>
+      <div className="mt-2 grid grid-cols-3 gap-3">
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Pools</Text>
+          <Text size="large">{data?.investments?.total_pools ?? 0}</Text>
+        </div>
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Invested</Text>
+          <Text size="large">
+            {(data?.investments?.total_invested ?? 0).toLocaleString()}
+          </Text>
+        </div>
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Distributed</Text>
+          <Text size="large">
+            {(data?.investments?.total_distributed ?? 0).toLocaleString()}
+          </Text>
+        </div>
+      </div>
+
+      <Heading level="h2" className="mt-6">Recent ledger entries</Heading>
+      <div className="mt-2 space-y-2">
+        {data?.recent_entries?.length ? (
+          data.recent_entries.map((entry) => (
+            <div key={entry.id} className="border rounded p-3 flex justify-between">
+              <Text>
+                {entry.entry_type ?? "ENTRY"}
+                {entry.description && (
+                  <span className="text-ui-fg-subtle ml-2">{entry.description}</span>
+                )}
+              </Text>
+              <Text>
+                {(entry.amount ?? 0).toLocaleString()}
+                {entry.created_at && (
+                  <span className="ml-2 text-ui-fg-subtle">
+                    {new Date(entry.created_at).toLocaleString()}
+                  </span>
+                )}
+              </Text>
+            </div>
+          ))
+        ) : (
+          <Text className="text-ui-fg-subtle">No ledger entries yet.</Text>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+export const Component = CoalitionCreditsPage
+export default CoalitionCreditsPage

--- a/admin-panel/src/routes/vendor-verification/index.ts
+++ b/admin-panel/src/routes/vendor-verification/index.ts
@@ -1,0 +1,1 @@
+export { Component } from "./page"

--- a/admin-panel/src/routes/vendor-verification/page.tsx
+++ b/admin-panel/src/routes/vendor-verification/page.tsx
@@ -1,0 +1,92 @@
+import { useQuery } from "@tanstack/react-query"
+import { Container, Heading, Text } from "@medusajs/ui"
+import { sdk } from "@lib/client"
+
+type FunnelResponse = {
+  total: number
+  by_status: Record<string, number>
+  by_level: Record<string, number>
+  median_time_to_verify_ms: number | null
+}
+
+export const VendorVerificationPage = () => {
+  const { data, isLoading, error } = useQuery<FunnelResponse>({
+    queryKey: ["vendor-verification-funnel"],
+    queryFn: () => sdk.client.fetch<FunnelResponse>("/admin/vendor-verification/funnel"),
+  })
+
+  return (
+    <Container>
+      <Heading>Vendor Verification</Heading>
+      <Text size="small" className="text-ui-fg-subtle">
+        Verification funnel + signing instrumentation per
+        AGGRESSIVE_OPERATIONS_GUIDE.md §5.1.
+      </Text>
+
+      {isLoading && <Text className="mt-4">Loading…</Text>}
+      {error && (
+        <Text className="mt-4 text-ui-fg-error">
+          Failed to load funnel: {(error as Error).message}
+        </Text>
+      )}
+
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Total verifications</Text>
+          <Text size="large">{data?.total ?? 0}</Text>
+        </div>
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Median time to verify</Text>
+          <Text size="large">{formatDuration(data?.median_time_to_verify_ms ?? null)}</Text>
+        </div>
+        <div className="border rounded p-3">
+          <Text size="xsmall" className="text-ui-fg-subtle">Status buckets</Text>
+          <Text size="large">{Object.keys(data?.by_status ?? {}).length}</Text>
+        </div>
+      </div>
+
+      <Heading level="h2" className="mt-6">By check status</Heading>
+      <div className="mt-2 space-y-2">
+        {data?.by_status && Object.keys(data.by_status).length > 0 ? (
+          Object.entries(data.by_status).map(([status, count]) => (
+            <div key={status} className="border rounded p-3 flex justify-between">
+              <Text>{status}</Text>
+              <Text>{count}</Text>
+            </div>
+          ))
+        ) : (
+          <Text className="text-ui-fg-subtle">No verification checks recorded yet.</Text>
+        )}
+      </div>
+
+      <Heading level="h2" className="mt-6">By verification level</Heading>
+      <div className="mt-2 space-y-2">
+        {data?.by_level && Object.keys(data.by_level).length > 0 ? (
+          Object.entries(data.by_level).map(([level, count]) => (
+            <div key={level} className="border rounded p-3 flex justify-between">
+              <Text>{level}</Text>
+              <Text>{count}</Text>
+            </div>
+          ))
+        ) : (
+          <Text className="text-ui-fg-subtle">No verifications recorded yet.</Text>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "—"
+  const hours = Math.floor(ms / (60 * 60 * 1000))
+  const minutes = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000))
+  if (hours > 24) {
+    const days = Math.floor(hours / 24)
+    return `${days}d ${hours % 24}h`
+  }
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+export const Component = VendorVerificationPage
+export default VendorVerificationPage

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "description": "A starter for Medusa projects.",
   "author": "Medusa (https://medusajs.com)",
   "license": "MIT",
+  "packageManager": "pnpm@10.13.1",
   "keywords": [
     "sqlite",
     "postgres",

--- a/backend/src/api/admin/vendor-verification/funnel/route.ts
+++ b/backend/src/api/admin/vendor-verification/funnel/route.ts
@@ -1,0 +1,17 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { VENDOR_VERIFICATION_MODULE } from "../../../../modules/vendor-verification"
+import type VendorVerificationService from "../../../../modules/vendor-verification/service"
+
+/**
+ * GET /admin/vendor-verification/funnel
+ *
+ * Returns the funnel summary the admin Verification page renders:
+ * counts by check status, counts by verification level, total
+ * verification records, and the median time-to-verify in milliseconds
+ * computed across all PASSED checks.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const service = req.scope.resolve<VendorVerificationService>(VENDOR_VERIFICATION_MODULE)
+  const funnel = await service.getVerificationFunnel()
+  res.json(funnel)
+}

--- a/backend/src/api/v1/integrations/blackout/entitlements/economic-standing/route.ts
+++ b/backend/src/api/v1/integrations/blackout/entitlements/economic-standing/route.ts
@@ -1,16 +1,24 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import {
   isBlackoutIntegrationEnabled,
   verifyBlackoutToken,
 } from "../../../../../../lib/blackout-oauth"
+import { HAWALA_LEDGER_MODULE } from "../../../../../../modules/hawala-ledger"
+import type HawalaLedgerModuleService from "../../../../../../modules/hawala-ledger/service"
 
 /**
  * Economic-standing endpoint per `docs/contracts/entitlements.yaml` §2.5.
  *
- * Foundation milestone: depends on the Coalition Credits ledger UX,
- * payout-breakdown extension, and creator-rewards eligibility surface that
- * are scoped in AGGRESSIVE_OPERATIONS_GUIDE.md §5.1. Returns 501 with
- * `code: foundation_milestone` until those workstreams ship.
+ * Returns the EconomicStanding shape: Coalition Credits balance (sum of
+ * available + pending across the MXID's wallet/earnings accounts), payout
+ * summary with the next payout window, vendor sales summary for the
+ * current measurement period, and creator-rewards eligibility flags.
+ *
+ * Resolution path: MXID → seller_metadata.mxid (workstream 1) and/or
+ * customer.metadata.mxid → ledger accounts. Empty totals are a valid
+ * response, not a 404 — a fresh MXID with no transactions is expected
+ * during foundation milestone.
  */
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
   if (!isBlackoutIntegrationEnabled()) {
@@ -27,9 +35,62 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     return res.status(401).json({ code: "unauthorized", message: "Invalid or missing Bearer token" })
   }
 
-  return res.status(501).json({
-    code: "foundation_milestone",
-    message:
-      "Economic standing endpoint is contractually defined but pending the Coalition Credits ledger UX and payout-breakdown extension scoped in AGGRESSIVE_OPERATIONS_GUIDE.md §5.1.",
+  const mxid = String(req.query.mxid || "").trim()
+  if (!mxid) {
+    return res.status(400).json({ code: "bad_request", message: "mxid is required" })
+  }
+
+  const hawala = req.scope.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (sql: string, bindings?: unknown[]) => Promise<{ rows?: Array<Record<string, unknown>> }>
+  }
+
+  const standing = await hawala.getEconomicStandingByMxid({ mxid, pgConnection })
+
+  const sellerEarningsSources = standing.sources.filter(
+    (s) => s.account_type === "SELLER_EARNINGS"
+  )
+  const creatorEarningsSources = standing.sources.filter(
+    (s) => s.account_type === "CREATOR_EARNINGS"
+  )
+  const grossSellerVolume = sellerEarningsSources.reduce(
+    (sum, s) => sum + s.available + s.pending,
+    0
+  )
+
+  res.json({
+    mxid,
+    coalition_credits: {
+      available: Math.round(standing.available),
+      pending: Math.round(standing.pending),
+      currency: standing.currency,
+      last_settlement_at: standing.last_settlement_at,
+    },
+    payouts: {
+      pending_amount: Math.round(
+        sellerEarningsSources.reduce((sum, s) => sum + s.pending, 0)
+      ),
+      currency: standing.currency,
+      next_payout_at: null,
+    },
+    vendor_sales: {
+      period: measurementPeriodLabel(new Date()),
+      gross_volume: Math.round(grossSellerVolume),
+      net_volume: Math.round(
+        sellerEarningsSources.reduce((sum, s) => sum + s.available, 0)
+      ),
+      currency: standing.currency,
+    },
+    creator_rewards: {
+      eligible: creatorEarningsSources.length > 0,
+      program_keys: creatorEarningsSources.length > 0 ? ["creator-rewards"] : [],
+    },
+    evaluated_at: new Date().toISOString(),
   })
+}
+
+function measurementPeriodLabel(d: Date): string {
+  const year = d.getUTCFullYear()
+  const quarter = Math.floor(d.getUTCMonth() / 3) + 1
+  return `${year}-Q${quarter}`
 }

--- a/backend/src/api/v1/integrations/blackout/entitlements/governance-roles/route.ts
+++ b/backend/src/api/v1/integrations/blackout/entitlements/governance-roles/route.ts
@@ -3,14 +3,16 @@ import {
   isBlackoutIntegrationEnabled,
   verifyBlackoutToken,
 } from "../../../../../../lib/blackout-oauth"
+import { ENTITLEMENT_MODULE } from "../../../../../../modules/entitlement"
+import type EntitlementModuleService from "../../../../../../modules/entitlement/service"
 
 /**
  * Governance-roles endpoint per `docs/contracts/entitlements.yaml` §2.5.
  *
- * Foundation milestone: depends on the cooperative + governance modules'
- * Matrix-ACL synchronization and the MXID-keyed vendor-roles revision
- * scoped in AGGRESSIVE_OPERATIONS_GUIDE.md §2.1 and §5.1. Returns 501 with
- * `code: foundation_milestone` until those workstreams ship.
+ * Returns the roles, vote eligibility, Synapse power-level intent, and
+ * derived FBM commerce permissions for an MXID. Coalition-side roles are
+ * read off the entitlement table as `governance.role.<role>.<coalition_id>`
+ * grants; the static role→permission map lives in the entitlement service.
  */
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
   if (!isBlackoutIntegrationEnabled()) {
@@ -27,9 +29,12 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     return res.status(401).json({ code: "unauthorized", message: "Invalid or missing Bearer token" })
   }
 
-  return res.status(501).json({
-    code: "foundation_milestone",
-    message:
-      "Governance roles endpoint is contractually defined but pending the cooperative/governance Matrix-ACL synchronization and vendor-roles MXID revision scoped in AGGRESSIVE_OPERATIONS_GUIDE.md §2.1 and §5.1.",
-  })
+  const mxid = String(req.query.mxid || "").trim()
+  if (!mxid) {
+    return res.status(400).json({ code: "bad_request", message: "mxid is required" })
+  }
+
+  const service = req.scope.resolve<EntitlementModuleService>(ENTITLEMENT_MODULE)
+  const snapshot = await service.getGovernanceRoles(mxid)
+  return res.json(snapshot)
 }

--- a/backend/src/jobs/hawala-settlement.ts
+++ b/backend/src/jobs/hawala-settlement.ts
@@ -1,7 +1,12 @@
 import { MedusaContainer } from "@medusajs/framework/types"
 import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
-import { createStellarSettlementService } from "../modules/hawala-ledger/stellar-settlement"
+import {
+  createStellarSettlementService,
+  stellarMetrics,
+} from "../modules/hawala-ledger/stellar-settlement"
+import { selectSettlementRail } from "../modules/hawala-ledger/dual-rail-selector"
+import { getBridgeHealth } from "../modules/hawala-ledger/health"
 import { runQueueConsumer } from "../shared/queue-runtime"
 import { requeueWithBackoff } from "../shared/queue-requeue-adapter"
 
@@ -74,8 +79,50 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
       payload: invoiceEvent,
       idempotencyKey: invoiceEvent.invoice_id,
       handler: async () => {
-        // Submit to Stellar
+        // Dual-rail selection: pick Stripe-ACH vs Stellar-USDC based on
+        // bridge health and amount. Stripe-ACH leg is intentionally
+        // out of scope here; the selector logs the decision so ops can
+        // see why Stellar was (or was not) chosen.
         const stellarService = createStellarSettlementService()
+        const lastBatch = existingBatches[existingBatches.length - 1]
+        const lastBatchStatus = lastBatch
+          ? lastBatch.status === "FAILED"
+            ? "failed" as const
+            : lastBatch.status === "PENDING"
+              ? "pending" as const
+              : "succeeded" as const
+          : "unknown" as const
+        const health = await getBridgeHealth({
+          service: stellarService,
+          lastBatchStatus,
+        })
+        const decision = selectSettlementRail({
+          amount: totalVolume,
+          currency: "USDC",
+          health,
+        })
+        stellarMetrics.inc("stellar.dual_rail_decision", {
+          rail: decision.rail,
+          batch_id: batch.id,
+        })
+        console.log(
+          `[Hawala Settlement] Dual-rail decision: ${decision.rail} (` +
+            decision.reasons.map((r) => `${r.check}=${r.outcome}`).join(", ") +
+            `)`
+        )
+
+        if (decision.rail === "stripe_ach") {
+          await hawalaService.updateSettlementBatches({
+            id: batch.id,
+            status: "PENDING",
+            metadata: {
+              dual_rail_decision: "stripe_ach",
+              dual_rail_reasons: decision.reasons,
+              note: "Stripe-ACH leg pending operator action; Stellar bridge skipped",
+            },
+          })
+          return
+        }
 
         const stellarResult = await stellarService.submitSettlementBatch({
           batchId: batch.id,

--- a/backend/src/lib/__tests__/instrumentation.unit.spec.ts
+++ b/backend/src/lib/__tests__/instrumentation.unit.spec.ts
@@ -1,0 +1,50 @@
+import {
+  emitMetric,
+  resetMetricsForTesting,
+  snapshotMetrics,
+} from "../instrumentation"
+
+describe("instrumentation", () => {
+  beforeEach(() => {
+    resetMetricsForTesting()
+  })
+
+  it("counts emissions of the same (name, labels) pair", () => {
+    const stderr = jest.spyOn(console, "warn").mockImplementation(() => {})
+    emitMetric("vendor.verification.submitted", { check_type: "IDENTITY" })
+    emitMetric("vendor.verification.submitted", { check_type: "IDENTITY" })
+    emitMetric("vendor.verification.submitted", { check_type: "LOCATION" })
+
+    const snap = snapshotMetrics()
+    const identity = snap.find(
+      (m) =>
+        m.name === "vendor.verification.submitted" &&
+        m.labels.check_type === "IDENTITY"
+    )
+    const location = snap.find(
+      (m) =>
+        m.name === "vendor.verification.submitted" &&
+        m.labels.check_type === "LOCATION"
+    )
+    expect(identity?.value).toBe(2)
+    expect(location?.value).toBe(1)
+    expect(stderr).toHaveBeenCalledTimes(3)
+    stderr.mockRestore()
+  })
+
+  it("treats label key order as irrelevant", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+    emitMetric("m", { a: 1, b: 2 })
+    emitMetric("m", { b: 2, a: 1 })
+    const snap = snapshotMetrics()
+    expect(snap.filter((s) => s.name === "m")).toHaveLength(1)
+    expect(snap.find((s) => s.name === "m")?.value).toBe(2)
+  })
+
+  it("supports custom non-1 increments", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+    emitMetric("vendor.verification.trust_score", { level: "AUDITED" }, 75)
+    const snap = snapshotMetrics()
+    expect(snap.find((s) => s.name === "vendor.verification.trust_score")?.value).toBe(75)
+  })
+})

--- a/backend/src/lib/instrumentation.ts
+++ b/backend/src/lib/instrumentation.ts
@@ -1,0 +1,67 @@
+/**
+ * Lightweight instrumentation surface for FBM modules.
+ *
+ * Today: emits structured-JSON log lines on stderr that grep / jq
+ * pipelines can read, plus a process-level in-memory counter map an
+ * `/admin/.../metrics` route can read. This is intentionally
+ * dependency-free so the same call sites work whether `prom-client` or
+ * `@opentelemetry/api` is later wired in.
+ *
+ * Migration plan: when `prom-client` lands in deps, swap the body of
+ * `emitMetric` for a `Counter`/`Histogram` registry; keep the call-site
+ * shape stable so call sites need no further change.
+ */
+
+const counters = new Map<string, number>()
+
+export function emitMetric(
+  name: string,
+  labels: Record<string, string | number | boolean> = {},
+  value = 1
+): void {
+  const key = stableKey(name, labels)
+  counters.set(key, (counters.get(key) ?? 0) + value)
+  const payload = {
+    metric: name,
+    value,
+    labels,
+    ts: new Date().toISOString(),
+  }
+  // eslint-disable-next-line no-console -- structured-metric sink
+  console.warn(JSON.stringify(payload))
+}
+
+export function snapshotMetrics(): Array<{
+  name: string
+  labels: Record<string, string | number | boolean>
+  value: number
+}> {
+  const out: Array<{
+    name: string
+    labels: Record<string, string | number | boolean>
+    value: number
+  }> = []
+  for (const [key, value] of counters.entries()) {
+    const [name, labelsJson] = key.split("\x01")
+    out.push({
+      name,
+      labels: labelsJson ? (JSON.parse(labelsJson) as Record<string, string | number | boolean>) : {},
+      value,
+    })
+  }
+  return out
+}
+
+export function resetMetricsForTesting(): void {
+  counters.clear()
+}
+
+function stableKey(
+  name: string,
+  labels: Record<string, string | number | boolean>
+): string {
+  const sortedKeys = Object.keys(labels).sort()
+  const sorted: Record<string, string | number | boolean> = {}
+  for (const k of sortedKeys) sorted[k] = labels[k]
+  return `${name}\x01${JSON.stringify(sorted)}`
+}

--- a/backend/src/modules/entitlement/__tests__/entitlement-service.unit.spec.ts
+++ b/backend/src/modules/entitlement/__tests__/entitlement-service.unit.spec.ts
@@ -239,14 +239,12 @@ describe("EntitlementModuleService", () => {
       expect(decision.reasons.some((r) => r.detail?.includes("listing.write.prod_1"))).toBe(true)
     })
 
-    it("evaluateAccess() returns foundation_milestone_pending for non-listing resource kinds", async () => {
+    it("evaluateAccess() returns foundation_milestone_pending for resource kinds whose substrate is still pending", async () => {
       const svc = makeService()
       for (const kind of [
         "matrix-room",
-        "governance-proposal",
         "fulfillment-node",
         "ledger-tx",
-        "platform-admin",
       ] as const) {
         const decision = await svc.evaluateAccess({
           mxid: MXID,
@@ -259,6 +257,97 @@ describe("EntitlementModuleService", () => {
         expect(skip?.outcome).toBe("skip")
         expect(skip?.detail).toBe("foundation_milestone_pending")
       }
+    })
+
+    it("evaluateAccess() denies governance-proposal.vote without a derived governance permission", async () => {
+      const svc = makeService()
+      const decision = await svc.evaluateAccess({
+        mxid: MXID,
+        resourceKind: "governance-proposal",
+        resourceId: "prop_1",
+        action: "write",
+      })
+      expect(decision.allowed).toBe(false)
+      expect(decision.reasons.some((r) => r.check === "governance-proposal.write")).toBe(true)
+    })
+
+    it("evaluateAccess() permits governance-proposal.vote derived from a member role grant", async () => {
+      const svc = makeService()
+      await svc.grant({
+        customer_external_id: MXID,
+        feature_key: "governance.role.member.coalition_alpha",
+        source_order_id: "ord_role",
+        product_id: "role_member",
+      })
+      const decision = await svc.evaluateAccess({
+        mxid: MXID,
+        resourceKind: "governance-proposal",
+        resourceId: "prop_1",
+        action: "write",
+      })
+      expect(decision.allowed).toBe(true)
+    })
+
+    it("evaluateAccess() permits platform-admin only with a platform.admin grant", async () => {
+      const svc = makeService()
+      const denied = await svc.evaluateAccess({
+        mxid: MXID,
+        resourceKind: "platform-admin",
+        resourceId: "any",
+        action: "admin",
+      })
+      expect(denied.allowed).toBe(false)
+
+      await svc.grant({
+        customer_external_id: MXID,
+        feature_key: "platform.admin",
+        source_order_id: "ord_admin",
+        product_id: "p_admin",
+      })
+      const allowed = await svc.evaluateAccess({
+        mxid: MXID,
+        resourceKind: "platform-admin",
+        resourceId: "any",
+        action: "admin",
+      })
+      expect(allowed.allowed).toBe(true)
+    })
+
+    it("getGovernanceRoles() reads governance.role.<role>.<coalition> grants and derives FBM permissions", async () => {
+      const svc = makeService()
+      await svc.grant({
+        customer_external_id: MXID,
+        feature_key: "governance.role.steward.coalition_alpha",
+        source_order_id: "ord_a",
+        product_id: "p_a",
+      })
+      await svc.grant({
+        customer_external_id: MXID,
+        feature_key: "governance.role.member.coalition_beta",
+        source_order_id: "ord_b",
+        product_id: "p_b",
+      })
+
+      const snapshot = await svc.getGovernanceRoles(MXID)
+      expect(snapshot.mxid).toBe(MXID)
+      expect(snapshot.roles).toHaveLength(2)
+
+      const steward = snapshot.roles.find((r) => r.role === "steward")
+      expect(steward?.coalition_id).toBe("coalition_alpha")
+      expect(steward?.fbm_permissions).toEqual(
+        expect.arrayContaining(["listing.create", "governance.proposal.create"])
+      )
+      expect(steward?.matrix_acls.find((a) => a.room_id === "!coalition_alpha-governance")?.level).toBe(50)
+
+      const member = snapshot.roles.find((r) => r.role === "member")
+      expect(member?.coalition_id).toBe("coalition_beta")
+      expect(member?.fbm_permissions).toEqual(expect.arrayContaining(["governance.proposal.vote"]))
+    })
+
+    it("getGovernanceRoles() returns an empty role list when the MXID holds no role grants", async () => {
+      const svc = makeService()
+      const snapshot = await svc.getGovernanceRoles(MXID)
+      expect(snapshot.roles).toEqual([])
     })
   })
 })

--- a/backend/src/modules/entitlement/service.ts
+++ b/backend/src/modules/entitlement/service.ts
@@ -11,6 +11,78 @@ import {
 export type EntitlementType = InferTypeOf<typeof Entitlement>
 export type EntitlementGrantRuleType = InferTypeOf<typeof EntitlementGrantRule>
 
+/**
+ * Static governance-role → FBM commerce-permission mapping per
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §2.1. Roles are Matrix-side names; the
+ * permission keys here are the FBM-side feature keys the entitlements
+ * service answers `evaluateAccess` against. Keep flat and explicit; if
+ * this grows past one screen, replace with a Casbin policy file.
+ */
+const GOVERNANCE_FBM_PERMISSIONS: Record<string, string[]> = {
+  vendor: ["listing.create", "listing.write", "order.fulfill", "payout.withdraw"],
+  steward: [
+    "listing.create",
+    "listing.write",
+    "order.fulfill",
+    "payout.withdraw",
+    "governance.proposal.create",
+    "coalition.member.invite",
+  ],
+  member: ["listing.read", "governance.proposal.vote"],
+  observer: ["listing.read"],
+}
+
+const GOVERNANCE_VOTE_ELIGIBILITY: Record<string, string[]> = {
+  vendor: ["finance", "operations"],
+  steward: ["finance", "operations", "membership", "constitution"],
+  member: ["finance", "operations", "membership"],
+  observer: [],
+}
+
+/**
+ * Synapse power level a role implies inside the coalition's governance
+ * room. Default is 0 (member). 50 is moderator-equivalent and 100 is
+ * room-admin-equivalent in the standard Matrix power-level model.
+ */
+const GOVERNANCE_POWER_LEVEL: Record<string, number> = {
+  vendor: 25,
+  steward: 50,
+  member: 0,
+  observer: 0,
+}
+
+function matrixAclsForRole(
+  role: string,
+  coalitionId: string
+): Array<{ room_id: string; level: number }> {
+  const level = GOVERNANCE_POWER_LEVEL[role] ?? 0
+  // Convention: every coalition has a `governance` room and a `commerce`
+  // room. The Blackout side owns the actual room IDs; we just expose
+  // intent here as `!<coalition>:<room>` style refs that Blackout can
+  // resolve against its room directory.
+  return [
+    { room_id: `!${coalitionId}-governance`, level },
+    { room_id: `!${coalitionId}-commerce`, level },
+  ]
+}
+
+function derivedPermissionsFromGrants(
+  grants: Array<{ feature_key: string }>
+): Set<string> {
+  const out = new Set<string>()
+  for (const g of grants) {
+    out.add(g.feature_key)
+    const parts = g.feature_key.split(".")
+    if (parts[0] === "governance" && parts[1] === "role" && parts.length >= 4) {
+      const role = parts[2]
+      for (const perm of GOVERNANCE_FBM_PERMISSIONS[role] ?? []) {
+        out.add(perm)
+      }
+    }
+  }
+  return out
+}
+
 export type GrantInput = {
   customer_id?: string | null
   customer_external_id?: string | null
@@ -307,11 +379,44 @@ class EntitlementModuleService extends MedusaService({
         })
         return { allowed: false, reasons, evaluated_at }
       }
+      case "governance-proposal": {
+        const required = `governance.proposal.${input.action === "read" ? "read" : input.action === "write" ? "vote" : "create"}`
+        const derived = derivedPermissionsFromGrants(live)
+        if (derived.has(required) || derived.has("governance.proposal.create")) {
+          reasons.push({
+            check: `governance-proposal.${input.action}`,
+            outcome: "pass",
+            detail: `derived permission ${required}`,
+          })
+          return { allowed: true, reasons, evaluated_at }
+        }
+        reasons.push({
+          check: `governance-proposal.${input.action}`,
+          outcome: "fail",
+          detail: `no governance role grants ${required}`,
+        })
+        return { allowed: false, reasons, evaluated_at }
+      }
+      case "platform-admin": {
+        const adminMatch = live.find((e) => e.feature_key === "platform.admin")
+        if (adminMatch) {
+          reasons.push({
+            check: "platform-admin",
+            outcome: "pass",
+            detail: `granted by feature_key=${adminMatch.feature_key}`,
+          })
+          return { allowed: true, reasons, evaluated_at }
+        }
+        reasons.push({
+          check: "platform-admin",
+          outcome: "fail",
+          detail: "no platform.admin grant",
+        })
+        return { allowed: false, reasons, evaluated_at }
+      }
       case "matrix-room":
-      case "governance-proposal":
       case "fulfillment-node":
       case "ledger-tx":
-      case "platform-admin":
         reasons.push({
           check: input.resourceKind,
           outcome: "skip",
@@ -319,6 +424,70 @@ class EntitlementModuleService extends MedusaService({
         })
         return { allowed: false, reasons, evaluated_at }
     }
+  }
+
+  /**
+   * Render a governance-roles snapshot for an MXID per the §2.5 contract.
+   *
+   * The role→permission mapping is intentionally a static table here.
+   * Casbin or similar is reserved for the moment this outgrows a screen —
+   * see plan workstream 1 OSS leverage notes. Coalition membership
+   * resolution itself remains foundation_milestone_pending until the
+   * `cooperative` module exposes membership; this method returns the
+   * derived FBM permissions and Synapse power-level intent for any roles
+   * the entitlement table already records as feature_keys of the form
+   * `governance.role.<role>.<coalition_id>`.
+   */
+  async getGovernanceRoles(mxid: string): Promise<{
+    mxid: string
+    roles: Array<{
+      coalition_id: string
+      role: string
+      vote_eligibility: string[]
+      matrix_acls: Array<{ room_id: string; level: number }>
+      fbm_permissions: string[]
+    }>
+    evaluated_at: string
+  }> {
+    const evaluated_at = new Date().toISOString()
+    if (!mxid) {
+      return { mxid: "", roles: [], evaluated_at }
+    }
+    const grants = await this.listGrantsByMxid(mxid, {
+      status: EntitlementStatus.ACTIVE,
+    })
+    const now = Date.now()
+    const live = grants.filter(
+      (e) => !e.expires_at || new Date(e.expires_at).getTime() > now
+    )
+
+    const rolesByCoalition = new Map<
+      string,
+      { role: string; coalition_id: string }
+    >()
+    for (const g of live) {
+      const parts = g.feature_key.split(".")
+      if (parts[0] === "governance" && parts[1] === "role" && parts.length >= 4) {
+        const role = parts[2]
+        const coalition_id = parts.slice(3).join(".")
+        const key = `${coalition_id}::${role}`
+        if (!rolesByCoalition.has(key)) {
+          rolesByCoalition.set(key, { role, coalition_id })
+        }
+      }
+    }
+
+    const roles = Array.from(rolesByCoalition.values()).map(
+      ({ role, coalition_id }) => ({
+        coalition_id,
+        role,
+        vote_eligibility: GOVERNANCE_VOTE_ELIGIBILITY[role] ?? [],
+        matrix_acls: matrixAclsForRole(role, coalition_id),
+        fbm_permissions: GOVERNANCE_FBM_PERMISSIONS[role] ?? [],
+      })
+    )
+
+    return { mxid, roles, evaluated_at }
   }
 
   private async findApplicableRules(args: {

--- a/backend/src/modules/hawala-ledger/__tests__/dual-rail-selector.unit.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/dual-rail-selector.unit.spec.ts
@@ -1,0 +1,80 @@
+import { selectSettlementRail } from "../dual-rail-selector"
+
+const healthyHealth = {
+  horizon_reachable: true,
+  usdc_balance: 1_000_000,
+  last_batch_status: "succeeded" as const,
+}
+
+describe("selectSettlementRail", () => {
+  it("forces Stripe-ACH for non-USD/USDC currencies", () => {
+    const result = selectSettlementRail({
+      amount: 100,
+      currency: "EUR",
+      health: healthyHealth,
+    })
+    expect(result.rail).toBe("stripe_ach")
+    expect(result.reasons.find((r) => r.check === "currency")?.outcome).toBe("fail")
+  })
+
+  it("forces Stripe-ACH below the minimum Stellar amount", () => {
+    const result = selectSettlementRail({
+      amount: 0.5,
+      currency: "USD",
+      health: healthyHealth,
+    })
+    expect(result.rail).toBe("stripe_ach")
+    expect(result.reasons.find((r) => r.check === "amount_threshold")?.outcome).toBe("fail")
+  })
+
+  it("forces Stripe-ACH when Horizon is unreachable", () => {
+    const result = selectSettlementRail({
+      amount: 100,
+      currency: "USDC",
+      health: { ...healthyHealth, horizon_reachable: false },
+    })
+    expect(result.rail).toBe("stripe_ach")
+    expect(result.reasons.find((r) => r.check === "horizon_reachable")?.outcome).toBe("fail")
+  })
+
+  it("forces Stripe-ACH when the last batch failed", () => {
+    const result = selectSettlementRail({
+      amount: 100,
+      currency: "USDC",
+      health: { ...healthyHealth, last_batch_status: "failed" },
+    })
+    expect(result.rail).toBe("stripe_ach")
+    expect(result.reasons.find((r) => r.check === "last_batch_status")?.outcome).toBe("fail")
+  })
+
+  it("forces Stripe-ACH when bridge USDC liquidity is below the amount", () => {
+    const result = selectSettlementRail({
+      amount: 5_000,
+      currency: "USDC",
+      health: { ...healthyHealth, usdc_balance: 100 },
+    })
+    expect(result.rail).toBe("stripe_ach")
+    expect(result.reasons.find((r) => r.check === "usdc_liquidity")?.outcome).toBe("fail")
+  })
+
+  it("picks Stellar-USDC when all checks pass", () => {
+    const result = selectSettlementRail({
+      amount: 100,
+      currency: "USDC",
+      health: healthyHealth,
+    })
+    expect(result.rail).toBe("stellar_usdc")
+    expect(result.reasons.every((r) => r.outcome === "pass")).toBe(true)
+  })
+
+  it("honors operator forceRail override regardless of health", () => {
+    const result = selectSettlementRail({
+      amount: 100,
+      currency: "EUR",
+      health: { ...healthyHealth, horizon_reachable: false },
+      forceRail: "stellar_usdc",
+    })
+    expect(result.rail).toBe("stellar_usdc")
+    expect(result.reasons[0].check).toBe("force_rail")
+  })
+})

--- a/backend/src/modules/hawala-ledger/__tests__/economic-standing.unit.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/economic-standing.unit.spec.ts
@@ -1,0 +1,163 @@
+import HawalaLedgerModuleService from "../service"
+
+/**
+ * Unit-tests `getEconomicStandingByMxid` against in-memory fakes for the
+ * pg connection (used to resolve MXID → seller_id / customer_id) and the
+ * MedusaService CRUD ops (used to read ledger accounts and entries).
+ */
+function makeService(args: {
+  sellerMetadata?: Array<{ seller_id: string; mxid: string }>
+  customers?: Array<{ id: string; mxid: string }>
+  ledgerAccounts?: Array<{
+    id: string
+    owner_id: string | null
+    owner_type: string | null
+    account_type: string
+    available_balance: number
+    pending_balance: number
+    currency_code: string
+  }>
+  ledgerEntries?: Array<{
+    id: string
+    debit_account_id?: string | null
+    credit_account_id?: string | null
+    entry_type: string
+    created_at: string
+  }>
+}) {
+  const svc = Object.create(
+    HawalaLedgerModuleService.prototype
+  ) as HawalaLedgerModuleService
+
+  ;(svc as unknown as {
+    listLedgerAccounts: (filters: Record<string, unknown>) => Promise<unknown[]>
+  }).listLedgerAccounts = async (filters) => {
+    const accounts = args.ledgerAccounts ?? []
+    if (filters.owner_id && Array.isArray(filters.owner_id)) {
+      const ids = filters.owner_id as string[]
+      return accounts.filter((a) => a.owner_id && ids.includes(a.owner_id))
+    }
+    return accounts
+  }
+
+  ;(svc as unknown as {
+    listLedgerEntries: (filters: Record<string, unknown>) => Promise<unknown[]>
+  }).listLedgerEntries = async (filters) => {
+    const entries = args.ledgerEntries ?? []
+    if (filters.credit_account_id && Array.isArray(filters.credit_account_id)) {
+      const ids = filters.credit_account_id as string[]
+      return entries.filter(
+        (e) => e.credit_account_id && ids.includes(e.credit_account_id)
+      )
+    }
+    return entries
+  }
+
+  const pgConnection = {
+    raw: async (sql: string, bindings?: unknown[]) => {
+      const mxid = (bindings?.[0] as string) ?? ""
+      if (sql.includes("seller_metadata")) {
+        const hit = (args.sellerMetadata ?? []).find((s) => s.mxid === mxid)
+        return { rows: hit ? [{ seller_id: hit.seller_id }] : [] }
+      }
+      if (sql.includes("customer")) {
+        const hit = (args.customers ?? []).find((c) => c.mxid === mxid)
+        return { rows: hit ? [{ id: hit.id }] : [] }
+      }
+      return { rows: [] }
+    },
+  }
+
+  return { svc, pgConnection }
+}
+
+describe("HawalaLedgerModuleService.getEconomicStandingByMxid", () => {
+  const MXID = "@alice:bmc.example"
+
+  it("returns zero totals when the MXID resolves to no accounts", async () => {
+    const { svc, pgConnection } = makeService({})
+    const result = await svc.getEconomicStandingByMxid({ mxid: MXID, pgConnection })
+    expect(result.available).toBe(0)
+    expect(result.pending).toBe(0)
+    expect(result.sources).toEqual([])
+    expect(result.last_settlement_at).toBeNull()
+  })
+
+  it("sums available + pending across SELLER_EARNINGS and USER_WALLET", async () => {
+    const { svc, pgConnection } = makeService({
+      sellerMetadata: [{ seller_id: "seller_1", mxid: MXID }],
+      customers: [{ id: "cus_1", mxid: MXID }],
+      ledgerAccounts: [
+        {
+          id: "acc_seller",
+          owner_id: "seller_1",
+          owner_type: "SELLER",
+          account_type: "SELLER_EARNINGS",
+          available_balance: 1500,
+          pending_balance: 250,
+          currency_code: "USD",
+        },
+        {
+          id: "acc_wallet",
+          owner_id: "cus_1",
+          owner_type: "CUSTOMER",
+          account_type: "USER_WALLET",
+          available_balance: 50,
+          pending_balance: 0,
+          currency_code: "USD",
+        },
+      ],
+    })
+
+    const result = await svc.getEconomicStandingByMxid({ mxid: MXID, pgConnection })
+    expect(result.available).toBe(1550)
+    expect(result.pending).toBe(250)
+    expect(result.currency).toBe("USD")
+    expect(result.sources).toHaveLength(2)
+    expect(result.sources.map((s) => s.account_type).sort()).toEqual([
+      "SELLER_EARNINGS",
+      "USER_WALLET",
+    ])
+  })
+
+  it("surfaces the most recent SETTLEMENT entry as last_settlement_at", async () => {
+    const { svc, pgConnection } = makeService({
+      sellerMetadata: [{ seller_id: "seller_1", mxid: MXID }],
+      ledgerAccounts: [
+        {
+          id: "acc_seller",
+          owner_id: "seller_1",
+          owner_type: "SELLER",
+          account_type: "SELLER_EARNINGS",
+          available_balance: 100,
+          pending_balance: 0,
+          currency_code: "USDC",
+        },
+      ],
+      ledgerEntries: [
+        {
+          id: "e1",
+          credit_account_id: "acc_seller",
+          entry_type: "PAYOUT",
+          created_at: "2026-04-30T00:00:00.000Z",
+        },
+        {
+          id: "e2",
+          credit_account_id: "acc_seller",
+          entry_type: "SETTLEMENT",
+          created_at: "2026-05-01T00:00:00.000Z",
+        },
+        {
+          id: "e3",
+          credit_account_id: "acc_seller",
+          entry_type: "SETTLEMENT",
+          created_at: "2026-05-09T12:00:00.000Z",
+        },
+      ],
+    })
+
+    const result = await svc.getEconomicStandingByMxid({ mxid: MXID, pgConnection })
+    expect(result.last_settlement_at).toBe("2026-05-09T12:00:00.000Z")
+    expect(result.currency).toBe("USDC")
+  })
+})

--- a/backend/src/modules/hawala-ledger/dual-rail-selector.ts
+++ b/backend/src/modules/hawala-ledger/dual-rail-selector.ts
@@ -1,0 +1,120 @@
+/**
+ * Dual-rail settlement selector per AGGRESSIVE_OPERATIONS_GUIDE.md §5.1.
+ *
+ * Picks Stripe-ACH or Stellar-USDC for a given settlement amount based on
+ * currency, amount thresholds, and current bridge health. Pure function;
+ * no I/O. Callers (jobs, settlement routes) snapshot bridge health
+ * separately via `getBridgeHealth()` and feed it in here.
+ *
+ * Selection rules in order:
+ *   1. If the currency is not USD/USDC, force Stripe-ACH (Stellar bridge
+ *      only supports USDC today).
+ *   2. If the amount is below `minStellarAmount`, force Stripe-ACH —
+ *      Stellar transaction fees are flat in stroops, but for sub-dollar
+ *      amounts the Stripe fee is competitive and avoids on-chain noise.
+ *   3. If the bridge is unhealthy or USDC liquidity is below the
+ *      requested amount, force Stripe-ACH.
+ *   4. Otherwise, prefer Stellar-USDC.
+ */
+
+export type Rail = "stripe_ach" | "stellar_usdc"
+
+export type BridgeHealthSnapshot = {
+  horizon_reachable: boolean
+  usdc_balance: number
+  last_batch_status: "succeeded" | "pending" | "failed" | "unknown"
+}
+
+export type SelectorInput = {
+  amount: number
+  currency: string
+  health: BridgeHealthSnapshot
+  /**
+   * Settlements below this amount route through Stripe-ACH even when
+   * the Stellar bridge is healthy. Default 1.00 USD.
+   */
+  minStellarAmount?: number
+  /**
+   * Force a particular rail regardless of automatic selection. Operators
+   * use this for incident response (e.g., disable Stellar entirely
+   * during a network freeze). Defaults to none.
+   */
+  forceRail?: Rail
+}
+
+export type SelectorDecision = {
+  rail: Rail
+  reasons: Array<{ check: string; outcome: "pass" | "fail" | "skip"; detail?: string }>
+}
+
+export function selectSettlementRail(input: SelectorInput): SelectorDecision {
+  const reasons: SelectorDecision["reasons"] = []
+
+  if (input.forceRail) {
+    return {
+      rail: input.forceRail,
+      reasons: [
+        { check: "force_rail", outcome: "pass", detail: `forced by operator: ${input.forceRail}` },
+      ],
+    }
+  }
+
+  const minStellar = input.minStellarAmount ?? 1.0
+  const currency = input.currency.toUpperCase()
+
+  if (currency !== "USD" && currency !== "USDC") {
+    reasons.push({
+      check: "currency",
+      outcome: "fail",
+      detail: `${currency} not supported on Stellar bridge; routing Stripe-ACH`,
+    })
+    return { rail: "stripe_ach", reasons }
+  }
+  reasons.push({ check: "currency", outcome: "pass" })
+
+  if (input.amount < minStellar) {
+    reasons.push({
+      check: "amount_threshold",
+      outcome: "fail",
+      detail: `amount ${input.amount} < minStellarAmount ${minStellar}; routing Stripe-ACH`,
+    })
+    return { rail: "stripe_ach", reasons }
+  }
+  reasons.push({ check: "amount_threshold", outcome: "pass" })
+
+  if (!input.health.horizon_reachable) {
+    reasons.push({
+      check: "horizon_reachable",
+      outcome: "fail",
+      detail: "Horizon unreachable; routing Stripe-ACH",
+    })
+    return { rail: "stripe_ach", reasons }
+  }
+  reasons.push({ check: "horizon_reachable", outcome: "pass" })
+
+  if (input.health.last_batch_status === "failed") {
+    reasons.push({
+      check: "last_batch_status",
+      outcome: "fail",
+      detail: "previous batch failed; routing Stripe-ACH while bridge recovers",
+    })
+    return { rail: "stripe_ach", reasons }
+  }
+  reasons.push({
+    check: "last_batch_status",
+    outcome: "pass",
+    detail: input.health.last_batch_status,
+  })
+
+  if (input.health.usdc_balance < input.amount) {
+    reasons.push({
+      check: "usdc_liquidity",
+      outcome: "fail",
+      detail: `bridge USDC balance ${input.health.usdc_balance} < amount ${input.amount}; routing Stripe-ACH`,
+    })
+    return { rail: "stripe_ach", reasons }
+  }
+  reasons.push({ check: "usdc_liquidity", outcome: "pass" })
+
+  return { rail: "stellar_usdc", reasons }
+}

--- a/backend/src/modules/hawala-ledger/health.ts
+++ b/backend/src/modules/hawala-ledger/health.ts
@@ -1,0 +1,32 @@
+import { StellarSettlementService } from "./stellar-settlement"
+import type { BridgeHealthSnapshot } from "./dual-rail-selector"
+
+/**
+ * Snapshot the Stellar/USDC bridge health for the dual-rail selector and
+ * for ops dashboards. Wraps Horizon access so a network outage cannot
+ * crash the settlement job.
+ *
+ * The shape mirrors `BridgeHealthSnapshot` from `dual-rail-selector.ts`.
+ * Operators consume this through `/admin/hawala/bridge/health` (added in
+ * a follow-up route) or via the settlement-job logs.
+ */
+export async function getBridgeHealth(args: {
+  service: StellarSettlementService
+  lastBatchStatus?: "succeeded" | "pending" | "failed" | "unknown"
+}): Promise<BridgeHealthSnapshot> {
+  let horizon_reachable = false
+  let usdc_balance = 0
+
+  try {
+    usdc_balance = await args.service.getUsdcBalance()
+    horizon_reachable = true
+  } catch {
+    horizon_reachable = false
+  }
+
+  return {
+    horizon_reachable,
+    usdc_balance,
+    last_batch_status: args.lastBatchStatus ?? "unknown",
+  }
+}

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -2045,6 +2045,130 @@ class HawalaLedgerModuleService extends MedusaService({
 
     return { splits, total_split: grossAmount }
   }
+
+  // ==================== ECONOMIC STANDING (§5.1) ====================
+
+  /**
+   * Aggregate Coalition Credits standing for an MXID per the §2.5
+   * entitlements contract. Sums available + pending balances across the
+   * customer's USER_WALLET, the seller's SELLER_EARNINGS, and (if any)
+   * CREATOR_EARNINGS accounts.
+   *
+   * `seller_id` resolution comes from `seller_metadata.mxid` (added by
+   * Migration202607AddMxidToSellerMetadata). `customer_id` resolution
+   * uses Medusa customer.metadata.mxid as the conventional slot — the
+   * customer-side metadata is a JSONB blob so the lookup is a single
+   * indexed query in production-sized installs.
+   *
+   * Returns null totals (rather than throwing) when the MXID resolves to
+   * no accounts; this is the expected state for new MXIDs that haven't
+   * transacted yet.
+   */
+  async getEconomicStandingByMxid(args: {
+    mxid: string
+    pgConnection?: { raw: (sql: string, bindings?: unknown[]) => Promise<{ rows?: Array<Record<string, unknown>> }> }
+  }): Promise<{
+    mxid: string
+    available: number
+    pending: number
+    currency: string
+    last_settlement_at: string | null
+    sources: Array<{
+      account_id: string
+      account_type: string
+      owner_type: string | null
+      available: number
+      pending: number
+    }>
+  }> {
+    const { mxid } = args
+    const ownerIds: string[] = []
+    let currency = "USD"
+
+    if (args.pgConnection) {
+      try {
+        const sellerLookup = await args.pgConnection.raw(
+          `SELECT seller_id FROM seller_metadata WHERE mxid = ? AND deleted_at IS NULL LIMIT 1`,
+          [mxid]
+        )
+        const sellerId = sellerLookup?.rows?.[0]?.seller_id
+        if (typeof sellerId === "string") ownerIds.push(sellerId)
+      } catch {
+        // schema not yet migrated; treat as no match
+      }
+
+      try {
+        const customerLookup = await args.pgConnection.raw(
+          `SELECT id FROM customer WHERE metadata->>'mxid' = ? AND deleted_at IS NULL LIMIT 1`,
+          [mxid]
+        )
+        const customerId = customerLookup?.rows?.[0]?.id
+        if (typeof customerId === "string") ownerIds.push(customerId)
+      } catch {
+        // customer table not present in this scope; ignore
+      }
+    }
+
+    if (ownerIds.length === 0) {
+      return {
+        mxid,
+        available: 0,
+        pending: 0,
+        currency,
+        last_settlement_at: null,
+        sources: [],
+      }
+    }
+
+    const accounts = await this.listLedgerAccounts({
+      owner_id: ownerIds,
+    })
+
+    let available = 0
+    let pending = 0
+    const sources: Array<{
+      account_id: string
+      account_type: string
+      owner_type: string | null
+      available: number
+      pending: number
+    }> = []
+
+    for (const account of accounts) {
+      const accountAvailable = Number(account.available_balance ?? 0)
+      const accountPending = Number(account.pending_balance ?? 0)
+      available += accountAvailable
+      pending += accountPending
+      currency = account.currency_code || currency
+      sources.push({
+        account_id: account.id,
+        account_type: String(account.account_type),
+        owner_type: account.owner_type ? String(account.owner_type) : null,
+        available: accountAvailable,
+        pending: accountPending,
+      })
+    }
+
+    let last_settlement_at: string | null = null
+    if (accounts.length > 0) {
+      const accountIds = accounts.map((a) => a.id)
+      const recent = await this.listLedgerEntries({
+        credit_account_id: accountIds,
+      })
+      const settlement = recent
+        .filter((e) => String((e as { entry_type?: string }).entry_type ?? "") === "SETTLEMENT")
+        .sort((a, b) => {
+          const at = new Date((a as { created_at?: string }).created_at ?? 0).getTime()
+          const bt = new Date((b as { created_at?: string }).created_at ?? 0).getTime()
+          return bt - at
+        })[0]
+      if (settlement && (settlement as { created_at?: string }).created_at) {
+        last_settlement_at = new Date((settlement as { created_at: string }).created_at).toISOString()
+      }
+    }
+
+    return { mxid, available, pending, currency, last_settlement_at, sources }
+  }
 }
 
 export default HawalaLedgerModuleService

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -2156,14 +2156,15 @@ class HawalaLedgerModuleService extends MedusaService({
         credit_account_id: accountIds,
       })
       const settlement = recent
-        .filter((e) => String((e as { entry_type?: string }).entry_type ?? "") === "SETTLEMENT")
+        .filter((e) => String((e as unknown as { entry_type?: string }).entry_type ?? "") === "SETTLEMENT")
         .sort((a, b) => {
-          const at = new Date((a as { created_at?: string }).created_at ?? 0).getTime()
-          const bt = new Date((b as { created_at?: string }).created_at ?? 0).getTime()
+          const at = new Date((a as unknown as { created_at?: string }).created_at ?? 0).getTime()
+          const bt = new Date((b as unknown as { created_at?: string }).created_at ?? 0).getTime()
           return bt - at
         })[0]
-      if (settlement && (settlement as { created_at?: string }).created_at) {
-        last_settlement_at = new Date((settlement as { created_at: string }).created_at).toISOString()
+      const settlementCreatedAt = (settlement as unknown as { created_at?: string } | undefined)?.created_at
+      if (settlementCreatedAt) {
+        last_settlement_at = new Date(settlementCreatedAt).toISOString()
       }
     }
 

--- a/backend/src/modules/hawala-ledger/stellar-settlement.ts
+++ b/backend/src/modules/hawala-ledger/stellar-settlement.ts
@@ -14,6 +14,59 @@ export interface StellarConfig {
   horizonUrl: string
   signerSecretKey: string
   usdcIssuer: string
+  /**
+   * Retry configuration for Horizon submissions. Defaults to 3 attempts
+   * with exponential backoff (250ms, 500ms, 1000ms). Inline today;
+   * candidate to swap for `p-retry` (MIT) once a dependency bump lands.
+   */
+  retry?: {
+    maxAttempts?: number
+    baseDelayMs?: number
+  }
+}
+
+/**
+ * Lightweight metric counters with a structured-log fallback. When
+ * `prom-client` (Apache-2.0) lands in deps, swap the implementation for
+ * a `Counter`/`Histogram` registry. Until then, every increment writes a
+ * one-line JSON log on stderr so operators can grep counts.
+ */
+export const stellarMetrics = {
+  inc(name: string, labels: Record<string, string | number> = {}) {
+    const payload = { metric: name, labels, ts: new Date().toISOString() }
+    // eslint-disable-next-line no-console -- structured-metric sink
+    console.warn(JSON.stringify(payload))
+  },
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: { maxAttempts: number; baseDelayMs: number; metricLabels: Record<string, string> }
+): Promise<T> {
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      const result = await fn()
+      if (attempt > 1) {
+        stellarMetrics.inc("stellar.submit.retry_recovered", {
+          ...opts.metricLabels,
+          attempt,
+        })
+      }
+      return result
+    } catch (err) {
+      lastErr = err
+      stellarMetrics.inc("stellar.submit.retry", {
+        ...opts.metricLabels,
+        attempt,
+        is_final: attempt === opts.maxAttempts ? "true" : "false",
+      })
+      if (attempt === opts.maxAttempts) break
+      const delay = opts.baseDelayMs * Math.pow(2, attempt - 1)
+      await new Promise((r) => setTimeout(r, delay))
+    }
+  }
+  throw lastErr
 }
 
 export interface SettlementData {
@@ -38,12 +91,17 @@ export class StellarSettlementService {
   private keypair: Keypair
   private networkPassphrase: string
   private usdcAsset: Asset
+  private retryConfig: { maxAttempts: number; baseDelayMs: number }
 
   constructor(config: StellarConfig) {
     this.server = new Horizon.Server(config.horizonUrl)
     this.keypair = Keypair.fromSecret(config.signerSecretKey)
     this.networkPassphrase = config.networkPassphrase
     this.usdcAsset = new Asset("USDC", config.usdcIssuer)
+    this.retryConfig = {
+      maxAttempts: config.retry?.maxAttempts ?? 3,
+      baseDelayMs: config.retry?.baseDelayMs ?? 250,
+    }
   }
 
   /**
@@ -113,12 +171,31 @@ export class StellarSettlementService {
       .setTimeout(30)
       .build()
 
-    // Sign and submit
+    // Sign and submit (with retry/backoff on transient Horizon failures)
     transaction.sign(this.keypair)
-    const result = await this.server.submitTransaction(transaction)
+    let result: { hash: string; ledger: number }
+    try {
+      result = await withRetry(
+        () => this.server.submitTransaction(transaction) as unknown as Promise<{ hash: string; ledger: number }>,
+        {
+          ...this.retryConfig,
+          metricLabels: { op: "submit_settlement_batch", batch_id: data.batchId },
+        }
+      )
+      stellarMetrics.inc("stellar.submit.success", {
+        op: "submit_settlement_batch",
+        batch_id: data.batchId,
+      })
+    } catch (err) {
+      stellarMetrics.inc("stellar.submit.failure", {
+        op: "submit_settlement_batch",
+        batch_id: data.batchId,
+      })
+      throw err
+    }
 
     // Extract fee from result - SDK v13 uses result_xdr for detailed info
-    const feeCharged = (result as any).fee_charged ?? (result as any).feeCharged ?? '0'
+    const feeCharged = (result as { fee_charged?: string; feeCharged?: string }).fee_charged ?? (result as { fee_charged?: string; feeCharged?: string }).feeCharged ?? '0'
 
     return {
       txHash: result.hash,
@@ -157,7 +234,26 @@ export class StellarSettlementService {
     const transaction = transactionBuilder.setTimeout(30).build()
     transaction.sign(this.keypair)
 
-    const result = await this.server.submitTransaction(transaction)
+    let result: { hash: string; ledger: number }
+    try {
+      result = await withRetry(
+        () => this.server.submitTransaction(transaction) as unknown as Promise<{ hash: string; ledger: number }>,
+        {
+          ...this.retryConfig,
+          metricLabels: { op: "process_usdc_payment", destination: data.destinationAddress },
+        }
+      )
+      stellarMetrics.inc("stellar.submit.success", {
+        op: "process_usdc_payment",
+        destination: data.destinationAddress,
+      })
+    } catch (err) {
+      stellarMetrics.inc("stellar.submit.failure", {
+        op: "process_usdc_payment",
+        destination: data.destinationAddress,
+      })
+      throw err
+    }
 
     return {
       txHash: result.hash,

--- a/backend/src/modules/marketplace-signing/__tests__/plugin-signing-service.unit.spec.ts
+++ b/backend/src/modules/marketplace-signing/__tests__/plugin-signing-service.unit.spec.ts
@@ -91,4 +91,42 @@ describe("PluginSigningService.sign", () => {
       if (prev !== undefined) process.env.MARKETPLACE_SIGNING_PRIVATE_KEY_PEM = prev
     }
   })
+
+  it("signVendorEvent produces an envelope that verifies against the configured public key", () => {
+    withSigningKey(() => {
+      const service = new PluginSigningService()
+      const envelope = service.signVendorEvent({
+        kind: "order.fulfilled",
+        subject: "order_abc123",
+        payload: {
+          order_id: "order_abc123",
+          fulfilled_at: "2026-05-10T00:00:00.000Z",
+          fulfillment_node: "node_local_42",
+        },
+        signedAt: new Date("2026-05-10T00:00:01Z"),
+      })
+
+      expect(envelope.alg).toBe("ed25519")
+      expect(envelope.payloadType).toBe("order.fulfilled")
+      expect(envelope.subject).toBe("order_abc123")
+      expect(envelope.keyId).toBe("test-key-1")
+
+      const publicKey = (global as any).__test_public_key
+      const message = [
+        "1",
+        envelope.payloadType,
+        envelope.subject,
+        envelope.payloadHash,
+        envelope.signedAt,
+      ].join("|")
+
+      const ok = cryptoVerify(
+        null,
+        Buffer.from(message, "utf8"),
+        publicKey,
+        Buffer.from(envelope.signature, "base64")
+      )
+      expect(ok).toBe(true)
+    })
+  })
 })

--- a/backend/src/modules/marketplace-signing/service.ts
+++ b/backend/src/modules/marketplace-signing/service.ts
@@ -5,11 +5,32 @@ import {
   KeyObject,
   sign as cryptoSign,
 } from "crypto"
+import { emitMetric } from "../../lib/instrumentation"
 
 export interface PluginManifestLike {
   id: string
   version: string
   [key: string]: unknown
+}
+
+/**
+ * Generalized vendor-event envelope signed with the same Ed25519 keypair
+ * used for plugin bundles. The `kind` discriminator is freeform so the
+ * signing service stays decoupled from the specific event taxonomy
+ * (`order.fulfilled`, `payout.confirmed`, `vendor.verified`, etc.).
+ *
+ * The envelope shape borrows Sigstore conventions (subject, payloadType,
+ * signature) so anyone familiar with supply-chain tooling can read it
+ * without the FBM-specific glossary.
+ */
+export interface VendorEventSignedEnvelope {
+  keyId: string
+  alg: "ed25519"
+  payloadType: string
+  payloadHash: string
+  subject: string
+  signedAt: string
+  signature: string
 }
 
 export interface PluginSignedBundle {
@@ -71,31 +92,96 @@ class PluginSigningService {
     assetHashes: Record<string, string>
     signedAt?: Date
   }): PluginSignedBundle {
-    const { keyId, key } = this.getPrivateKey()
-    const signedAt = (args.signedAt ?? new Date()).toISOString()
+    try {
+      const { keyId, key } = this.getPrivateKey()
+      const signedAt = (args.signedAt ?? new Date()).toISOString()
 
-    const manifestHash = sha256(canonicalJson(args.manifest))
-    const assetHashesHash = sha256(canonicalJson(args.assetHashes))
+      const manifestHash = sha256(canonicalJson(args.manifest))
+      const assetHashesHash = sha256(canonicalJson(args.assetHashes))
 
-    const payload = [
-      SIGNING_PROTOCOL_VERSION,
-      manifestHash,
-      args.codeSha256,
-      assetHashesHash,
-      signedAt,
-    ].join("|")
+      const payload = [
+        SIGNING_PROTOCOL_VERSION,
+        manifestHash,
+        args.codeSha256,
+        assetHashesHash,
+        signedAt,
+      ].join("|")
 
-    const signature = cryptoSign(null, Buffer.from(payload, "utf8"), key)
-      .toString("base64")
+      const signature = cryptoSign(null, Buffer.from(payload, "utf8"), key)
+        .toString("base64")
 
-    return {
-      keyId,
-      alg: "ed25519",
-      manifestHash,
-      codeHash: args.codeSha256,
-      assetHashes: { ...args.assetHashes },
-      signedAt,
-      signature,
+      emitMetric("marketplace.signing.success", {
+        kind: "plugin_bundle",
+        plugin_id: args.manifest.id,
+        plugin_version: args.manifest.version,
+      })
+
+      return {
+        keyId,
+        alg: "ed25519",
+        manifestHash,
+        codeHash: args.codeSha256,
+        assetHashes: { ...args.assetHashes },
+        signedAt,
+        signature,
+      }
+    } catch (err) {
+      emitMetric("marketplace.signing.failure", {
+        kind: "plugin_bundle",
+        plugin_id: args.manifest.id ?? "unknown",
+      })
+      throw err
+    }
+  }
+
+  /**
+   * Sign an arbitrary vendor-event payload (orders, payouts, vendor
+   * certifications) with the same Ed25519 keypair used for plugin
+   * bundles. Subject is a stable identifier for the event (e.g. the
+   * order id, the payout id); `kind` is the event taxonomy entry.
+   */
+  signVendorEvent(args: {
+    kind: string
+    subject: string
+    payload: Record<string, unknown>
+    signedAt?: Date
+  }): VendorEventSignedEnvelope {
+    try {
+      const { keyId, key } = this.getPrivateKey()
+      const signedAt = (args.signedAt ?? new Date()).toISOString()
+      const payloadCanonical = canonicalJson(args.payload)
+      const payloadHash = sha256(payloadCanonical)
+
+      const message = [
+        SIGNING_PROTOCOL_VERSION,
+        args.kind,
+        args.subject,
+        payloadHash,
+        signedAt,
+      ].join("|")
+
+      const signature = cryptoSign(null, Buffer.from(message, "utf8"), key).toString("base64")
+
+      emitMetric("marketplace.signing.success", {
+        kind: args.kind,
+        subject: args.subject,
+      })
+
+      return {
+        keyId,
+        alg: "ed25519",
+        payloadType: args.kind,
+        payloadHash,
+        subject: args.subject,
+        signedAt,
+        signature,
+      }
+    } catch (err) {
+      emitMetric("marketplace.signing.failure", {
+        kind: args.kind,
+        subject: args.subject,
+      })
+      throw err
     }
   }
 }

--- a/backend/src/modules/seller-extension/migrations/Migration202607AddMxidToSellerMetadata.ts
+++ b/backend/src/modules/seller-extension/migrations/Migration202607AddMxidToSellerMetadata.ts
@@ -1,0 +1,40 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Add Matrix `mxid` column to `seller_metadata` per
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §2.1 and §5.1.
+ *
+ * The MXID is the canonical identity for every actor in the BMC ecosystem.
+ * Adding it to `seller_metadata` lets vendor-side commerce permissions be
+ * derived from Matrix-side governance roles via the entitlements service.
+ *
+ * The column is nullable while existing vendors are being backfilled (see
+ * `scripts/backfill-mxid.ts`). A partial unique index ensures two non-null
+ * vendors cannot share the same MXID without preventing legitimate NULLs
+ * during the backfill window.
+ */
+export class Migration202607AddMxidToSellerMetadata extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+        ADD COLUMN IF NOT EXISTS "mxid" TEXT NULL;
+    `)
+
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_seller_metadata_mxid"
+        ON "seller_metadata" ("mxid")
+        WHERE "mxid" IS NOT NULL AND "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_seller_metadata_mxid"
+        ON "seller_metadata" ("mxid");
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP INDEX IF EXISTS "IDX_seller_metadata_mxid";')
+    this.addSql('DROP INDEX IF EXISTS "UQ_seller_metadata_mxid";')
+    this.addSql('ALTER TABLE "seller_metadata" DROP COLUMN IF EXISTS "mxid";')
+  }
+}

--- a/backend/src/modules/seller-extension/models/seller-metadata.ts
+++ b/backend/src/modules/seller-extension/models/seller-metadata.ts
@@ -147,6 +147,11 @@ const SellerMetadata = model.define("seller_metadata", {
   creator_total_followers: model.number().default(0),
   creator_audience_geo: model.json().nullable(), // CreatorAudienceGeo
 
+  // Matrix MXID — canonical identity per AGGRESSIVE_OPERATIONS_GUIDE.md §2.1.
+  // Nullable while existing vendors are backfilled; uniqueness enforced via
+  // a partial unique index in Migration202607AddMxidToSellerMetadata.
+  mxid: model.text().nullable(),
+
   // Metadata for additional extensions
   metadata: model.json().nullable(),
 })

--- a/backend/src/modules/vendor-verification/service.ts
+++ b/backend/src/modules/vendor-verification/service.ts
@@ -1,7 +1,8 @@
 import { MedusaService } from "@medusajs/framework/utils"
-import { 
-  VendorVerification, 
-  VerificationCheck, 
+import { emitMetric } from "../../lib/instrumentation"
+import {
+  VendorVerification,
+  VerificationCheck,
   VendorBadge,
   VerificationLevel,
   VerificationType,
@@ -172,6 +173,11 @@ class VendorVerificationService extends MedusaService({
     
     if (existingChecks.length > 0) {
       const existing = existingChecks[0]
+      emitMetric("vendor.verification.submitted", {
+        seller_id: sellerId,
+        check_type: checkType,
+        update: true,
+      })
       // Update existing check
       return this.updateVerificationChecks({
         id: existing.id,
@@ -181,7 +187,12 @@ class VendorVerificationService extends MedusaService({
         status: CheckStatus.PENDING,
       })
     }
-    
+
+    emitMetric("vendor.verification.submitted", {
+      seller_id: sellerId,
+      check_type: checkType,
+      update: false,
+    })
     // Create new check
     return this.createVerificationChecks({
       vendor_verification_id: verification.id,
@@ -215,14 +226,32 @@ class VendorVerificationService extends MedusaService({
       verified_at: new Date(),
       expires_at: result.expires_at,
       notes: result.notes,
-      score_contribution: result.status === CheckStatus.PASSED 
+      score_contribution: result.status === CheckStatus.PASSED
         ? (result.score_contribution ?? TRUST_SCORE_WEIGHTS[check.check_type as VerificationType] ?? 0)
         : 0,
     })
-    
+
+    emitMetric("vendor.verification.processed", {
+      check_id: checkId,
+      check_type: check.check_type,
+      status: result.status,
+      verified_by: result.verified_by,
+    })
+    if (result.status === CheckStatus.PASSED) {
+      emitMetric("vendor.verification.verified", {
+        check_id: checkId,
+        check_type: check.check_type,
+      })
+    } else if (result.status === CheckStatus.FAILED) {
+      emitMetric("vendor.verification.rejected", {
+        check_id: checkId,
+        check_type: check.check_type,
+      })
+    }
+
     // Recalculate trust score
     await this.recalculateTrustScore(check.vendor_verification_id)
-    
+
     return updated
   }
   
@@ -265,8 +294,66 @@ class VendorVerificationService extends MedusaService({
       level,
       last_verified_at: new Date(),
     })
-    
+
+    emitMetric("vendor.verification.trust_score", {
+      verification_id: verificationId,
+      level,
+      passed_check_count: passedTypes.size,
+    }, totalScore)
+
     return totalScore
+  }
+
+  /**
+   * Build the admin verification funnel summary used by the
+   * Coalition admin dashboard. Shape: total counts grouped by status,
+   * plus median time-to-verify in milliseconds.
+   */
+  async getVerificationFunnel(): Promise<{
+    by_status: Record<string, number>
+    by_level: Record<string, number>
+    median_time_to_verify_ms: number | null
+    total: number
+  }> {
+    const verifications = await this.listVendorVerifications({})
+    const checks = await this.listVerificationChecks({})
+
+    const by_level: Record<string, number> = {}
+    for (const v of verifications) {
+      by_level[v.level] = (by_level[v.level] ?? 0) + 1
+    }
+
+    const by_status: Record<string, number> = {}
+    for (const c of checks) {
+      by_status[c.status] = (by_status[c.status] ?? 0) + 1
+    }
+
+    const verifiedTimes: number[] = []
+    for (const c of checks) {
+      if (c.status === CheckStatus.PASSED && c.verified_at) {
+        const created = new Date(c.created_at as unknown as string).getTime()
+        const verified = new Date(c.verified_at as unknown as string).getTime()
+        if (Number.isFinite(created) && Number.isFinite(verified) && verified >= created) {
+          verifiedTimes.push(verified - created)
+        }
+      }
+    }
+
+    let median: number | null = null
+    if (verifiedTimes.length > 0) {
+      const sorted = [...verifiedTimes].sort((a, b) => a - b)
+      const mid = Math.floor(sorted.length / 2)
+      median = sorted.length % 2 === 0
+        ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+        : sorted[mid]
+    }
+
+    return {
+      by_status,
+      by_level,
+      median_time_to_verify_ms: median,
+      total: verifications.length,
+    }
   }
   
   /**

--- a/backend/src/scripts/backfill-mxid.ts
+++ b/backend/src/scripts/backfill-mxid.ts
@@ -163,8 +163,10 @@ async function resolveMxid(args: {
   //    we lazy-import so the script still runs in environments without it.
   if (process.env.MATRIX_HOMESERVER_URL && process.env.MATRIX_BACKFILL_TOKEN) {
     try {
+      // matrix-js-sdk is an optional peer-dep; fall through to synthesis
+      // when it isn't installed in the operator's environment.
       const sdkModule: { createClient?: (opts: unknown) => unknown } = await import(
-        "matrix-js-sdk"
+        /* @vite-ignore */ "matrix-js-sdk" as unknown as string
       )
       if (typeof sdkModule.createClient === "function") {
         const client = sdkModule.createClient({

--- a/backend/src/scripts/backfill-mxid.ts
+++ b/backend/src/scripts/backfill-mxid.ts
@@ -1,0 +1,196 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { readFileSync, existsSync } from "node:fs"
+
+/**
+ * Backfill `seller_metadata.mxid` per AGGRESSIVE_OPERATIONS_GUIDE.md §2.1
+ * and §5.1.
+ *
+ * Resolution order for each seller:
+ *   1. Manual override CSV (if `MXID_BACKFILL_CSV` env var points to one).
+ *      Format: one `email,mxid` pair per line. Comments start with `#`.
+ *   2. Synapse user-directory lookup over the matrix-js-sdk client API
+ *      (if `MATRIX_HOMESERVER_URL` and `MATRIX_BACKFILL_TOKEN` are set).
+ *   3. Best-effort `@<localpart>:<homeserver_default>` synthesis when
+ *      `MXID_BACKFILL_DEFAULT_HOMESERVER` is set. Skipped otherwise.
+ *
+ * The script is **idempotent**: rows with a non-null `mxid` are left
+ * untouched. Rows whose resolved MXID already belongs to a different
+ * seller are reported and skipped (operator must resolve manually).
+ *
+ * Run:
+ *   pnpm medusa exec ./src/scripts/backfill-mxid.ts
+ *
+ * Dry-run (no writes):
+ *   MXID_BACKFILL_DRY_RUN=1 pnpm medusa exec ./src/scripts/backfill-mxid.ts
+ *
+ * See `docs/runbooks/MXID_VENDOR_BACKFILL.md` for the operator runbook.
+ */
+export default async function backfillMxid({ container }: ExecArgs) {
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+  const dryRun = process.env.MXID_BACKFILL_DRY_RUN === "1"
+  const overrides = loadOverrideCsv(process.env.MXID_BACKFILL_CSV)
+  const defaultHomeserver = process.env.MXID_BACKFILL_DEFAULT_HOMESERVER || null
+
+  console.log("\n========================================")
+  console.log("Backfill seller_metadata.mxid")
+  console.log(`  dry-run: ${dryRun ? "yes" : "no"}`)
+  console.log(`  overrides: ${overrides.size} email→mxid pairs`)
+  console.log(`  default homeserver: ${defaultHomeserver ?? "(none — synthesis disabled)"}`)
+  console.log("========================================\n")
+
+  const sellersResult = await pgConnection.raw(`
+    SELECT
+      sm.id              AS seller_metadata_id,
+      sm.seller_id       AS seller_id,
+      sm.mxid            AS existing_mxid,
+      m.email            AS member_email,
+      s.name             AS seller_name
+    FROM seller_metadata sm
+    INNER JOIN seller   s ON s.id        = sm.seller_id
+    INNER JOIN member   m ON m.seller_id = s.id
+    WHERE sm.deleted_at IS NULL
+    ORDER BY sm.created_at ASC
+  `)
+
+  const sellers = sellersResult.rows || []
+  console.log(`Found ${sellers.length} seller_metadata rows to consider\n`)
+
+  let updated = 0
+  let alreadySet = 0
+  let conflict = 0
+  let unresolved = 0
+  let errors = 0
+
+  const seenMxids = new Map<string, string>() // mxid -> seller_metadata_id
+
+  for (const row of sellers) {
+    const { seller_metadata_id, seller_id, existing_mxid, member_email, seller_name } = row
+    try {
+      if (existing_mxid) {
+        seenMxids.set(existing_mxid, seller_metadata_id)
+        console.log(`✓  Already set: ${member_email} -> ${existing_mxid}`)
+        alreadySet++
+        continue
+      }
+
+      const resolved = await resolveMxid({
+        email: member_email,
+        overrides,
+        defaultHomeserver,
+      })
+
+      if (!resolved) {
+        console.log(`?  Unresolved: ${member_email} (${seller_name}) — skip`)
+        unresolved++
+        continue
+      }
+
+      const owner = seenMxids.get(resolved)
+      if (owner && owner !== seller_metadata_id) {
+        console.log(`!  Conflict: ${resolved} already mapped to ${owner}; ${member_email} skipped`)
+        conflict++
+        continue
+      }
+
+      if (dryRun) {
+        console.log(`(dry-run) Would set ${member_email} -> ${resolved}`)
+      } else {
+        await pgConnection.raw(
+          `UPDATE seller_metadata SET mxid = ? WHERE id = ? AND mxid IS NULL`,
+          [resolved, seller_metadata_id]
+        )
+        console.log(`✅ Updated: ${member_email} -> ${resolved} (${seller_name})`)
+      }
+      seenMxids.set(resolved, seller_metadata_id)
+      updated++
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`❌ Error processing ${member_email}: ${message}`)
+      errors++
+    }
+  }
+
+  console.log("\n========================================")
+  console.log("Backfill complete")
+  console.log("========================================")
+  console.log(`Updated:     ${updated}${dryRun ? " (dry-run, no writes)" : ""}`)
+  console.log(`Already set: ${alreadySet}`)
+  console.log(`Conflicts:   ${conflict}`)
+  console.log(`Unresolved:  ${unresolved}`)
+  console.log(`Errors:      ${errors}`)
+  console.log("========================================\n")
+}
+
+function loadOverrideCsv(path: string | undefined): Map<string, string> {
+  if (!path || !existsSync(path)) return new Map()
+  const out = new Map<string, string>()
+  const text = readFileSync(path, "utf8")
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line || line.startsWith("#")) continue
+    const [emailRaw, mxidRaw] = line.split(",")
+    const email = (emailRaw || "").trim().toLowerCase()
+    const mxid = (mxidRaw || "").trim()
+    if (!email || !mxid) continue
+    if (!isValidMxid(mxid)) {
+      console.warn(`(override CSV) ignoring invalid MXID for ${email}: ${mxid}`)
+      continue
+    }
+    out.set(email, mxid)
+  }
+  return out
+}
+
+const MXID_PATTERN = /^@[A-Za-z0-9._=/-]+:[A-Za-z0-9.-]+$/
+
+function isValidMxid(value: string): boolean {
+  return MXID_PATTERN.test(value)
+}
+
+async function resolveMxid(args: {
+  email: string
+  overrides: Map<string, string>
+  defaultHomeserver: string | null
+}): Promise<string | null> {
+  const lowered = args.email.toLowerCase()
+
+  // 1. Manual override CSV.
+  const override = args.overrides.get(lowered)
+  if (override) return override
+
+  // 2. Synapse user-directory lookup. Optional dependency on matrix-js-sdk;
+  //    we lazy-import so the script still runs in environments without it.
+  if (process.env.MATRIX_HOMESERVER_URL && process.env.MATRIX_BACKFILL_TOKEN) {
+    try {
+      const sdkModule: { createClient?: (opts: unknown) => unknown } = await import(
+        "matrix-js-sdk"
+      )
+      if (typeof sdkModule.createClient === "function") {
+        const client = sdkModule.createClient({
+          baseUrl: process.env.MATRIX_HOMESERVER_URL,
+          accessToken: process.env.MATRIX_BACKFILL_TOKEN,
+        }) as { searchUserDirectory?: (q: { term: string; limit?: number }) => Promise<{ results?: Array<{ user_id?: string }> }> }
+        if (typeof client.searchUserDirectory === "function") {
+          const result = await client.searchUserDirectory({ term: lowered, limit: 1 })
+          const first = result?.results?.[0]?.user_id
+          if (first && isValidMxid(first)) return first
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(`(matrix-js-sdk) lookup failed for ${lowered}: ${message}`)
+    }
+  }
+
+  // 3. Best-effort synthesis from email localpart.
+  if (args.defaultHomeserver) {
+    const localpart = lowered.split("@")[0]?.replace(/[^a-z0-9._=/-]/g, "_")
+    if (localpart) {
+      const synthetic = `@${localpart}:${args.defaultHomeserver}`
+      if (isValidMxid(synthetic)) return synthetic
+    }
+  }
+
+  return null
+}

--- a/docs/AGGRESSIVE_OPERATIONS_GUIDE.md
+++ b/docs/AGGRESSIVE_OPERATIONS_GUIDE.md
@@ -304,7 +304,7 @@ These remain the authoritative operational documentation for the Blackout layer.
 
 ### §7.2 New runbooks required by the consolidation
 
-The consolidation introduces six new runbooks that ship as part of foundation milestone work.
+The consolidation introduces nine new runbooks that ship as part of foundation milestone work. The first six are the original consolidation set; the last three were added with the §5.1 FBM workstreams.
 
 The single-point-of-failure map at `docs/operations/SPOF_MAP.md` inventories the single points of failure across the consolidated stack, including the primary server, Cloudflare Tunnel, Postgres hosting both FBM and Synapse, the secrets manager, and the maintainer. The map is updated whenever a new single point of failure is introduced or an existing one is mitigated.
 
@@ -317,6 +317,12 @@ The secrets manager migration runbook at `docs/runbooks/SECRETS_MANAGER_MIGRATIO
 The compat-layer credential recovery runbook at `docs/runbooks/COMPAT_LAYER_CREDENTIAL_RECOVERY.md` documents recovery procedures for linked-account OAuth tokens, widget secrets, and OBS-WS passwords (which are AES-GCM at rest in the Blackout database) in data-loss scenarios.
 
 The deaddrop-appservice runbook at `docs/runbooks/DEADDROP_APPSERVICE.md` documents the operational procedures for the `apps/deaddrop-appservice/` application that ships in the Blackout repository but currently has no operational runbook.
+
+The MXID vendor backfill runbook at `docs/runbooks/MXID_VENDOR_BACKFILL.md` documents how to backfill `seller_metadata.mxid` for existing vendors via the override-CSV / Synapse user-directory / email-localpart-synthesis resolution chain, including pre-flight checks, dry-run, live run, verification queries, and rollback.
+
+The Stellar/USDC bridge runbook at `docs/runbooks/STELLAR_USDC_BRIDGE.md` documents the mainnet config checklist, key rotation SOP, failed-tx triage, liquidity provisioning, deferred multi-sig governance plan, and the structured-log metric counters emitted by the bridge code paths.
+
+The storefront Capacitor embed runbook at `docs/runbooks/STOREFRONT_CAPACITOR_EMBED.md` documents the X-FBM-Embed-Origin handshake, the BLACKOUT_EMBED_ALLOWED_ORIGINS allowlist, the `/api/auth/embed-bootstrap` POST contract, the manual + automated test path, and the JWS-verification deferral.
 
 ### §7.3 Identity hardening
 
@@ -401,14 +407,14 @@ Foundation milestone unbuilt rows:
 
 |System                                                                        |Progress|Status                                                                   |
 |------------------------------------------------------------------------------|--------|-------------------------------------------------------------------------|
-|Coalition Credits ledger UX (extends `hawala-ledger`)                         |0–100%  |Foundation milestone critical                                            |
-|Stellar/USDC settlement bridge production-ready                               |0–100%  |Foundation milestone critical                                            |
-|Entitlements service contract (HTTP exposure, OpenAPI doc)                    |0–100%  |Foundation milestone critical                                            |
-|Vendor-roles revision (Matrix MXID-keyed)                                     |0–100%  |Foundation milestone critical                                            |
-|Existing-vendor migration to MXID-keyed records                               |0–100%  |Foundation milestone critical                                            |
-|Unified retail/marketplace listing presentation                               |0–100%  |Foundation milestone critical                                            |
-|Order Cycles share-box scheduler (extends `order-cycle` + `food-distribution`)|0–100%  |Foundation milestone critical                                            |
-|Storefront polish + Capacitor render compatibility                            |0–100%  |Foundation milestone; extends `STOREFRONT_AUDIT.md`                      |
+|Coalition Credits ledger UX (extends `hawala-ledger`)                         |75–100% |Backend aggregator + economic-standing endpoint + storefront `/user/coalition-credits` + admin dashboard shipped (`53190aa`); Stripe-ACH leg + transfer-to-member UI deferred|
+|Stellar/USDC settlement bridge production-ready                               |75–100% |Retry/backoff + dual-rail selector + bridge health + runbook + .env template shipped (`ae5c59e`); mainnet cutover and signer key provisioning remain operator work|
+|Entitlements service contract (HTTP exposure, OpenAPI doc)                    |100%    |Shipped: `a1db190` (initial HTTP surface) + `fe4a33f` (governance-roles) + `53190aa` (economic-standing)|
+|Vendor-roles revision (Matrix MXID-keyed)                                     |100%    |Shipped (`fe4a33f`): partial-unique mxid column + getGovernanceRoles + role→permission map|
+|Existing-vendor migration to MXID-keyed records                               |75–100% |Backfill script + `MXID_VENDOR_BACKFILL.md` runbook shipped (`fe4a33f`); production execution remains operator work|
+|Unified retail/marketplace listing presentation                               |75–100% |Selector + retail/marketplace ProductDetailsPage prop + `/shop` retail entry shipped (`ead9e2a`); retail browse styling deferred to differentiation|
+|Order Cycles share-box scheduler (extends `order-cycle` + `food-distribution`)|100%    |Shipped (`b5c158d`)                                                       |
+|Storefront polish + Capacitor render compatibility                            |75–100% |Embed-context detector + middleware CSP swap + `/api/auth/embed-bootstrap` + `STOREFRONT_CAPACITOR_EMBED.md` shipped (`97bc3e2`); JWS verification awaits Blackout pubkey publication|
 |Vendor activation Sprint A (TTFLL ≤ 5 min)                                    |0–100%  |Foundation milestone; partially specced; `FEATURE_BUILD_PLAN.md` Sprint A|
 |Cooperative governance proposal flow with Matrix ACL sync                     |0–100%  |Foundation milestone; extends `cooperative` + `governance`               |
 |Railway → primary-server migration (FBM)                                      |0–100%  |Foundation milestone critical                                            |

--- a/docs/contracts/entitlements.yaml
+++ b/docs/contracts/entitlements.yaml
@@ -123,12 +123,13 @@ paths:
     get:
       tags: [economic-standing]
       operationId: getEconomicStanding
-      x-foundation-milestone: true
       summary: Economic standing for an MXID.
       description: |
-        Coalition Credits balance, pending payout balances, vendor sales
-        volume in the current measurement period, and creator reward
-        eligibility flags. Backed by `hawala-ledger` and `payout-breakdown`.
+        Coalition Credits balance (available + pending across the MXID's
+        wallet and earnings accounts), payout summary, vendor sales volume
+        in the current measurement period, and creator reward eligibility
+        flags. Backed by `hawala-ledger`. Returns zeroed totals (rather
+        than 404) for MXIDs that have not yet transacted.
       parameters:
         - $ref: '#/components/parameters/MxidQuery'
       responses:
@@ -139,8 +140,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/EconomicStanding'
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '404': { $ref: '#/components/responses/NotFound' }
-        '501': { $ref: '#/components/responses/NotImplemented' }
         '503': { $ref: '#/components/responses/ServiceDisabled' }
 
   /entitlements/governance-roles:
@@ -326,7 +325,6 @@ components:
 
     EconomicStanding:
       type: object
-      x-foundation-milestone: true
       required: [mxid, coalition_credits, payouts, vendor_sales, creator_rewards]
       properties:
         mxid: { $ref: '#/components/schemas/Mxid' }
@@ -344,7 +342,6 @@ components:
 
     CoalitionCreditsBalance:
       type: object
-      x-foundation-milestone: true
       required: [available, currency]
       properties:
         available:
@@ -364,7 +361,6 @@ components:
 
     PayoutSummary:
       type: object
-      x-foundation-milestone: true
       properties:
         pending_amount:
           type: integer
@@ -377,7 +373,6 @@ components:
 
     VendorSalesSummary:
       type: object
-      x-foundation-milestone: true
       properties:
         period:
           type: string
@@ -393,7 +388,6 @@ components:
 
     CreatorRewardEligibility:
       type: object
-      x-foundation-milestone: true
       properties:
         eligible: { type: boolean }
         program_keys:

--- a/docs/contracts/entitlements.yaml
+++ b/docs/contracts/entitlements.yaml
@@ -147,13 +147,16 @@ paths:
     get:
       tags: [governance-roles]
       operationId: getGovernanceRoles
-      x-foundation-milestone: true
       summary: Governance roles held by an MXID.
       description: |
         Roles held within each coalition the user belongs to, the petitions
         and proposals they can vote on, the Matrix ACLs that follow from
         those roles, and the FBM commerce permissions that follow from those
-        roles. Backed by `cooperative` and `governance` modules.
+        roles. Read off the entitlement table as
+        `governance.role.<role>.<coalition_id>` grants; FBM permissions
+        derived via the static role→permission map in the entitlement
+        service. Coalition-level membership resolution still depends on the
+        `cooperative` module exposing membership.
       parameters:
         - $ref: '#/components/parameters/MxidQuery'
       responses:
@@ -165,7 +168,6 @@ paths:
                 $ref: '#/components/schemas/GovernanceRoles'
         '401': { $ref: '#/components/responses/Unauthorized' }
         '404': { $ref: '#/components/responses/NotFound' }
-        '501': { $ref: '#/components/responses/NotImplemented' }
         '503': { $ref: '#/components/responses/ServiceDisabled' }
 
   /entitlements/coalitions:
@@ -401,7 +403,6 @@ components:
 
     GovernanceRoles:
       type: object
-      x-foundation-milestone: true
       required: [mxid, roles]
       properties:
         mxid: { $ref: '#/components/schemas/Mxid' }

--- a/docs/runbooks/MXID_VENDOR_BACKFILL.md
+++ b/docs/runbooks/MXID_VENDOR_BACKFILL.md
@@ -1,0 +1,135 @@
+# MXID Vendor Backfill
+
+**Last validated:** _not yet executed; first run is the migration itself._
+
+> Cross-link: [`AGGRESSIVE_OPERATIONS_GUIDE.md`](../AGGRESSIVE_OPERATIONS_GUIDE.md) §2.1 (unified identity model) and §5.1 (foundation milestone exit criterion).
+
+This runbook covers backfilling Matrix MXIDs onto existing FBM vendors so the entitlements service can answer governance-role and economic-standing queries by MXID per the §2.5 contract. The backfill is **idempotent and non-destructive**: rows that already have an MXID are left untouched, and a partial unique index prevents two vendors from sharing the same MXID.
+
+## When to run
+
+- After deploying the migration `Migration202607AddMxidToSellerMetadata` to add the `mxid` column to `seller_metadata`.
+- Whenever a batch of vendors is onboarded outside the standard signup flow (e.g. CSV imports, partner cohorts).
+- As the recurring step in the foundation-milestone bus-factor drill (§7.4).
+
+## Resolution order
+
+The backfill script tries three sources in order, taking the first hit:
+
+1. **Manual override CSV** — `MXID_BACKFILL_CSV` env var pointing to a file with `email,mxid` pairs (one per line, `#` for comments). This is the source of truth for vendors whose MXID we know but who never appeared in the Synapse user directory.
+2. **Synapse user-directory lookup** via `matrix-js-sdk` (Apache-2.0). Requires `MATRIX_HOMESERVER_URL` and an admin-scoped `MATRIX_BACKFILL_TOKEN`. The script searches by email (the directory is configured server-side to index `m.id_msisdn` / `m.id_email` 3PIDs).
+3. **Best-effort synthesis** from the email localpart against `MXID_BACKFILL_DEFAULT_HOMESERVER`, e.g. `alice@example.com → @alice:bmc.example` when the env var is `bmc.example`. Skipped when the env var is unset.
+
+If nothing resolves, the row is left as-is and reported as `Unresolved`. Operators should add the MXID to the override CSV and re-run.
+
+## Pre-flight checklist
+
+1. Confirm the migration is applied:
+   ```sh
+   pnpm --filter backend medusa db:status
+   ```
+   `Migration202607AddMxidToSellerMetadata` should show as **executed**.
+2. Snapshot the current state for rollback:
+   ```sh
+   psql "$DATABASE_URL" -c "SELECT id, seller_id, mxid FROM seller_metadata WHERE deleted_at IS NULL" \
+     > "/tmp/seller_metadata_pre_backfill_$(date -u +%Y%m%dT%H%M%SZ).csv"
+   ```
+3. If using the Synapse path, validate token has user-directory search scope:
+   ```sh
+   curl -sH "Authorization: Bearer $MATRIX_BACKFILL_TOKEN" \
+     "$MATRIX_HOMESERVER_URL/_matrix/client/v3/user_directory/search" \
+     -d '{"search_term": "test", "limit": 1}' | jq '.results | length'
+   ```
+4. If using the override CSV, validate it parses:
+   ```sh
+   head -5 "$MXID_BACKFILL_CSV"
+   ```
+   Comments (`#`) and blank lines are ignored.
+
+## Dry run (always do this first)
+
+```sh
+MXID_BACKFILL_DRY_RUN=1 \
+MXID_BACKFILL_CSV=/path/to/overrides.csv \
+MATRIX_HOMESERVER_URL=https://matrix.bmc.example \
+MATRIX_BACKFILL_TOKEN=... \
+MXID_BACKFILL_DEFAULT_HOMESERVER=bmc.example \
+  pnpm --filter backend medusa exec ./src/scripts/backfill-mxid.ts
+```
+
+The script prints one line per seller showing what would happen. Confirm the totals at the end (Updated / Already set / Conflicts / Unresolved / Errors) match expectations before the live run.
+
+## Live run
+
+Drop `MXID_BACKFILL_DRY_RUN=1` and re-run:
+
+```sh
+MXID_BACKFILL_CSV=/path/to/overrides.csv \
+MATRIX_HOMESERVER_URL=https://matrix.bmc.example \
+MATRIX_BACKFILL_TOKEN=... \
+MXID_BACKFILL_DEFAULT_HOMESERVER=bmc.example \
+  pnpm --filter backend medusa exec ./src/scripts/backfill-mxid.ts
+```
+
+## Verification queries
+
+After the live run, confirm:
+
+```sql
+-- How many vendors now have an MXID:
+SELECT COUNT(*) FILTER (WHERE mxid IS NOT NULL) AS with_mxid,
+       COUNT(*) FILTER (WHERE mxid IS NULL)     AS without_mxid
+FROM seller_metadata WHERE deleted_at IS NULL;
+
+-- Spot any duplicates the partial unique index missed (should be 0):
+SELECT mxid, COUNT(*) FROM seller_metadata
+ WHERE mxid IS NOT NULL AND deleted_at IS NULL
+ GROUP BY mxid HAVING COUNT(*) > 1;
+```
+
+Smoke-test the entitlements surface:
+
+```sh
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"client_id":"...","client_secret":"..."}' \
+  "$FBM_API/v1/integrations/blackout/oauth/token" | jq -r .access_token)
+
+curl -sH "Authorization: Bearer $TOKEN" \
+  "$FBM_API/v1/integrations/blackout/entitlements/governance-roles?mxid=@alice:bmc.example" | jq .
+```
+
+A vendor backfilled into seller_metadata with appropriate `governance.role.*` grants should return a populated `roles[]` array. A vendor with no governance role grants returns `roles: []` — that's expected, not a failure.
+
+## Rollback
+
+Two reversal paths:
+
+1. **Per-row** (preferred): use the pre-backfill snapshot CSV from step 2 above. Replay it with:
+   ```sh
+   psql "$DATABASE_URL" -c "
+     CREATE TEMP TABLE pre_backfill (id TEXT, seller_id TEXT, mxid TEXT);
+     COPY pre_backfill FROM '/tmp/seller_metadata_pre_backfill_<TIMESTAMP>.csv' CSV;
+     UPDATE seller_metadata sm
+        SET mxid = pb.mxid
+       FROM pre_backfill pb
+      WHERE sm.id = pb.id;
+   "
+   ```
+2. **Schema-level** (last resort): roll back the migration. This drops the column and all backfilled values.
+   ```sh
+   pnpm --filter backend medusa db:rollback Migration202607AddMxidToSellerMetadata
+   ```
+
+Schema rollback is destructive; use the per-row path unless the column itself is the problem.
+
+## Known limitations (foundation milestone)
+
+- The script does not deduplicate across the `member` table for sellers with multiple member rows; only the joined row is considered. This is deliberate — multi-member sellers in the foundation milestone are an outlier and should be handled by the override CSV.
+- The Synapse path requires the user directory to index 3PID emails. If the homeserver is configured with `user_directory.search_all_users: false` and the vendor email is not present as a 3PID, the lookup returns no result and the script falls through to synthesis (or skips if synthesis is disabled).
+- MXID format is validated against the §2.5 contract regex `^@[A-Za-z0-9._=/-]+:[A-Za-z0-9.-]+$`. Invalid override entries are logged and skipped.
+
+## Bus-factor notes
+
+- The script is safe to re-run; subsequent runs only touch new sellers.
+- Every line of output is structured enough that a co-maintainer can paste it into the incident channel without redaction (no MXIDs are secrets; emails appear in plain text and should be treated per the project privacy policy).
+- If the script aborts mid-run, no partial state is committed beyond the rows already updated; re-running picks up where it stopped.

--- a/docs/runbooks/STELLAR_USDC_BRIDGE.md
+++ b/docs/runbooks/STELLAR_USDC_BRIDGE.md
@@ -1,0 +1,115 @@
+# Stellar/USDC Settlement Bridge
+
+**Last validated:** _testnet validation only; mainnet cutover is staged but not executed in this repository_.
+
+> Cross-link: [`AGGRESSIVE_OPERATIONS_GUIDE.md`](../AGGRESSIVE_OPERATIONS_GUIDE.md) §1.3 (Coalition Credits as cross-platform settlement layer), §5.1 (foundation milestone), and §7.2 (new runbooks required by the consolidation).
+
+This runbook covers the operational lifecycle of the Stellar/USDC bridge that anchors `hawala-ledger` settlement batches on-chain. The bridge is implemented in `backend/src/modules/hawala-ledger/stellar-settlement.ts` and consumed by `backend/src/jobs/hawala-settlement.ts`.
+
+The current scope is **ops-readiness without mainnet cutover**: the code paths handle retry/backoff, dual-rail selection, and emit structured metrics; the runbook documents the mainnet steps without provisioning live keys here.
+
+## Architecture
+
+The bridge does two distinct things on Stellar:
+
+1. **Anchor settlement batches** via `manageData` operations carrying a Merkle root of every entry in the batch. This is auditable, immutable, and cheap — anyone can later verify a batch by re-computing the Merkle root and looking up the on-chain key `hawala_batch_<batch_id>`.
+2. **Move USDC value** between Stellar accounts via `payment` operations (the `processUsdcPayment` path in `stellar-settlement.ts`). This is the actual settlement leg used when the dual-rail selector picks Stellar over Stripe-ACH.
+
+The dual-rail selector lives at `backend/src/modules/hawala-ledger/dual-rail-selector.ts`. It picks Stripe-ACH or Stellar-USDC for each settlement based on currency, amount, Horizon reachability, last-batch status, and bridge USDC liquidity. The decision is logged on every run; operators can override via the `forceRail` parameter.
+
+## Mainnet config checklist
+
+When ready to cut over from testnet to mainnet, work through this list and check off each step in the operations channel:
+
+- [ ] Generate a fresh signer keypair using `Keypair.random()` in a clean offline environment. Do **not** reuse the testnet keypair.
+- [ ] Store the secret in the chosen secrets manager per [`SECRETS_MANAGER_MIGRATION.md`](./SECRETS_MANAGER_MIGRATION.md). The signer secret never touches `.env` files outside the manager.
+- [ ] Fund the new signer account with at least 5 XLM (`createAccount` minimum + headroom for trustlines + fees) using a fresh transfer from a funded mainnet account.
+- [ ] Add the USDC trustline using `addUsdcTrustline()` against the Circle mainnet issuer (`GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`). Verify the trustline appears in `account.balances`.
+- [ ] Top the bridge wallet with the operator-decided opening USDC balance (typical recommendation: enough for one week of expected settlement volume + 25% headroom).
+- [ ] Update production env to set `STELLAR_NETWORK=mainnet`, `STELLAR_HORIZON_URL=https://horizon.stellar.org`, and `STELLAR_USDC_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`.
+- [ ] Flip `ENABLE_STELLAR_SETTLEMENT=true` in production.
+- [ ] Run a smoke settlement (1.00 USDC) against the bridge wallet's own address. Confirm Horizon reports the transaction, Merkle root anchored matches the local computation, and the dual-rail selector picked `stellar_usdc`.
+- [ ] Update this runbook's "Last validated" line with the date and the smoke-settlement transaction hash.
+
+## Key rotation SOP
+
+Cadence: **at least every 90 days**, plus immediately on any suspected exposure.
+
+Procedure:
+
+1. Generate the new keypair offline.
+2. Fund the new account with 5 XLM and add the USDC trustline (steps from the cutover checklist).
+3. Open a maintenance window (settlement job pauses cleanly because each batch completes inside one job tick).
+4. Drain the old wallet by calling `processUsdcPayment` to the new wallet for the full USDC balance, then sweep XLM with a `mergeAccount` operation if you want to fully retire the old account.
+5. Update the secrets manager with the new signer secret.
+6. Restart the FBM backend so `createStellarSettlementService()` picks up the new env-driven secret.
+7. Run the same smoke settlement from the cutover checklist to confirm the new wallet is operational.
+8. Record the rotation in the operations log; add the old wallet's tx history to the audit trail before retiring it.
+
+## Failed-tx triage
+
+The `submitSettlementBatch` and `processUsdcPayment` paths wrap Horizon calls in a 3-attempt exponential-backoff retry. After all three attempts, the function throws and the job sets the batch to `FAILED` with the error in `metadata`. The `stellar.submit.failure` counter increments.
+
+When you see a `FAILED` batch:
+
+1. Check the failure metric label (`op`) to see whether it was a settlement anchor or a USDC payment.
+2. Look at the Horizon response code captured in the batch metadata. Common cases:
+   - `tx_insufficient_balance`: bridge wallet ran out of XLM for fees. Fund and retry.
+   - `op_no_trust`: destination has not added the USDC trustline. Coordinate with the recipient.
+   - `tx_too_late`: clock skew or Horizon delay; usually transient.
+   - `tx_bad_seq`: someone else used the same source account in parallel; check for a stuck transaction.
+3. If transient, requeue the batch via the admin route (`POST /admin/hawala/settlements/:id/retry`).
+4. If non-transient, fix the root cause, then requeue.
+
+The settlement job will not auto-retry a `FAILED` batch on the next tick; this is intentional so a wedged batch does not consume retry budget.
+
+## Liquidity provisioning
+
+The dual-rail selector forces Stripe-ACH whenever the bridge's USDC balance is below the requested settlement amount. Bridge balances should be monitored and topped up before liquidity becomes the binding constraint.
+
+Cadence: **weekly review** with a top-up target of one full settlement period of expected volume + 25% headroom.
+
+Top-up procedure:
+
+1. Move USDC from the operator-controlled treasury account to the bridge wallet using a standard Stellar payment (Lobstr, Solar, or `processUsdcPayment` from a funded sister account).
+2. Confirm the bridge wallet's `getUsdcBalance()` reflects the new total before the next settlement tick.
+3. Log the top-up in the operations channel with the source tx hash so the audit trail is complete.
+
+## Multi-sig governance (deferred)
+
+The bridge wallet is a single-sig wallet today. Multi-sig is the right pattern once settlement volume is meaningful enough that a single-key compromise is a material risk. This is **deferred to differentiation milestone** per the foundation-milestone scope; tracking issue should be filed when the volume crosses the operator's risk threshold.
+
+When the time comes, the migration is:
+
+1. Add additional signers via `setOptions` raising the master weight or adding cosigners.
+2. Update the FBM backend to construct multi-sig transactions (the SDK supports this natively).
+3. Re-run the cutover smoke test with the new threshold.
+
+## Settlement monitoring
+
+Counters emitted by `stellar-settlement.ts` (current implementation logs structured JSON; swap for `prom-client` once a dependency bump lands):
+
+- `stellar.submit.success` — successful submission (batch anchor or USDC payment), labels: `op`, `batch_id` or `destination`.
+- `stellar.submit.failure` — submission failed after all retries, labels: `op`, `batch_id` or `destination`.
+- `stellar.submit.retry` — single retry attempt, labels: `op`, `attempt`, `is_final`.
+- `stellar.submit.retry_recovered` — submission succeeded after one or more retries, labels: `op`, `attempt`.
+- `stellar.dual_rail_decision` — emitted from the settlement job, labels: `rail` (`stripe_ach` or `stellar_usdc`), `batch_id`.
+
+Every counter is JSON-shaped on stderr today, so a `grep '"metric":' | jq .` produces a clean event stream until the metrics backend is wired in.
+
+## Standards alignment
+
+The bridge runbook intentionally uses terminology from Stellar's Standards documents so any operator familiar with the ecosystem can reason about it without a glossary:
+
+- **SEP-1** — operational metadata for the issuer; we don't ship a `stellar.toml` today but the runbook acknowledges the convention.
+- **SEP-24** — interactive deposits/withdrawals between fiat and Stellar tokens. The dual-rail selector's Stripe-ACH leg is conceptually a SEP-24 off-ramp implemented with Stripe instead of an anchor protocol; the runbook follows SEP-24's vocabulary (anchor, trust, fee transparency).
+- **SEP-31** — direct payment between anchors. Not used today; called out so future bridge-to-bridge work has a starting reference.
+
+## See also
+
+- [`SECRETS_MANAGER_MIGRATION.md`](./SECRETS_MANAGER_MIGRATION.md) — where the signer secret should live.
+- [`MXID_VENDOR_BACKFILL.md`](./MXID_VENDOR_BACKFILL.md) — vendor identity prerequisite for routing settlements to the right account.
+- `backend/src/modules/hawala-ledger/stellar-settlement.ts` — implementation.
+- `backend/src/modules/hawala-ledger/dual-rail-selector.ts` — selection logic.
+- `backend/src/modules/hawala-ledger/health.ts` — health snapshot helper.
+- `backend/src/jobs/hawala-settlement.ts` — daily settlement job consuming both.

--- a/docs/runbooks/STOREFRONT_CAPACITOR_EMBED.md
+++ b/docs/runbooks/STOREFRONT_CAPACITOR_EMBED.md
@@ -1,0 +1,115 @@
+# Storefront ↔ Capacitor Embed
+
+**Last validated:** _not yet executed; awaits Blackout-side webview test_.
+
+> Cross-link: [`AGGRESSIVE_OPERATIONS_GUIDE.md`](../AGGRESSIVE_OPERATIONS_GUIDE.md) §1.2 (Blackout owns the primary mobile surface), §2.8 (storefront polish for Capacitor wrapper), and §5.1 (foundation milestone).
+
+This runbook documents the contract between the Blackout Capacitor wrapper and the FBM storefront so commerce flows render correctly when embedded as in-app views in the Blackout mobile app. The contract has three pieces: an allowlisted embed origin, a CSP swap for `frame-ancestors`, and a one-time auth bootstrap.
+
+## Handshake protocol
+
+Every request originating from the Blackout webview MUST carry the `X-FBM-Embed-Origin` header. The value is the origin that hosts the Capacitor webview, e.g.:
+
+- `capacitor://localhost` for iOS native
+- `https://blackout.bmc.example` for the production webview if proxied through HTTPS
+
+Set the allowlisted origins in the storefront environment via `BLACKOUT_EMBED_ALLOWED_ORIGINS` (comma-separated). Origins outside this list never receive the relaxed CSP and never gain the embed-bootstrap path; the storefront treats them as ordinary external callers.
+
+Storefront response headers when the request is from an allowlisted origin:
+
+- `Content-Security-Policy: frame-ancestors <origin>` — replaces the default `X-Frame-Options: SAMEORIGIN`.
+- `X-FBM-Embed-Origin-Echo: <origin>` — echoes the resolved origin back so wrapper logs can confirm the handshake.
+
+Origins not allowlisted continue to receive the default `X-Frame-Options: SAMEORIGIN` and cannot iframe the storefront.
+
+## Auth bootstrap
+
+After the webview loads, the wrapper POSTs the Blackout-issued JWT to `/api/auth/embed-bootstrap`:
+
+```http
+POST /api/auth/embed-bootstrap
+Host: storefront.bmc.example
+X-FBM-Embed-Origin: capacitor://localhost
+Content-Type: application/json
+
+{ "token": "<Blackout JWT>" }
+```
+
+Successful response: `200 { "ok": true, "embed_origin": "capacitor://localhost" }` plus a `_medusa_jwt` cookie scoped to the webview session (`SameSite=None; Secure; Max-Age=43200`).
+
+Error responses:
+
+- `400 { "code": "not_embedded" }` — the request did not carry `X-FBM-Embed-Origin`.
+- `403 { "code": "origin_not_allowed" }` — the origin is not in the allowlist.
+- `400 { "code": "bad_request" }` — JSON body missing or malformed `token`.
+
+The storefront reads `_medusa_jwt` from the cookie jar like any other authenticated session; the rest of the storefront UX needs no Capacitor-specific changes.
+
+## Capacitor wrapper integration sketch
+
+On the Blackout side, after `WebView.create()` resolves and before navigating to the FBM storefront, run something like:
+
+```ts
+const FBM_ORIGIN = "https://storefront.bmc.example"
+const EMBED_ORIGIN = "capacitor://localhost"
+const blackoutToken = await getCurrentBlackoutAccessToken()
+
+await fetch(`${FBM_ORIGIN}/api/auth/embed-bootstrap`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-FBM-Embed-Origin": EMBED_ORIGIN,
+  },
+  body: JSON.stringify({ token: blackoutToken }),
+  credentials: "include",
+})
+
+await CapacitorWebview.loadURL(`${FBM_ORIGIN}/products`, {
+  customHeaders: { "X-FBM-Embed-Origin": EMBED_ORIGIN },
+})
+```
+
+Capacitor sends `customHeaders` with every request the webview makes to the matching origin, which is what triggers the storefront middleware's CSP swap on each page navigation.
+
+## Testing
+
+### Backend / storefront-side
+
+```sh
+# Confirm bootstrap path exists and validates origin allowlist:
+curl -sf https://storefront.bmc.example/api/auth/embed-bootstrap | jq
+
+# Confirm an allowed origin gets a relaxed CSP:
+curl -sI https://storefront.bmc.example/products \
+  -H "X-FBM-Embed-Origin: capacitor://localhost" | grep -i content-security-policy
+
+# Confirm a disallowed origin does NOT get it:
+curl -sI https://storefront.bmc.example/products \
+  -H "X-FBM-Embed-Origin: https://evil.example" | grep -i x-frame-options
+```
+
+### Blackout-side
+
+Open the Blackout app on a staging build, navigate to the FBM commerce view, and confirm:
+
+1. The webview renders the FBM storefront (no blank screen, no XFO error).
+2. The user appears logged in (the Blackout session persisted into FBM via the bootstrap).
+3. Cart and order operations succeed end-to-end.
+
+### Automated
+
+`storefront/src/__tests__/embed-context.test.ts` covers the embed-context detector. End-to-end webview testing remains manual until Blackout publishes its Capacitor test harness.
+
+## Known limitations (foundation milestone)
+
+- The bootstrap endpoint accepts the JWT shape but does not yet verify the JWS — Blackout has not published the signing pubkey FBM should pin. When that arrives, swap the body of the route to verify with `jose` (MIT) before setting the cookie.
+- Cookies returned by the bootstrap endpoint are not `httpOnly` so the embedded page can refresh them from the runtime; this is the standard webview pattern but operators should note the trade-off.
+- Service-worker / offline support remains out of scope (deferred to differentiation milestone). Network failures inside the webview surface as blank pages until then.
+- The relaxed CSP only applies to the explicit allowlisted origins. Adding a new wrapper means setting `BLACKOUT_EMBED_ALLOWED_ORIGINS` on the storefront and restarting; there is no dynamic discovery.
+
+## See also
+
+- `storefront/src/lib/runtime/embed-context.ts` — detector + allowlist parser.
+- `storefront/src/middleware.ts` — `applyEmbedHeaders` swap.
+- `storefront/src/app/api/auth/embed-bootstrap/route.ts` — bootstrap endpoint.
+- `STOREFRONT_AUDIT.md` — addendum will be added once Blackout-side webview tests are green.

--- a/e2e/tests/vendor-verification.spec.ts
+++ b/e2e/tests/vendor-verification.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * §5.1 foundation milestone — vendor verification + signing
+ * instrumentation smoke. Confirms the new admin funnel route returns
+ * the documented shape and the new entitlements endpoints are wired.
+ *
+ * Operates against a running stack (`docker compose up`) and a backend
+ * exposing /admin/vendor-verification/funnel without auth (current
+ * pattern in this repo). Adjust auth once admin auth is layered on.
+ */
+
+const BACKEND = process.env.BACKEND_URL || "http://localhost:9000"
+
+test.describe("§5.1 vendor verification funnel", () => {
+  test("GET /admin/vendor-verification/funnel returns the documented shape", async ({ request }) => {
+    const r = await request.get(`${BACKEND}/admin/vendor-verification/funnel`)
+    if (r.status() === 401 || r.status() === 403) {
+      test.skip(true, "admin auth required in this environment; covered by unit test")
+    }
+    expect(r.status()).toBe(200)
+    const body = await r.json()
+    expect(typeof body.total).toBe("number")
+    expect(body.by_status).toBeDefined()
+    expect(body.by_level).toBeDefined()
+    expect(["number", "object"]).toContain(typeof body.median_time_to_verify_ms)
+  })
+
+  test("entitlements economic-standing returns 503 when integration disabled, or zeroed totals when MXID is unknown", async ({ request }) => {
+    const r = await request.get(
+      `${BACKEND}/v1/integrations/blackout/entitlements/economic-standing?mxid=@e2e-unknown:bmc.example`,
+      {
+        headers: {
+          Authorization: "Bearer test-token-not-real",
+        },
+      }
+    )
+    // Acceptable outcomes: 503 (integration disabled), 401 (token rejected), or
+    // 200 with zeroed totals when integration is enabled and the token
+    // is a valid Blackout-issued JWT.
+    expect([200, 401, 503]).toContain(r.status())
+    if (r.status() === 200) {
+      const body = await r.json()
+      expect(body.coalition_credits).toBeDefined()
+      expect(body.coalition_credits.available).toBe(0)
+      expect(body.coalition_credits.pending).toBe(0)
+    }
+  })
+})

--- a/storefront/package.json
+++ b/storefront/package.json
@@ -2,6 +2,7 @@
   "name": "b2c-storefront",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.13.1",
   "scripts": {
     "wait": "await-backend",
     "launcher": "launch-storefront",

--- a/storefront/src/__tests__/embed-context.test.ts
+++ b/storefront/src/__tests__/embed-context.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { detectEmbedContext, getAllowedEmbedOrigins } from "@/lib/runtime/embed-context"
+
+function makeHeaders(map: Record<string, string>) {
+  return {
+    get(name: string): string | null {
+      return map[name.toLowerCase()] ?? null
+    },
+  }
+}
+
+describe("detectEmbedContext", () => {
+  const ORIG_ENV = process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS
+
+  beforeEach(() => {
+    process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS =
+      "capacitor://localhost, https://blackout.bmc.example"
+  })
+
+  afterEach(() => {
+    if (ORIG_ENV === undefined) delete process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS
+    else process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS = ORIG_ENV
+  })
+
+  it("returns isEmbedded=false when X-FBM-Embed-Origin is missing", () => {
+    const ctx = detectEmbedContext(makeHeaders({}))
+    expect(ctx.isEmbedded).toBe(false)
+    expect(ctx.origin).toBeNull()
+    expect(ctx.isAllowedOrigin).toBe(false)
+  })
+
+  it("flags allowlisted origins as allowed", () => {
+    const ctx = detectEmbedContext(
+      makeHeaders({ "x-fbm-embed-origin": "capacitor://localhost" })
+    )
+    expect(ctx.isEmbedded).toBe(true)
+    expect(ctx.origin).toBe("capacitor://localhost")
+    expect(ctx.isAllowedOrigin).toBe(true)
+  })
+
+  it("treats origin matching as case-insensitive", () => {
+    const ctx = detectEmbedContext(
+      makeHeaders({ "x-fbm-embed-origin": "HTTPS://Blackout.BMC.Example" })
+    )
+    expect(ctx.isAllowedOrigin).toBe(true)
+  })
+
+  it("rejects origins not in the allowlist", () => {
+    const ctx = detectEmbedContext(
+      makeHeaders({ "x-fbm-embed-origin": "https://malicious.example" })
+    )
+    expect(ctx.isEmbedded).toBe(true)
+    expect(ctx.isAllowedOrigin).toBe(false)
+  })
+})
+
+describe("getAllowedEmbedOrigins", () => {
+  it("parses a comma-separated env var ignoring whitespace and empty entries", () => {
+    process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS =
+      "  capacitor://localhost ,, https://blackout.bmc.example  ,"
+    expect(getAllowedEmbedOrigins()).toEqual([
+      "capacitor://localhost",
+      "https://blackout.bmc.example",
+    ])
+  })
+
+  it("returns an empty array when the env var is unset", () => {
+    delete process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS
+    expect(getAllowedEmbedOrigins()).toEqual([])
+  })
+})

--- a/storefront/src/__tests__/presentation.test.ts
+++ b/storefront/src/__tests__/presentation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { selectPresentation } from "@/lib/listing/presentation"
+
+describe("selectPresentation", () => {
+  it("/shop entries default to retail", () => {
+    expect(selectPresentation({ routeKind: "shop" })).toBe("retail")
+  })
+
+  it("/products entries default to marketplace", () => {
+    expect(selectPresentation({ routeKind: "products" })).toBe("marketplace")
+  })
+
+  it("a vendor seller-handle forces marketplace regardless of route", () => {
+    expect(
+      selectPresentation({ routeKind: "shop", sellerHandle: "alice-farm" })
+    ).toBe("marketplace")
+  })
+
+  it("a coalition storefront context forces marketplace", () => {
+    expect(
+      selectPresentation({
+        routeKind: "shop",
+        storefrontContext: {
+          organization_id: "org_alpha",
+          storefront_id: "sf_alpha",
+        },
+      })
+    ).toBe("marketplace")
+  })
+
+  it("a coalition member without storefront context still gets marketplace", () => {
+    expect(
+      selectPresentation({ routeKind: "shop", isCoalitionMember: true })
+    ).toBe("marketplace")
+  })
+
+  it("embed routes always render marketplace presentation", () => {
+    expect(selectPresentation({ routeKind: "embed" })).toBe("marketplace")
+  })
+
+  it("falls back to retail when no signals point either way", () => {
+    expect(selectPresentation({})).toBe("retail")
+  })
+})

--- a/storefront/src/app/[locale]/(main)/shop/[handle]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/shop/[handle]/page.tsx
@@ -6,6 +6,13 @@ import { getStorefrontContext } from "@/lib/data/cookies"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
+/**
+ * Retail entry for a single product. Same data source as
+ * `/products/[handle]`; presentation defaults to `retail` per the
+ * unified retail/marketplace design in
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §1.1. Switches to `marketplace` when
+ * the buyer is in a coalition's storefront context.
+ */
 export async function generateMetadata({
   params,
 }: {
@@ -22,7 +29,7 @@ export async function generateMetadata({
   return generateProductMetadata(prod)
 }
 
-export default async function ProductPage({
+export default async function ShopProductPage({
   params,
 }: {
   params: Promise<{ handle: string; locale: string }>
@@ -41,9 +48,9 @@ export default async function ProductPage({
 
   const storefrontContext = await getStorefrontContext()
   const presentation = selectPresentation({
-    routeKind: "products",
+    routeKind: "shop",
     storefrontContext,
-    sellerHandle: prod.seller?.handle ?? null,
+    sellerHandle: null,
   })
 
   return (

--- a/storefront/src/app/[locale]/(main)/shop/page.tsx
+++ b/storefront/src/app/[locale]/(main)/shop/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 
 export const metadata: Metadata = {
   title: "Shop",
@@ -28,7 +29,8 @@ export default async function ShopLandingPage() {
         vendor-forward marketplace view automatically.
       </p>
       <p className="text-secondary text-sm">
-        Browse all products at <a className="underline" href="/products">/products</a>.
+        Browse the catalog by <Link className="underline" href="/categories">category</Link>
+        {" "}or by <Link className="underline" href="/vendors">vendor</Link>.
       </p>
     </main>
   )

--- a/storefront/src/app/[locale]/(main)/shop/page.tsx
+++ b/storefront/src/app/[locale]/(main)/shop/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Shop",
+  description:
+    "Public retail catalog. Same listings as the vendor marketplace, presented in retail mode for general visitors.",
+}
+
+/**
+ * Retail entry landing per the unified presentation design in
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §1.1. Coalition members browsing in a
+ * coalition storefront context get the marketplace presentation
+ * automatically; everyone else lands here for the retail catalog.
+ *
+ * The retail-side product list is intentionally minimal today: the same
+ * underlying `listProducts()` data source as `/products` powers the
+ * marketplace catalog and will be added here as the retail browse
+ * experience matures (deferred from this workstream).
+ */
+export default async function ShopLandingPage() {
+  return (
+    <main className="container py-8 space-y-4">
+      <h1 className="heading-md uppercase">Shop</h1>
+      <p className="text-secondary max-w-prose">
+        This is the public retail catalog. The same listings powering the
+        vendor marketplace are presented here in retail mode. Coalition
+        members signed in to their coalition&apos;s storefront see the
+        vendor-forward marketplace view automatically.
+      </p>
+      <p className="text-secondary text-sm">
+        Browse all products at <a className="underline" href="/products">/products</a>.
+      </p>
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/user/coalition-credits/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/coalition-credits/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from "next"
+import { AccountLoadingState, LoginForm, UserNavigation } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
+import {
+  getCoalitionCreditsWallet,
+  listCoalitionCreditsTransactions,
+} from "@/lib/data/coalition-credits"
+
+export const metadata: Metadata = {
+  title: "Coalition Credits",
+  description:
+    "Your Coalition Credits balance, recent ledger entries, and pending settlements.",
+}
+
+const TRANSACTION_LIMIT = 25
+
+export default async function CoalitionCreditsPage() {
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
+
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Coalition Credits" />
+  }
+
+  const [walletResult, transactionsResult] = await Promise.all([
+    getCoalitionCreditsWallet(),
+    listCoalitionCreditsTransactions({ limit: TRANSACTION_LIMIT }),
+  ])
+
+  const wallet = walletResult?.wallet ?? null
+  const balance = walletResult?.balance ?? null
+  const transactions = transactionsResult?.transactions ?? []
+
+  const currency = balance?.currency_code || wallet?.currency_code || "USD"
+
+  return (
+    <main className="container">
+      <div className="grid grid-cols-1 md:grid-cols-4 mt-6 gap-5 md:gap-8">
+        <UserNavigation />
+        <div className="md:col-span-3 space-y-8">
+          <header>
+            <h1 className="heading-md uppercase">Coalition Credits</h1>
+            <p className="text-secondary mt-2">
+              Coalition Credits settle every economic event in the Black Market
+              Coalition. Balances here reflect your wallet on the
+              <code className="ml-1">hawala-ledger</code> substrate.
+            </p>
+          </header>
+
+          <section className="rounded-lg border border-tertiary p-6 space-y-3">
+            <h2 className="heading-sm uppercase">Balance</h2>
+            <dl className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <dt className="text-secondary text-sm">Available</dt>
+                <dd className="heading-lg" data-testid="cc-available">
+                  {formatAmount(balance?.available_balance ?? 0, currency)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-secondary text-sm">Pending</dt>
+                <dd className="heading-md" data-testid="cc-pending">
+                  {formatAmount(balance?.pending_balance ?? 0, currency)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-secondary text-sm">Currency</dt>
+                <dd className="heading-md">{currency}</dd>
+              </div>
+            </dl>
+            {!wallet && (
+              <p className="text-sm text-secondary">
+                You don&apos;t have a Coalition Credits wallet yet. One will be
+                created automatically the first time you transact.
+              </p>
+            )}
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="heading-sm uppercase">Recent activity</h2>
+            {transactions.length === 0 ? (
+              <p className="text-secondary text-sm">
+                No transactions yet. Purchases, payouts, and transfers will
+                appear here.
+              </p>
+            ) : (
+              <table className="w-full text-sm">
+                <thead className="text-secondary uppercase text-xs">
+                  <tr>
+                    <th className="text-left py-2">Date</th>
+                    <th className="text-left">Type</th>
+                    <th className="text-left">Description</th>
+                    <th className="text-right">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {transactions.map((tx) => (
+                    <tr key={tx.id} className="border-t border-tertiary">
+                      <td className="py-2">
+                        {new Date(tx.created_at).toLocaleDateString()}
+                      </td>
+                      <td>{tx.entry_type}</td>
+                      <td className="text-secondary">{tx.description ?? ""}</td>
+                      <td
+                        className={`text-right ${tx.direction === "credit" ? "text-green-600" : "text-red-600"}`}
+                      >
+                        {tx.direction === "credit" ? "+" : "-"}
+                        {formatAmount(Math.abs(tx.amount), currency)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+function formatAmount(value: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 2,
+    }).format(value)
+  } catch {
+    return `${value.toFixed(2)} ${currency}`
+  }
+}

--- a/storefront/src/app/api/auth/embed-bootstrap/route.ts
+++ b/storefront/src/app/api/auth/embed-bootstrap/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server"
+import { detectEmbedContext } from "@/lib/runtime/embed-context"
+
+/**
+ * Capacitor / in-app webview auth bootstrap per
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §2.8 and §5.1.
+ *
+ * Blackout's Capacitor wrapper POSTs a Blackout-issued JWT to this
+ * endpoint after the webview loads. We validate the embed origin
+ * matches the allowlist, set the `_medusa_jwt` cookie scoped to the
+ * webview session, and return 204.
+ *
+ * Token signature/audience verification will be added once Blackout
+ * publishes the signing keys; the substrate today is the
+ * entitlements OAuth surface (see backend
+ * `/v1/integrations/blackout/oauth/token`). This route accepts the
+ * token shape but does not yet verify the JWS — that lands in a
+ * follow-up commit when the Blackout pubkey is available to pin.
+ */
+export async function POST(request: NextRequest) {
+  const ctx = detectEmbedContext({
+    get: (name) => request.headers.get(name),
+  })
+  if (!ctx.isEmbedded) {
+    return NextResponse.json(
+      { code: "not_embedded", message: "X-FBM-Embed-Origin header is required" },
+      { status: 400 }
+    )
+  }
+  if (!ctx.isAllowedOrigin || !ctx.origin) {
+    return NextResponse.json(
+      { code: "origin_not_allowed", message: "Embed origin is not in BLACKOUT_EMBED_ALLOWED_ORIGINS" },
+      { status: 403 }
+    )
+  }
+
+  let body: { token?: string }
+  try {
+    body = (await request.json()) as { token?: string }
+  } catch {
+    return NextResponse.json(
+      { code: "bad_request", message: "Invalid JSON body" },
+      { status: 400 }
+    )
+  }
+
+  const token = body?.token?.trim()
+  if (!token) {
+    return NextResponse.json(
+      { code: "bad_request", message: "token is required" },
+      { status: 400 }
+    )
+  }
+
+  const response = NextResponse.json(
+    { ok: true, embed_origin: ctx.origin },
+    { status: 200 }
+  )
+  response.cookies.set("_medusa_jwt", token, {
+    // Webview-friendly: not httpOnly so the embedded page can read it
+    // back when the in-app session needs to refresh; sameSite=none with
+    // secure=true is required for cross-origin webview cookies.
+    sameSite: "none",
+    secure: true,
+    path: "/",
+    maxAge: 60 * 60 * 12, // 12h aligns with Blackout token TTL
+  })
+  return response
+}
+
+export async function GET() {
+  // Probe endpoint so the Capacitor wrapper can confirm the bootstrap
+  // surface exists before posting the token.
+  return NextResponse.json({ ok: true, surface: "embed-bootstrap" })
+}

--- a/storefront/src/components/molecules/UserNavigation/UserNavigation.tsx
+++ b/storefront/src/components/molecules/UserNavigation/UserNavigation.tsx
@@ -35,6 +35,10 @@ const navigationItems = [
     label: "Wishlist",
     href: "/user/wishlist",
   },
+  {
+    label: "Coalition Credits",
+    href: "/user/coalition-credits",
+  },
 ]
 
 export const UserNavigation = () => {

--- a/storefront/src/components/sections/ProductDetailsPage/ProductDetailsPage.tsx
+++ b/storefront/src/components/sections/ProductDetailsPage/ProductDetailsPage.tsx
@@ -2,13 +2,16 @@ import { ProductDetails, ProductGallery } from "@/components/organisms"
 import { listProducts } from "@/lib/data/products"
 import { HomeProductSection } from "../HomeProductSection/HomeProductSection"
 import NotFound from "@/app/not-found"
+import type { Presentation } from "@/lib/listing/presentation"
 
 export const ProductDetailsPage = async ({
   handle,
   locale,
+  presentation = "marketplace",
 }: {
   handle: string
   locale: string
+  presentation?: Presentation
 }) => {
   const prod = await listProducts({
     countryCode: locale,
@@ -24,7 +27,7 @@ export const ProductDetailsPage = async ({
 
   return (
     <>
-      <div className="flex flex-col md:flex-row lg:gap-12">
+      <div className="flex flex-col md:flex-row lg:gap-12" data-presentation={presentation}>
         <div className="md:w-1/2 md:px-2">
           <ProductGallery images={prod?.images || []} />
         </div>
@@ -32,14 +35,16 @@ export const ProductDetailsPage = async ({
           <ProductDetails product={prod} locale={locale} />
         </div>
       </div>
-      <div className="my-8">
-        <HomeProductSection
-          heading="More from this seller"
-          products={prod.seller?.products}
-          // seller_handle={prod.seller?.handle}
-          locale={locale}
-        />
-      </div>
+      {presentation === "marketplace" && (
+        <div className="my-8">
+          <HomeProductSection
+            heading="More from this seller"
+            products={prod.seller?.products}
+            // seller_handle={prod.seller?.handle}
+            locale={locale}
+          />
+        </div>
+      )}
     </>
   )
 }

--- a/storefront/src/lib/data/coalition-credits.ts
+++ b/storefront/src/lib/data/coalition-credits.ts
@@ -1,0 +1,91 @@
+"use server"
+
+import { medusaFetch } from "../config"
+import { getAuthHeaders } from "./cookies"
+
+export type CoalitionCreditsWallet = {
+  id: string
+  account_number: string
+  balance: number
+  pending_balance: number
+  available_balance: number
+  currency_code: string
+}
+
+export type CoalitionCreditsTransaction = {
+  id: string
+  entry_type: string
+  amount: number
+  description: string | null
+  created_at: string
+  reference_type?: string | null
+  reference_id?: string | null
+  direction: "debit" | "credit"
+}
+
+/**
+ * Fetch the customer's Coalition Credits wallet (USER_WALLET account)
+ * with balance details. Wraps `/store/hawala/wallet` so the storefront
+ * can render a simple `{ wallet, balance }` shape.
+ */
+export const getCoalitionCreditsWallet = async (): Promise<{
+  wallet: CoalitionCreditsWallet
+  balance: {
+    balance: number
+    pending_balance: number
+    available_balance: number
+    currency_code: string
+  }
+} | null> => {
+  const authHeaders = await getAuthHeaders()
+  if (!authHeaders) return null
+
+  try {
+    return await medusaFetch<{
+      wallet: CoalitionCreditsWallet
+      balance: {
+        balance: number
+        pending_balance: number
+        available_balance: number
+        currency_code: string
+      }
+    }>("/store/hawala/wallet", {
+      method: "GET",
+      headers: authHeaders,
+      cache: "no-store",
+    })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fetch the customer's recent ledger transactions. Backed by
+ * `/store/hawala/transactions`.
+ */
+export const listCoalitionCreditsTransactions = async (params?: {
+  limit?: number
+  offset?: number
+}): Promise<{ transactions: CoalitionCreditsTransaction[] } | null> => {
+  const authHeaders = await getAuthHeaders()
+  if (!authHeaders) return null
+
+  const query = new URLSearchParams()
+  if (params?.limit) query.set("limit", String(params.limit))
+  if (params?.offset) query.set("offset", String(params.offset))
+  const qs = query.toString()
+  const path = `/store/hawala/transactions${qs ? `?${qs}` : ""}`
+
+  try {
+    return await medusaFetch<{ transactions: CoalitionCreditsTransaction[] }>(
+      path,
+      {
+        method: "GET",
+        headers: authHeaders,
+        cache: "no-store",
+      }
+    )
+  } catch {
+    return null
+  }
+}

--- a/storefront/src/lib/listing/presentation.ts
+++ b/storefront/src/lib/listing/presentation.ts
@@ -1,0 +1,61 @@
+/**
+ * Unified retail/marketplace listing presentation selector per
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §1.1.
+ *
+ * The retail shop and the vendor marketplace are presentation variants
+ * of the same underlying listing record. Routing decides which template
+ * renders based on:
+ *   - the entry path (`/shop/...` defaults to retail, `/products/...`
+ *     and `/sellers/.../products/...` default to marketplace)
+ *   - the storefront context cookie (organization_id + storefront_id)
+ *   - the seller handle (when the buyer is browsing a specific
+ *     vendor's storefront, marketplace presentation is correct
+ *     regardless of entry path)
+ *
+ * Pure function, no I/O. Callers fetch the storefront context separately
+ * via `getStorefrontContext()` and feed it in here.
+ */
+
+export type Presentation = "retail" | "marketplace"
+
+export type StorefrontContextLike = {
+  organization_id?: string | undefined
+  storefront_id?: string | undefined
+}
+
+export type SelectPresentationInput = {
+  /**
+   * The path segment that owns the route. Use the literal `"shop"` for
+   * the public retail entry and `"products"` for the marketplace entry.
+   * Anything else falls through to context-based selection.
+   */
+  routeKind?: "shop" | "products" | "seller" | "embed" | "other"
+  storefrontContext?: StorefrontContextLike
+  /**
+   * Present when the buyer is on a specific vendor's storefront page;
+   * marketplace presentation is the right answer in that case.
+   */
+  sellerHandle?: string | null
+  /**
+   * MXID lookup result (optional). When the buyer is a coalition member
+   * with active membership, marketplace presentation is preferred so
+   * they see vendor-forward chrome.
+   */
+  isCoalitionMember?: boolean
+}
+
+export function selectPresentation(input: SelectPresentationInput): Presentation {
+  if (input.routeKind === "shop") return "retail"
+  if (input.sellerHandle) return "marketplace"
+  if (input.routeKind === "embed") return "marketplace"
+
+  if (input.storefrontContext?.organization_id && input.storefrontContext?.storefront_id) {
+    return "marketplace"
+  }
+
+  if (input.isCoalitionMember) return "marketplace"
+
+  if (input.routeKind === "products") return "marketplace"
+
+  return "retail"
+}

--- a/storefront/src/lib/listing/presentation.ts
+++ b/storefront/src/lib/listing/presentation.ts
@@ -45,16 +45,23 @@ export type SelectPresentationInput = {
 }
 
 export function selectPresentation(input: SelectPresentationInput): Presentation {
-  if (input.routeKind === "shop") return "retail"
+  // Strong marketplace signals override the route default. A buyer on a
+  // coalition's storefront should see vendor-forward chrome even when
+  // they entered through `/shop/...`; a vendor's own product page is
+  // always marketplace presentation.
   if (input.sellerHandle) return "marketplace"
   if (input.routeKind === "embed") return "marketplace"
-
-  if (input.storefrontContext?.organization_id && input.storefrontContext?.storefront_id) {
+  if (
+    input.storefrontContext?.organization_id &&
+    input.storefrontContext?.storefront_id
+  ) {
     return "marketplace"
   }
-
   if (input.isCoalitionMember) return "marketplace"
 
+  // No marketplace signals: route defaults take over. `/shop` → retail,
+  // `/products` → marketplace, anything else → retail.
+  if (input.routeKind === "shop") return "retail"
   if (input.routeKind === "products") return "marketplace"
 
   return "retail"

--- a/storefront/src/lib/runtime/embed-context.ts
+++ b/storefront/src/lib/runtime/embed-context.ts
@@ -1,0 +1,47 @@
+/**
+ * Capacitor / in-app webview embed-context detector for the FBM
+ * storefront per AGGRESSIVE_OPERATIONS_GUIDE.md §2.8 and §5.1.
+ *
+ * The Blackout Capacitor wrapper signals embedded rendering by setting
+ * the `X-FBM-Embed-Origin` request header. When present and the origin
+ * is in the configured allowlist, the storefront swaps strict-origin
+ * cookies / iframe defaults for delegated-auth-friendly equivalents.
+ *
+ * Pure helpers here so middleware, server components, and the bootstrap
+ * endpoint can all share the same logic.
+ */
+
+const EMBED_ORIGIN_HEADER = "x-fbm-embed-origin"
+
+export type EmbedContext = {
+  isEmbedded: boolean
+  origin: string | null
+  isAllowedOrigin: boolean
+}
+
+export function getAllowedEmbedOrigins(): string[] {
+  const raw = process.env.BLACKOUT_EMBED_ALLOWED_ORIGINS ?? ""
+  return raw
+    .split(",")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0)
+}
+
+/**
+ * Detect embed context from a Headers-like input (Next.js request
+ * headers, fetch Headers, or a plain object). Origin allowlist is
+ * compared case-insensitively.
+ */
+export function detectEmbedContext(headers: {
+  get: (name: string) => string | null
+}): EmbedContext {
+  const origin = headers.get(EMBED_ORIGIN_HEADER)
+  if (!origin) {
+    return { isEmbedded: false, origin: null, isAllowedOrigin: false }
+  }
+  const allowed = getAllowedEmbedOrigins().map((o) => o.toLowerCase())
+  const isAllowed = allowed.includes(origin.toLowerCase())
+  return { isEmbedded: true, origin, isAllowedOrigin: isAllowed }
+}
+
+export const EMBED_HEADER_NAME = EMBED_ORIGIN_HEADER

--- a/storefront/src/middleware.ts
+++ b/storefront/src/middleware.ts
@@ -1,5 +1,6 @@
 import { HttpTypes } from "@medusajs/types"
 import { NextRequest, NextResponse } from "next/server"
+import { detectEmbedContext } from "./lib/runtime/embed-context"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || ""
 const PUBLISHABLE_API_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
@@ -130,6 +131,33 @@ function applyAttributionCookies(request: NextRequest, response: NextResponse) {
   }
 }
 
+/**
+ * Capacitor / in-app webview embed support per
+ * AGGRESSIVE_OPERATIONS_GUIDE.md §2.8 and §5.1. When the request
+ * carries `X-FBM-Embed-Origin` and the origin is allowlisted via
+ * `BLACKOUT_EMBED_ALLOWED_ORIGINS`, swap the default
+ * `X-Frame-Options: SAMEORIGIN` for a `frame-ancestors` CSP that names
+ * the embed origin. Origins outside the allowlist do not get the
+ * relaxed headers, so a malicious origin cannot opt itself in.
+ */
+function applyEmbedHeaders(request: NextRequest, response: NextResponse) {
+  const ctx = detectEmbedContext({
+    get: (name) => request.headers.get(name),
+  })
+  if (!ctx.isEmbedded || !ctx.isAllowedOrigin || !ctx.origin) return
+
+  // Override the default X-Frame-Options applied via next.config.ts
+  // headers(); modern browsers honor frame-ancestors over X-Frame-Options
+  // when both are present.
+  response.headers.set(
+    "Content-Security-Policy",
+    `frame-ancestors ${ctx.origin}`
+  )
+  // Echo the resolved origin for debugging the handshake from inside
+  // the webview without exposing it to non-embed callers.
+  response.headers.set("X-FBM-Embed-Origin-Echo", ctx.origin)
+}
+
 export async function middleware(request: NextRequest) {
   // Short-circuit static assets
   if (request.nextUrl.pathname.includes(".")) {
@@ -146,6 +174,7 @@ export async function middleware(request: NextRequest) {
   if (looksLikeLocale && cacheIdCookie) {
     const fastResponse = NextResponse.next()
     applyAttributionCookies(request, fastResponse)
+    applyEmbedHeaders(request, fastResponse)
     return fastResponse
   }
 
@@ -160,6 +189,7 @@ export async function middleware(request: NextRequest) {
   }
 
   applyAttributionCookies(request, response)
+  applyEmbedHeaders(request, response)
 
   const regionMap = await getRegionMap(cacheId)
   if (!regionMap.size) {

--- a/vendor-panel/package.json
+++ b/vendor-panel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vendor-panel",
   "version": "1.0.0",
+  "packageManager": "pnpm@10.13.1",
   "pnpm": {
     "overrides": {
       "axios": ">=1.13.5",


### PR DESCRIPTION
Adds the canonical Matrix MXID identity column to seller_metadata, wires the
entitlements service to derive FBM commerce permissions from
governance.role.<role>.<coalition_id> grants, and ships an idempotent
backfill script with manual-override + Synapse user-directory + synthesis
fallbacks.

- Add nullable mxid column + partial unique index to seller_metadata
- New static GOVERNANCE_FBM_PERMISSIONS / GOVERNANCE_VOTE_ELIGIBILITY /
  GOVERNANCE_POWER_LEVEL maps in the entitlement service
- New EntitlementModuleService.getGovernanceRoles(mxid) method
- evaluateAccess() now answers governance-proposal and platform-admin
  decisions instead of returning foundation_milestone_pending
- Replace the 501 in /v1/integrations/blackout/entitlements/governance-roles
  with the real implementation
- Drop x-foundation-milestone marker from governance-roles in the OpenAPI
  contract; clarify description to reflect the static role→permission map
- Add unit tests for getGovernanceRoles and the new evaluateAccess branches
- New backend/src/scripts/backfill-mxid.ts with manual-override CSV,
  matrix-js-sdk Synapse lookup, and email-localpart synthesis fallbacks
- New docs/runbooks/MXID_VENDOR_BACKFILL.md covering pre-flight, dry-run,
  live run, verification queries, and rollback procedures

https://claude.ai/code/session_01TMcm47SUV4VqZKeeatg1Hi