### PR TITLE
feat(playbook): wire 3-question picker into onboarding + backfill legacy sellers

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,6 +14,10 @@ concurrency:
   group: security-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '9'
+
 permissions:
   contents: read
   security-events: write
@@ -21,6 +25,41 @@ permissions:
   actions: read
 
 jobs:
+  posture-a-compliance:
+    name: Posture A Compliance (CCR closed-loop invariants)
+    runs-on: ubuntu-latest
+    # This gate enforces the architectural invariants documented in
+    # docs/POSTURE_A_COMPLIANCE.md. A failing test here means Coalition
+    # Credits could move without a goods/services purchase context — which
+    # collapses the payment-facilitator exemption and triggers FinCEN MSB
+    # classification. Do NOT add continue-on-error, do NOT downgrade to a
+    # warning. Loosening these tests requires a written compliance review.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm via corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Posture A invariants
+        working-directory: backend
+        run: pnpm test:posture-a
+        env:
+          NODE_ENV: test
+
   gitleaks:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,8 @@
     "test:integration:http": "TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
     "test:integration:modules": "TEST_TYPE=integration:modules NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
     "test:unit": "TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --silent --runInBand --forceExit --coverage --coverageProvider=v8",
-    "test:unit:ci": "npm run test:unit && node ./scripts/ensure-coverage.js"
+    "test:unit:ci": "npm run test:unit && node ./scripts/ensure-coverage.js",
+    "test:posture-a": "TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --runInBand --forceExit --testPathPattern=posture-a-invariants"
   },
   "dependencies": {
     "@bmc/restaurant-marketplace": "file:./restaurant-marketplace",

--- a/backend/src/api/store/carts/[id]/tier/route.ts
+++ b/backend/src/api/store/carts/[id]/tier/route.ts
@@ -1,0 +1,210 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  BASE_UNIT_PRICE_METADATA_KEY,
+  computeTierUnitPriceMinor,
+  isSlidingScaleTier,
+  SLIDING_SCALE_TIERS,
+  SlidingScaleTier,
+} from "../../../../../lib/sliding-scale"
+import {
+  PLAYBOOK_MODULE,
+  PLAYBOOK_RECIPES,
+  type PlaybookId,
+} from "../../../../../modules/playbook"
+
+type Body = { tier?: unknown }
+
+/**
+ * Apply the buyer's sliding-scale tier to the cart.
+ *
+ * 1. Validates the tier ∈ {supporter, standard, solidarity}.
+ * 2. Loads every line item with its product metadata, finds the seller
+ *    each product belongs to, and looks up the seller's playbook
+ *    assignment.
+ * 3. For each item whose seller's playbook has `allow_sliding_scale:
+ *    true`, computes the tier-adjusted unit_price via
+ *    `lib/sliding-scale.ts` and overrides the line item (setting
+ *    is_custom_price so Medusa's pricing flow respects the override).
+ * 4. Stashes the base (standard-tier, i.e. listed) unit price on line
+ *    item metadata under BASE_UNIT_PRICE_METADATA_KEY on first apply,
+ *    so subsequent re-applies (buyer toggles between tiers) always
+ *    derive from the original listed price rather than compounding.
+ * 5. Writes `cart.metadata.tier` and returns the cart.
+ *
+ * Line items from products on a Stall-playbook seller (or any seller
+ * without a playbook assignment yet) are left untouched.
+ *
+ * Idempotency: calling with the currently-applied tier is a no-op for
+ * line items whose stashed base equals their current unit_price.
+ */
+export async function POST(req: MedusaRequest<Body>, res: MedusaResponse) {
+  const { id } = req.params
+  if (!id) return res.status(400).json({ message: "cart id is required" })
+
+  const body = (req.validatedBody || req.body || {}) as Body
+  const tier = body.tier
+  if (!isSlidingScaleTier(tier)) {
+    return res.status(400).json({
+      message: `tier must be one of: ${SLIDING_SCALE_TIERS.join(", ")}`,
+    })
+  }
+
+  const cartModule: any = req.scope.resolve(Modules.CART)
+  const playbookService: any = req.scope.resolve(PLAYBOOK_MODULE)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: carts } = await query.graph({
+    entity: "cart",
+    fields: [
+      "id",
+      "metadata",
+      "items.id",
+      "items.product_id",
+      "items.unit_price",
+      "items.is_custom_price",
+      "items.metadata",
+    ],
+    filters: { id },
+  })
+  const cart = carts?.[0]
+  if (!cart) return res.status(404).json({ message: "Cart not found" })
+
+  const items = (cart.items ?? []) as Array<{
+    id: string
+    product_id: string | null
+    unit_price: number | string
+    is_custom_price?: boolean
+    metadata: Record<string, unknown> | null
+  }>
+
+  const productIds = Array.from(
+    new Set(items.map((i) => i.product_id).filter((p): p is string => !!p))
+  )
+
+  // productId -> { seller_id, metadata }
+  const productInfo = new Map<
+    string,
+    { sellerId: string | null; metadata: Record<string, unknown> }
+  >()
+
+  if (productIds.length > 0) {
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: ["id", "products.id", "products.metadata"],
+      filters: { "products.id": productIds },
+    })
+    for (const seller of (sellers ?? []) as Array<{
+      id: string
+      products?: Array<{ id: string; metadata?: Record<string, unknown> | null }>
+    }>) {
+      for (const product of seller.products ?? []) {
+        if (!product?.id) continue
+        productInfo.set(product.id, {
+          sellerId: seller.id,
+          metadata: (product.metadata ?? {}) as Record<string, unknown>,
+        })
+      }
+    }
+  }
+
+  // Batch the playbook lookup per unique seller.
+  const sellerIds = Array.from(
+    new Set(
+      Array.from(productInfo.values())
+        .map((v) => v.sellerId)
+        .filter((s): s is string => !!s)
+    )
+  )
+
+  const sellerAllowsSliding = new Map<string, boolean>()
+  if (sellerIds.length > 0) {
+    const assignments = (await playbookService.listPlaybookAssignments({
+      seller_id: sellerIds,
+    })) as Array<{ seller_id: string; recipe_id: string | null }>
+    for (const a of assignments ?? []) {
+      const recipe = a.recipe_id
+        ? PLAYBOOK_RECIPES[a.recipe_id as PlaybookId]
+        : null
+      sellerAllowsSliding.set(a.seller_id, recipe?.allow_sliding_scale === true)
+    }
+  }
+
+  const updates: Array<{
+    id: string
+    unit_price: number
+    is_custom_price: boolean
+    metadata: Record<string, unknown>
+  }> = []
+
+  for (const item of items) {
+    if (!item.product_id) continue
+    const info = productInfo.get(item.product_id)
+    if (!info?.sellerId) continue
+    if (!sellerAllowsSliding.get(info.sellerId)) continue
+
+    const itemMeta = (item.metadata ?? {}) as Record<string, unknown>
+    const stashed = itemMeta[BASE_UNIT_PRICE_METADATA_KEY]
+    const currentUnitPrice =
+      typeof item.unit_price === "string"
+        ? Number(item.unit_price)
+        : item.unit_price
+
+    // On first apply, stash the current unit_price as the base. On
+    // subsequent applies, always derive from the stash so toggling
+    // between tiers stays referenced to the original listed price.
+    const basePriceMinor =
+      typeof stashed === "number" && Number.isFinite(stashed) && stashed >= 0
+        ? stashed
+        : currentUnitPrice
+
+    if (!Number.isFinite(basePriceMinor) || basePriceMinor < 0) continue
+
+    const nextUnitPrice = computeTierUnitPriceMinor(
+      tier as SlidingScaleTier,
+      basePriceMinor,
+      info.metadata
+    )
+
+    const nextMetadata: Record<string, unknown> = {
+      ...itemMeta,
+      [BASE_UNIT_PRICE_METADATA_KEY]: basePriceMinor,
+      sliding_scale_tier: tier,
+    }
+
+    // True idempotency: re-saving the same tier on an already-priced
+    // line item is a no-op.
+    if (
+      nextUnitPrice === currentUnitPrice &&
+      item.is_custom_price === true &&
+      itemMeta[BASE_UNIT_PRICE_METADATA_KEY] === basePriceMinor &&
+      itemMeta.sliding_scale_tier === tier
+    ) {
+      continue
+    }
+
+    updates.push({
+      id: item.id,
+      unit_price: nextUnitPrice,
+      is_custom_price: true,
+      metadata: nextMetadata,
+    })
+  }
+
+  if (updates.length > 0) {
+    await cartModule.updateLineItems(updates)
+  }
+
+  const existingMd = (cart.metadata || {}) as Record<string, unknown>
+  if (existingMd.tier !== tier) {
+    await cartModule.updateCarts(id, {
+      metadata: { ...existingMd, tier },
+    })
+  }
+
+  return res.json({
+    cart_id: id,
+    tier,
+    line_items_repriced: updates.length,
+  })
+}

--- a/backend/src/api/vendor/__tests__/playbook-assign-route.unit.spec.ts
+++ b/backend/src/api/vendor/__tests__/playbook-assign-route.unit.spec.ts
@@ -1,0 +1,222 @@
+import { GET, POST } from "../playbook/assign/route"
+
+jest.mock("../../../shared", () => ({
+  requireSellerId: jest.fn(),
+}))
+
+const mockWorkflowRun = jest.fn()
+jest.mock("../../../workflows/assign-playbook", () => ({
+  assignPlaybookWorkflow: jest.fn(() => ({
+    run: (args: any) => mockWorkflowRun(args),
+  })),
+}))
+
+jest.mock("../../../modules/playbook", () => ({
+  PLAYBOOK_MODULE: "playbook",
+  PLAYBOOK_IDS: [
+    "stall",
+    "atelier",
+    "grove",
+    "workshop",
+    "commons",
+    "cycle",
+    "kitchen",
+    "harvest",
+    "hub",
+    "service",
+  ],
+}))
+
+import { requireSellerId } from "../../../shared"
+
+const createRes = () => {
+  const res: any = { statusCode: 200, body: undefined }
+  res.status = (code: number) => {
+    res.statusCode = code
+    return res
+  }
+  res.json = (payload: any) => {
+    res.body = payload
+    return res
+  }
+  return res
+}
+
+const makeReq = (
+  body: any,
+  opts: { listPlaybookAssignments?: jest.Mock } = {}
+) => ({
+  body,
+  scope: {
+    resolve: (key: string) => {
+      if (key === "playbook") {
+        return {
+          listPlaybookAssignments:
+            opts.listPlaybookAssignments ?? jest.fn().mockResolvedValue([]),
+        }
+      }
+      return {}
+    },
+  },
+})
+
+beforeEach(() => {
+  ;(requireSellerId as jest.Mock).mockReset()
+  mockWorkflowRun.mockReset()
+})
+
+describe("GET /vendor/playbook/assign", () => {
+  it("returns null when seller has no assignment", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_123")
+    const list = jest.fn().mockResolvedValue([])
+    const res = createRes()
+    await GET(
+      makeReq(undefined, { listPlaybookAssignments: list }) as any,
+      res as any
+    )
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ playbook_assignment: null })
+    expect(list).toHaveBeenCalledWith({ seller_id: "sel_123" })
+  })
+
+  it("returns the existing assignment row", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_123")
+    const row = { id: "pa_1", seller_id: "sel_123", recipe_id: "stall" }
+    const list = jest.fn().mockResolvedValue([row])
+    const res = createRes()
+    await GET(
+      makeReq(undefined, { listPlaybookAssignments: list }) as any,
+      res as any
+    )
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ playbook_assignment: row })
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    // requireSellerId already writes 401 + returns null when unauthenticated.
+    ;(requireSellerId as jest.Mock).mockImplementation(async (_req, res) => {
+      res.status(401).json({ message: "Unauthorized" })
+      return null
+    })
+    const res = createRes()
+    await GET(makeReq(undefined) as any, res as any)
+    expect(res.statusCode).toBe(401)
+  })
+})
+
+describe("POST /vendor/playbook/assign", () => {
+  it("upserts via workflow with valid input", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_123")
+    const row = {
+      id: "pa_1",
+      seller_id: "sel_123",
+      recipe_id: "atelier",
+      playbook_id: "pb_1",
+    }
+    mockWorkflowRun.mockResolvedValue({
+      result: { playbook_assignment: row },
+    })
+
+    const res = createRes()
+    await POST(
+      makeReq({
+        recipe_id: "atelier",
+        answers: {
+          size: "solo",
+          governance: "i_decide",
+          offering: "make_or_grow",
+        },
+        recommended_recipe_id: "stall",
+        overridden: true,
+      }) as any,
+      res as any
+    )
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ playbook_assignment: row })
+    expect(mockWorkflowRun).toHaveBeenCalledWith({
+      input: {
+        seller_id: "sel_123",
+        recipe_id: "atelier",
+        answers: {
+          size: "solo",
+          governance: "i_decide",
+          offering: "make_or_grow",
+        },
+        recommended_recipe_id: "stall",
+        migrated_from: null,
+      },
+    })
+  })
+
+  it("rejects invalid recipe_id with 400", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_123")
+    const res = createRes()
+    await POST(makeReq({ recipe_id: "not_a_real_playbook" }) as any, res as any)
+    expect(res.statusCode).toBe(400)
+    expect(res.body.type).toBe("invalid_data")
+    expect(mockWorkflowRun).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid answers shape with 400", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_123")
+    const res = createRes()
+    await POST(
+      makeReq({
+        recipe_id: "stall",
+        answers: { size: "huge", governance: "i_decide", offering: "make_or_grow" },
+      }) as any,
+      res as any
+    )
+    expect(res.statusCode).toBe(400)
+    expect(res.body.message).toMatch(/Invalid answers.size/)
+  })
+
+  it("accepts payload without answers (programmatic assignment)", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_456")
+    mockWorkflowRun.mockResolvedValue({
+      result: { playbook_assignment: { id: "pa_2", seller_id: "sel_456", recipe_id: "grove" } },
+    })
+    const res = createRes()
+    await POST(makeReq({ recipe_id: "grove" }) as any, res as any)
+    expect(res.statusCode).toBe(200)
+    expect(mockWorkflowRun).toHaveBeenCalledWith({
+      input: {
+        seller_id: "sel_456",
+        recipe_id: "grove",
+        answers: undefined,
+        recommended_recipe_id: undefined,
+        migrated_from: null,
+      },
+    })
+  })
+
+  it("ignores client-supplied migrated_from (server-controlled only)", async () => {
+    ;(requireSellerId as jest.Mock).mockResolvedValue("sel_789")
+    mockWorkflowRun.mockResolvedValue({
+      result: { playbook_assignment: { id: "pa_3", seller_id: "sel_789", recipe_id: "stall" } },
+    })
+    const res = createRes()
+    await POST(
+      makeReq({ recipe_id: "stall", migrated_from: "producer" } as any) as any,
+      res as any
+    )
+    expect(res.statusCode).toBe(200)
+    expect(mockWorkflowRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ migrated_from: null }),
+      })
+    )
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    ;(requireSellerId as jest.Mock).mockImplementation(async (_req, res) => {
+      res.status(401).json({ message: "Unauthorized" })
+      return null
+    })
+    const res = createRes()
+    await POST(makeReq({ recipe_id: "stall" }) as any, res as any)
+    expect(res.statusCode).toBe(401)
+    expect(mockWorkflowRun).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/api/vendor/notifications/buckets/route.ts
+++ b/backend/src/api/vendor/notifications/buckets/route.ts
@@ -1,0 +1,102 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { requireSellerId } from "../../../../shared"
+import {
+  classifyNotification,
+  countByBucket,
+  NOTIFICATION_BUCKETS,
+  type NotificationBucket,
+} from "../../../../lib/notification-buckets"
+
+type NotificationRow = {
+  id: string
+  template: string | null
+  data: Record<string, unknown> | null
+  created_at: string
+}
+
+/**
+ * GET /vendor/notifications/buckets
+ *
+ * Returns per-bucket counts plus the most-recent N notifications in each
+ * bucket so the vendor-panel drawer can render three tabs without a
+ * second round-trip. The "awaits_me" bucket is the primary signal — the
+ * UI is expected to surface its count as a badge on the bell icon.
+ *
+ * The endpoint is read-only and idempotent. Pagination per bucket is
+ * out of scope here; the existing `GET /vendor/notifications` (Mercur
+ * native) remains the cursor for deep history.
+ *
+ * Query params
+ *   limit          number   default 5     items per bucket (max 50)
+ *   since          ISO date optional      only count rows after this ts
+ *
+ * Response
+ *   {
+ *     counts:   { awaits_me, about_me, fyi },
+ *     samples:  { awaits_me: NotificationRow[], about_me: [], fyi: [] }
+ *   }
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const requested = Number(req.query?.limit)
+  const limit =
+    Number.isFinite(requested) && requested > 0
+      ? Math.min(Math.floor(requested), 50)
+      : 5
+
+  const sinceRaw = req.query?.since
+  const since =
+    typeof sinceRaw === "string" && sinceRaw.length > 0 ? sinceRaw : null
+
+  const filters: Record<string, unknown> = {
+    channel: "seller_feed",
+    to: sellerId,
+  }
+  if (since) {
+    // The query graph accepts Mikro-style operators on dateTime fields.
+    filters["created_at"] = { $gte: since }
+  }
+
+  const { data } = (await query.graph({
+    entity: "notification",
+    fields: ["id", "template", "data", "created_at"],
+    filters,
+    pagination: {
+      // Cap the per-call read; the vendor drawer surfaces only the top
+      // few. Bucketing N rows in memory is fine for this size.
+      take: 500,
+      order: { created_at: "DESC" },
+    },
+  })) as { data: NotificationRow[] }
+
+  const rows = data ?? []
+
+  const counts = countByBucket(rows)
+
+  const samples: Record<NotificationBucket, NotificationRow[]> = {
+    awaits_me: [],
+    about_me: [],
+    fyi: [],
+  }
+
+  for (const row of rows) {
+    const bucket = classifyNotification(row.template)
+    if (samples[bucket].length < limit) {
+      samples[bucket].push(row)
+    }
+    // Early exit when every bucket is full.
+    if (NOTIFICATION_BUCKETS.every((b) => samples[b].length >= limit)) {
+      break
+    }
+  }
+
+  return res.json({ counts, samples })
+}

--- a/backend/src/api/vendor/playbook/assign/route.ts
+++ b/backend/src/api/vendor/playbook/assign/route.ts
@@ -1,0 +1,171 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { requireSellerId } from "../../../../shared"
+import {
+  assignPlaybookWorkflow,
+  type AssignPlaybookInput,
+} from "../../../../workflows/assign-playbook"
+import {
+  PLAYBOOK_MODULE,
+  PLAYBOOK_IDS,
+  type PlaybookId,
+} from "../../../../modules/playbook"
+
+type PostBody = {
+  recipe_id?: string
+  answers?: AssignPlaybookInput["answers"]
+  recommended_recipe_id?: string
+  overridden?: boolean
+}
+
+const SIZE_VALUES = new Set(["solo", "small", "medium", "federation"])
+const GOVERNANCE_VALUES = new Set([
+  "i_decide",
+  "informal_agreement",
+  "circles",
+  "elected_reps",
+  "federation_council",
+])
+const OFFERING_VALUES = new Set([
+  "make_or_grow",
+  "services",
+  "subscription_or_season",
+  "kitchen_food",
+  "harvest_pool",
+  "aggregator",
+])
+
+function isPlaybookId(value: unknown): value is PlaybookId {
+  return typeof value === "string" && (PLAYBOOK_IDS as string[]).includes(value)
+}
+
+function validateAnswers(answers: unknown): {
+  ok: true
+  value: AssignPlaybookInput["answers"]
+} | { ok: false; message: string } {
+  if (answers === undefined || answers === null) {
+    return { ok: true, value: undefined }
+  }
+  if (typeof answers !== "object") {
+    return { ok: false, message: "answers must be an object" }
+  }
+  const a = answers as Record<string, unknown>
+  if (!SIZE_VALUES.has(String(a.size))) {
+    return { ok: false, message: `Invalid answers.size: ${String(a.size)}` }
+  }
+  if (!GOVERNANCE_VALUES.has(String(a.governance))) {
+    return { ok: false, message: `Invalid answers.governance: ${String(a.governance)}` }
+  }
+  if (!OFFERING_VALUES.has(String(a.offering))) {
+    return { ok: false, message: `Invalid answers.offering: ${String(a.offering)}` }
+  }
+  return {
+    ok: true,
+    value: {
+      size: a.size,
+      governance: a.governance,
+      offering: a.offering,
+    } as AssignPlaybookInput["answers"],
+  }
+}
+
+/**
+ * GET /vendor/playbook/assign
+ *
+ * Returns the authenticated seller's current playbook assignment, or
+ * `null` when none exists. Used by the onboarding gate and the
+ * dashboard banner to decide whether to surface the picker.
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  try {
+    const playbookService: any = req.scope.resolve(PLAYBOOK_MODULE)
+    const [assignment] = await playbookService.listPlaybookAssignments({
+      seller_id: sellerId,
+    })
+    return res.json({ playbook_assignment: assignment ?? null })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    console.error("[GET /vendor/playbook/assign] Error:", message)
+    return res.status(500).json({
+      type: "server_error",
+      message: "Failed to fetch playbook assignment",
+    })
+  }
+}
+
+/**
+ * POST /vendor/playbook/assign
+ *
+ * Upserts the seller's playbook assignment via `assignPlaybookWorkflow`.
+ * The workflow is idempotent (unique on `seller_id`); re-posting with a
+ * different `recipe_id` updates the existing row in place.
+ *
+ * Body:
+ *   - recipe_id (required): one of the ten PlaybookIds
+ *   - answers (optional): { size, governance, offering }
+ *   - recommended_recipe_id (optional): what the picker showed
+ *   - overridden (optional): true when the user picked a non-recommended
+ *     recipe; ignored if `recommended_recipe_id` differs from `recipe_id`
+ *     (the workflow derives it).
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest<PostBody>,
+  res: MedusaResponse
+) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const body = (req.body ?? {}) as PostBody
+
+  if (!isPlaybookId(body.recipe_id)) {
+    return res.status(400).json({
+      type: "invalid_data",
+      message: `Invalid recipe_id: ${String(body.recipe_id)}. Must be one of ${PLAYBOOK_IDS.join(", ")}`,
+    })
+  }
+
+  if (
+    body.recommended_recipe_id !== undefined &&
+    body.recommended_recipe_id !== null &&
+    !isPlaybookId(body.recommended_recipe_id)
+  ) {
+    return res.status(400).json({
+      type: "invalid_data",
+      message: `Invalid recommended_recipe_id: ${String(body.recommended_recipe_id)}`,
+    })
+  }
+
+  const answersResult = validateAnswers(body.answers)
+  if (!answersResult.ok) {
+    return res.status(400).json({
+      type: "invalid_data",
+      message: answersResult.message,
+    })
+  }
+
+  try {
+    const input: AssignPlaybookInput = {
+      seller_id: sellerId,
+      recipe_id: body.recipe_id,
+      answers: answersResult.value,
+      recommended_recipe_id: isPlaybookId(body.recommended_recipe_id)
+        ? body.recommended_recipe_id
+        : undefined,
+      // `migrated_from` is server-controlled (set by backfill script);
+      // ignore any client-supplied value here.
+      migrated_from: null,
+    }
+
+    const { result } = await assignPlaybookWorkflow(req.scope).run({ input })
+    return res.json({ playbook_assignment: result.playbook_assignment })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    console.error("[POST /vendor/playbook/assign] Error:", message)
+    return res.status(500).json({
+      type: "server_error",
+      message: `Failed to assign playbook: ${message}`,
+    })
+  }
+}

--- a/backend/src/lib/__tests__/notification-buckets.unit.spec.ts
+++ b/backend/src/lib/__tests__/notification-buckets.unit.spec.ts
@@ -1,0 +1,126 @@
+import {
+  BUCKET_LABELS,
+  classifyNotification,
+  countByBucket,
+  NOTIFICATION_BUCKETS,
+  type NotificationBucket,
+} from "../notification-buckets"
+
+describe("notification-buckets: taxonomy", () => {
+  it("exposes the three buckets in canonical order", () => {
+    expect(NOTIFICATION_BUCKETS).toEqual(["awaits_me", "about_me", "fyi"])
+  })
+
+  it("has a human-readable label for each bucket", () => {
+    for (const b of NOTIFICATION_BUCKETS) {
+      expect(BUCKET_LABELS[b]).toBeTruthy()
+    }
+  })
+})
+
+describe("notification-buckets: classifyNotification", () => {
+  it("classifies new orders as awaits_me (the marquee case)", () => {
+    expect(classifyNotification("seller_new_order_notification")).toBe("awaits_me")
+  })
+
+  it("classifies action-required and review-needed templates as awaits_me", () => {
+    expect(
+      classifyNotification("seller_verification_action_required_notification")
+    ).toBe("awaits_me")
+    expect(
+      classifyNotification("seller_escrow_milestone_review_needed")
+    ).toBe("awaits_me")
+    expect(
+      classifyNotification("seller_order_dispute_opened_notification")
+    ).toBe("awaits_me")
+  })
+
+  it("matches awaits_me pattern fallbacks for novel template names", () => {
+    expect(classifyNotification("fbm_payment_approval_required_v2")).toBe(
+      "awaits_me"
+    )
+    expect(classifyNotification("custom_pending_response_alert")).toBe("awaits_me")
+    expect(classifyNotification("vendor_fulfillment_overdue_24h")).toBe("awaits_me")
+  })
+
+  it("classifies acceptances / rejections / payouts as about_me", () => {
+    expect(
+      classifyNotification(
+        "seller_product_collection_request_accepted_notification"
+      )
+    ).toBe("about_me")
+    expect(
+      classifyNotification("seller_product_request_rejected_notification")
+    ).toBe("about_me")
+    expect(classifyNotification("seller_payout_completed_notification")).toBe(
+      "about_me"
+    )
+  })
+
+  it("classifies explicit broadcasts as fyi", () => {
+    expect(classifyNotification("platform_announcement")).toBe("fyi")
+    expect(classifyNotification("policy_change_notice")).toBe("fyi")
+    expect(classifyNotification("scheduled_maintenance")).toBe("fyi")
+  })
+
+  it("matches fyi pattern fallbacks for novel broadcast names", () => {
+    expect(classifyNotification("broadcast_v3_release_notes")).toBe("fyi")
+    expect(classifyNotification("announcement_2026_q2_roadmap")).toBe("fyi")
+  })
+
+  it("falls back to about_me for unknown templates (safe default)", () => {
+    expect(classifyNotification("some_template_we_have_never_seen")).toBe(
+      "about_me"
+    )
+    expect(classifyNotification("seller_random_event_notification")).toBe(
+      "about_me"
+    )
+  })
+
+  it("handles missing or non-string templates", () => {
+    expect(classifyNotification(null)).toBe("about_me")
+    expect(classifyNotification(undefined)).toBe("about_me")
+    expect(classifyNotification("")).toBe("about_me")
+    expect(classifyNotification(42 as unknown as string)).toBe("about_me")
+  })
+
+  it("awaits_me beats fyi when a template matches both", () => {
+    // Defence-in-depth: action-required overrides a coincidental
+    // "announcement_" prefix.
+    expect(
+      classifyNotification("announcement_action_required_fyi")
+    ).toBe("awaits_me")
+  })
+})
+
+describe("notification-buckets: countByBucket", () => {
+  it("returns zeros for an empty list", () => {
+    expect(countByBucket([])).toEqual({ awaits_me: 0, about_me: 0, fyi: 0 })
+  })
+
+  it("bins notifications correctly across buckets", () => {
+    const counts = countByBucket([
+      { template: "seller_new_order_notification" },
+      { template: "seller_new_order_notification" },
+      { template: "seller_product_request_accepted_notification" },
+      { template: "platform_announcement" },
+      { template: undefined },
+      { template: "broadcast_v2" },
+    ])
+    expect(counts).toEqual<Record<NotificationBucket, number>>({
+      awaits_me: 2,
+      about_me: 2,
+      fyi: 2,
+    })
+  })
+
+  it("is robust to missing/null template fields", () => {
+    const counts = countByBucket([
+      {},
+      { template: null },
+      { template: "" },
+      { template: "seller_new_order_notification" },
+    ])
+    expect(counts).toEqual({ awaits_me: 1, about_me: 3, fyi: 0 })
+  })
+})

--- a/backend/src/lib/__tests__/sliding-scale.unit.spec.ts
+++ b/backend/src/lib/__tests__/sliding-scale.unit.spec.ts
@@ -1,0 +1,156 @@
+import {
+  applyTierMultiplier,
+  BASE_UNIT_PRICE_METADATA_KEY,
+  computeTierUnitPriceMinor,
+  DEFAULT_TIER_MULTIPLIERS_BPS,
+  isSlidingScaleTier,
+  resolveTierAbsolutePriceMinor,
+  resolveTierMultiplierBps,
+  SLIDING_SCALE_TIERS,
+} from "../sliding-scale"
+
+describe("sliding-scale: invariants", () => {
+  it("exposes exactly the three tiers in the documented order", () => {
+    expect(SLIDING_SCALE_TIERS).toEqual(["supporter", "standard", "solidarity"])
+  })
+
+  it("standard tier defaults to 1:1 (10000 bps)", () => {
+    expect(DEFAULT_TIER_MULTIPLIERS_BPS.standard).toBe(10000)
+  })
+
+  it("supporter is above and solidarity is below standard", () => {
+    expect(DEFAULT_TIER_MULTIPLIERS_BPS.supporter).toBeGreaterThan(
+      DEFAULT_TIER_MULTIPLIERS_BPS.standard
+    )
+    expect(DEFAULT_TIER_MULTIPLIERS_BPS.solidarity).toBeLessThan(
+      DEFAULT_TIER_MULTIPLIERS_BPS.standard
+    )
+  })
+
+  it("exports a stable metadata key for stashing the base price", () => {
+    expect(BASE_UNIT_PRICE_METADATA_KEY).toBe("sliding_scale_base_unit_price_minor")
+  })
+})
+
+describe("sliding-scale: isSlidingScaleTier", () => {
+  it.each(["supporter", "standard", "solidarity"])(
+    "accepts %s",
+    (tier) => {
+      expect(isSlidingScaleTier(tier)).toBe(true)
+    }
+  )
+
+  it.each([
+    "Supporter",
+    "SUPPORTER",
+    "premium",
+    "",
+    null,
+    undefined,
+    42,
+    {},
+    [],
+  ])("rejects %p", (val) => {
+    expect(isSlidingScaleTier(val)).toBe(false)
+  })
+})
+
+describe("sliding-scale: resolveTierMultiplierBps", () => {
+  it("returns the default when no overrides are set", () => {
+    expect(resolveTierMultiplierBps("supporter", null)).toBe(12500)
+    expect(resolveTierMultiplierBps("standard", undefined)).toBe(10000)
+    expect(resolveTierMultiplierBps("solidarity", {})).toBe(6500)
+  })
+
+  it("honours a positive numeric override", () => {
+    const md = { sliding_scale_multipliers_bps: { supporter: 13000, solidarity: 7000 } }
+    expect(resolveTierMultiplierBps("supporter", md)).toBe(13000)
+    expect(resolveTierMultiplierBps("solidarity", md)).toBe(7000)
+  })
+
+  it("falls back to the default when an override is missing or invalid", () => {
+    const md = {
+      sliding_scale_multipliers_bps: {
+        supporter: "not a number",
+        solidarity: -100,
+        // standard intentionally absent
+      },
+    }
+    expect(resolveTierMultiplierBps("supporter", md)).toBe(12500)
+    expect(resolveTierMultiplierBps("solidarity", md)).toBe(6500)
+    expect(resolveTierMultiplierBps("standard", md)).toBe(10000)
+  })
+})
+
+describe("sliding-scale: resolveTierAbsolutePriceMinor", () => {
+  it("returns null when no explicit per-tier prices are set", () => {
+    expect(resolveTierAbsolutePriceMinor("supporter", null)).toBeNull()
+    expect(resolveTierAbsolutePriceMinor("supporter", {})).toBeNull()
+  })
+
+  it("returns the explicit price when set, rounded to integer minor units", () => {
+    const md = { sliding_scale_prices_minor: { supporter: 1250.4, solidarity: 800 } }
+    expect(resolveTierAbsolutePriceMinor("supporter", md)).toBe(1250)
+    expect(resolveTierAbsolutePriceMinor("solidarity", md)).toBe(800)
+  })
+
+  it("accepts a zero price (vendor opts certain tier to free)", () => {
+    const md = { sliding_scale_prices_minor: { solidarity: 0 } }
+    expect(resolveTierAbsolutePriceMinor("solidarity", md)).toBe(0)
+  })
+
+  it("rejects negative explicit prices", () => {
+    const md = { sliding_scale_prices_minor: { solidarity: -100 } }
+    expect(resolveTierAbsolutePriceMinor("solidarity", md)).toBeNull()
+  })
+})
+
+describe("sliding-scale: applyTierMultiplier", () => {
+  it("computes the standard tier as exactly the base price", () => {
+    expect(applyTierMultiplier(2500, 10000)).toBe(2500)
+  })
+
+  it("rounds half-up to the nearest minor unit", () => {
+    // 2500 * 12500 / 10000 = 3125 exactly
+    expect(applyTierMultiplier(2500, 12500)).toBe(3125)
+    // 333 * 6500 / 10000 = 216.45 -> 216
+    expect(applyTierMultiplier(333, 6500)).toBe(216)
+    // 333 * 12500 / 10000 = 416.25 -> 416
+    expect(applyTierMultiplier(333, 12500)).toBe(416)
+  })
+
+  it("returns 0 for non-finite or negative inputs (never writes negative)", () => {
+    expect(applyTierMultiplier(NaN, 10000)).toBe(0)
+    expect(applyTierMultiplier(-100, 10000)).toBe(0)
+    expect(applyTierMultiplier(100, 0)).toBe(0)
+    expect(applyTierMultiplier(100, -100)).toBe(0)
+  })
+})
+
+describe("sliding-scale: computeTierUnitPriceMinor", () => {
+  it("uses the listed price for the standard tier with default multipliers", () => {
+    expect(computeTierUnitPriceMinor("standard", 1000, {})).toBe(1000)
+  })
+
+  it("applies default multipliers when no overrides are set", () => {
+    expect(computeTierUnitPriceMinor("supporter", 1000, {})).toBe(1250)
+    expect(computeTierUnitPriceMinor("solidarity", 1000, {})).toBe(650)
+  })
+
+  it("absolute price beats multiplier override", () => {
+    const md = {
+      sliding_scale_prices_minor: { supporter: 1500 },
+      sliding_scale_multipliers_bps: { supporter: 30000 },
+    }
+    expect(computeTierUnitPriceMinor("supporter", 1000, md)).toBe(1500)
+  })
+
+  it("multiplier override beats default when no absolute price is set", () => {
+    const md = { sliding_scale_multipliers_bps: { solidarity: 5000 } }
+    expect(computeTierUnitPriceMinor("solidarity", 1000, md)).toBe(500)
+  })
+
+  it("treats null metadata as 'no overrides'", () => {
+    expect(computeTierUnitPriceMinor("supporter", 800, null)).toBe(1000)
+  })
+})

--- a/backend/src/lib/notification-buckets.ts
+++ b/backend/src/lib/notification-buckets.ts
@@ -1,0 +1,134 @@
+/**
+ * Three-bucket notification classifier.
+ *
+ * The vendor-panel notifications drawer surfaces a flat list of every
+ * notification on the seller's feed. As the surface area grows, that
+ * flat list buries the things sellers actually need to act on. This
+ * helper splits incoming notifications into three buckets so the UI
+ * can show them as tabs and keep the actionable signal up front.
+ *
+ *   awaits_me — actions you must take. New orders to fulfill, returns
+ *               to approve, verification follow-ups, escrow milestones
+ *               waiting on your sign-off. Loud. Counts in the drawer
+ *               header. Source of FBM's "you owe someone a reply" UX.
+ *
+ *   about_me  — things that happened TO you. Reviews left, requests
+ *               accepted/rejected, payouts sent, refunds processed.
+ *               Informational; you can read them at your leisure.
+ *
+ *   fyi       — broadcasts. Platform announcements, scheduled
+ *               maintenance, policy changes. Not personalised; not
+ *               counted in the urgency badge.
+ *
+ * Classification is template-driven. The explicit lists are the source
+ * of truth; the substring-pattern fallbacks keep newly-shipped
+ * templates in a sensible bucket until they're explicitly classified.
+ * Templates that match nothing fall to about_me (the safe default —
+ * most notifications are informational).
+ *
+ * The classifier is pure. The endpoint
+ * `backend/src/api/vendor/notifications/buckets/route.ts` calls it for
+ * every row on the seller_feed; the vendor-panel drawer reads the
+ * resulting bucket counts and per-bucket lists.
+ */
+
+export type NotificationBucket = "awaits_me" | "about_me" | "fyi"
+
+export const NOTIFICATION_BUCKETS: readonly NotificationBucket[] = [
+  "awaits_me",
+  "about_me",
+  "fyi",
+] as const
+
+export const BUCKET_LABELS: Record<NotificationBucket, string> = {
+  awaits_me: "Awaits me",
+  about_me: "About me",
+  fyi: "FYI",
+}
+
+/**
+ * Explicit "this template demands action" templates. Add new ones here
+ * as the platform surfaces them.
+ */
+const AWAITS_ME_TEMPLATES = new Set<string>([
+  // Mercur native
+  "seller_new_order_notification",
+  "seller_order_return_requested_notification",
+  "seller_order_dispute_opened_notification",
+  "seller_verification_action_required_notification",
+  // FBM composition-layer (some forward-looking; safe to list)
+  "seller_escrow_milestone_review_needed",
+  "seller_patronage_request_pending",
+  "seller_bargaining_bid_pending_response",
+  "seller_collective_pool_commit_window_closing",
+])
+
+/**
+ * Pattern fallbacks: any template containing one of these substrings
+ * is awaits_me. Order matters less than coverage — the goal is to
+ * route new templates into the right tab automatically.
+ */
+const AWAITS_ME_PATTERNS: readonly string[] = [
+  "new_order",
+  "action_required",
+  "approval_needed",
+  "approval_required",
+  "fulfillment_overdue",
+  "dispute_opened",
+  "pending_response",
+  "review_needed",
+  "awaiting_signoff",
+]
+
+const FYI_TEMPLATES = new Set<string>([
+  "platform_announcement",
+  "policy_change_notice",
+  "scheduled_maintenance",
+  "feature_launched_announcement",
+])
+
+const FYI_PATTERNS: readonly string[] = [
+  "broadcast_",
+  "announcement_",
+  "platform_news_",
+  "scheduled_maintenance",
+]
+
+/**
+ * Classify a single template into a bucket. Pure; safe to call from
+ * anywhere on the backend or in a worker.
+ */
+export function classifyNotification(
+  template: string | null | undefined
+): NotificationBucket {
+  if (typeof template !== "string" || template.length === 0) {
+    return "about_me"
+  }
+  if (AWAITS_ME_TEMPLATES.has(template)) return "awaits_me"
+  for (const pattern of AWAITS_ME_PATTERNS) {
+    if (template.includes(pattern)) return "awaits_me"
+  }
+  if (FYI_TEMPLATES.has(template)) return "fyi"
+  for (const pattern of FYI_PATTERNS) {
+    if (template.includes(pattern)) return "fyi"
+  }
+  return "about_me"
+}
+
+/**
+ * Count notifications by bucket. Input is an array of objects with a
+ * `template` field; everything else is ignored.
+ */
+export function countByBucket(
+  notifications: ReadonlyArray<{ template?: string | null }>
+): Record<NotificationBucket, number> {
+  const counts: Record<NotificationBucket, number> = {
+    awaits_me: 0,
+    about_me: 0,
+    fyi: 0,
+  }
+  for (const n of notifications) {
+    counts[classifyNotification(n?.template)] += 1
+  }
+  return counts
+}

--- a/backend/src/lib/sliding-scale.ts
+++ b/backend/src/lib/sliding-scale.ts
@@ -1,0 +1,143 @@
+/**
+ * Sliding-scale pricing helper.
+ *
+ * The storefront writes the buyer's tier choice to `cart.metadata.tier`.
+ * `POST /store/carts/:id/tier` reads each line item's product, decides
+ * whether sliding scale applies (the seller's playbook must allow it),
+ * and overrides the line item's `unit_price` for the chosen tier.
+ *
+ * Two override mechanisms, in order of precedence:
+ *   1. Explicit per-tier prices in product metadata:
+ *        product.metadata.sliding_scale_prices_minor = {
+ *          supporter:  <minor units>,
+ *          standard:   <minor units>,
+ *          solidarity: <minor units>,
+ *        }
+ *      A vendor can set absolute prices per tier here. Standard tier is
+ *      typically the listed price (we still record it for symmetry).
+ *
+ *   2. Multiplier in basis points (1 bp = 0.01 %):
+ *        product.metadata.sliding_scale_multipliers_bps = {
+ *          supporter:  <bps, e.g. 12500 = +25 %>,
+ *          standard:   <bps, e.g. 10000 = listed>,
+ *          solidarity: <bps, e.g.  6500 = -35 %>,
+ *        }
+ *      If absent, DEFAULT_TIER_MULTIPLIERS_BPS is used.
+ *
+ * Eligibility is gated upstream: only products whose seller is on a
+ * playbook with `allow_sliding_scale: true` participate (every playbook
+ * except Stall — see backend/src/modules/playbook/recipes/*).
+ *
+ * Posture A note: this is a buyer-facing UX layer. The choice records on
+ * cart/order metadata for downstream patronage accounting, but does not
+ * itself create a transferable claim or modify the CCR closed-loop
+ * invariants enforced in modules/hawala-ledger/posture-a-guard.
+ */
+
+export type SlidingScaleTier = "supporter" | "standard" | "solidarity"
+
+export const SLIDING_SCALE_TIERS: readonly SlidingScaleTier[] = [
+  "supporter",
+  "standard",
+  "solidarity",
+] as const
+
+/**
+ * Default platform-wide multipliers. Picked to land roughly symmetric
+ * around the standard tier so a 1:1 supporter/solidarity ratio
+ * approximately covers the discount.
+ *
+ * Vendors can override per-product via `sliding_scale_multipliers_bps`.
+ */
+export const DEFAULT_TIER_MULTIPLIERS_BPS: Record<SlidingScaleTier, number> = {
+  supporter: 12500, // +25 %
+  standard: 10000, // listed
+  solidarity: 6500, // -35 %
+}
+
+export const BASE_UNIT_PRICE_METADATA_KEY = "sliding_scale_base_unit_price_minor"
+
+export function isSlidingScaleTier(value: unknown): value is SlidingScaleTier {
+  return (
+    typeof value === "string" &&
+    (SLIDING_SCALE_TIERS as readonly string[]).includes(value)
+  )
+}
+
+/**
+ * Resolve the bps multiplier for a tier given the product's metadata.
+ * Falls back to DEFAULT_TIER_MULTIPLIERS_BPS if no override is set.
+ */
+export function resolveTierMultiplierBps(
+  tier: SlidingScaleTier,
+  productMetadata: Record<string, unknown> | null | undefined
+): number {
+  const overrides = (productMetadata?.sliding_scale_multipliers_bps ?? null) as
+    | Record<string, unknown>
+    | null
+  const candidate = overrides?.[tier]
+  if (
+    typeof candidate === "number" &&
+    Number.isFinite(candidate) &&
+    candidate > 0
+  ) {
+    return candidate
+  }
+  return DEFAULT_TIER_MULTIPLIERS_BPS[tier]
+}
+
+/**
+ * Resolve an explicit per-tier price (in minor units) from product
+ * metadata, or `null` if not set. When non-null, this beats the
+ * multiplier path entirely.
+ */
+export function resolveTierAbsolutePriceMinor(
+  tier: SlidingScaleTier,
+  productMetadata: Record<string, unknown> | null | undefined
+): number | null {
+  const explicit = (productMetadata?.sliding_scale_prices_minor ?? null) as
+    | Record<string, unknown>
+    | null
+  const candidate = explicit?.[tier]
+  if (
+    typeof candidate === "number" &&
+    Number.isFinite(candidate) &&
+    candidate >= 0
+  ) {
+    return Math.round(candidate)
+  }
+  return null
+}
+
+/**
+ * Apply a bps multiplier to a base minor-unit price. Rounds to the
+ * nearest minor unit (half-up via Math.round). Negative or non-finite
+ * inputs return 0 — by construction we never write a negative price.
+ */
+export function applyTierMultiplier(
+  basePriceMinor: number,
+  multiplierBps: number
+): number {
+  if (!Number.isFinite(basePriceMinor) || basePriceMinor < 0) return 0
+  if (!Number.isFinite(multiplierBps) || multiplierBps <= 0) return 0
+  return Math.max(0, Math.round((basePriceMinor * multiplierBps) / 10000))
+}
+
+/**
+ * Compute the adjusted unit price for a tier. Absolute price beats
+ * multiplier; multiplier beats default.
+ *
+ * `basePriceMinor` is the listed (standard-tier) price in the currency's
+ * minor units (e.g. cents for USD). Returns the same units.
+ */
+export function computeTierUnitPriceMinor(
+  tier: SlidingScaleTier,
+  basePriceMinor: number,
+  productMetadata: Record<string, unknown> | null | undefined
+): number {
+  const explicit = resolveTierAbsolutePriceMinor(tier, productMetadata)
+  if (explicit !== null) return explicit
+
+  const bps = resolveTierMultiplierBps(tier, productMetadata)
+  return applyTierMultiplier(basePriceMinor, bps)
+}

--- a/backend/src/modules/donation/__tests__/fiscal-sponsors.unit.spec.ts
+++ b/backend/src/modules/donation/__tests__/fiscal-sponsors.unit.spec.ts
@@ -1,0 +1,169 @@
+import {
+  DEFAULT_FISCAL_SPONSOR,
+  deriveDonationSettingsFields,
+  FISCAL_SPONSOR_KEYS,
+  FISCAL_SPONSORS,
+  isFiscalSponsorKey,
+  resolveActiveFiscalSponsor,
+  type FiscalSponsor,
+} from "../fiscal-sponsors"
+
+describe("fiscal-sponsors: registry", () => {
+  it("exposes the four documented candidates", () => {
+    expect(FISCAL_SPONSOR_KEYS).toEqual([
+      "allied_media_projects",
+      "neo_philanthropy",
+      "tides_foundation",
+      "selc_local",
+    ])
+  })
+
+  it("AMP is the default per docs/FISCAL_SPONSOR_DECISION.md", () => {
+    expect(DEFAULT_FISCAL_SPONSOR).toBe("allied_media_projects")
+  })
+
+  it("each candidate has a display name + tagline", () => {
+    for (const key of FISCAL_SPONSOR_KEYS) {
+      const sponsor = FISCAL_SPONSORS[key]
+      expect(sponsor.name).toBeTruthy()
+      expect(sponsor.tagline).toBeTruthy()
+    }
+  })
+
+  it("ships every candidate as not-live (agreement pending)", () => {
+    // Safety invariant: a registry entry must NOT be hard-coded `live`.
+    // Going live is gated on the FBM_FISCAL_SPONSOR_LIVE env flag so
+    // accidentally merging "live: true" can't bypass the agreement.
+    for (const key of FISCAL_SPONSOR_KEYS) {
+      expect(FISCAL_SPONSORS[key].live).toBe(false)
+      expect(FISCAL_SPONSORS[key].ledger_account_id).toBeNull()
+    }
+  })
+})
+
+describe("fiscal-sponsors: isFiscalSponsorKey", () => {
+  it.each(FISCAL_SPONSOR_KEYS)("accepts %s", (key) => {
+    expect(isFiscalSponsorKey(key)).toBe(true)
+  })
+
+  it.each(["", null, undefined, "AlliedMediaProjects", "amp", 42])(
+    "rejects %p",
+    (val) => {
+      expect(isFiscalSponsorKey(val)).toBe(false)
+    }
+  )
+})
+
+describe("fiscal-sponsors: resolveActiveFiscalSponsor", () => {
+  it("returns the default when no env override is set", () => {
+    const sponsor = resolveActiveFiscalSponsor({})
+    expect(sponsor.key).toBe(DEFAULT_FISCAL_SPONSOR)
+    expect(sponsor.name).toBe("Allied Media Projects")
+    expect(sponsor.live).toBe(false)
+    expect(sponsor.ledger_account_id).toBeNull()
+  })
+
+  it("honours FBM_FISCAL_SPONSOR_PROVIDER when set to a known key", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_PROVIDER: "tides_foundation",
+    })
+    expect(sponsor.key).toBe("tides_foundation")
+    expect(sponsor.name).toBe("Tides Foundation")
+  })
+
+  it("falls back to the default for unknown provider values", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_PROVIDER: "nonsense",
+    })
+    expect(sponsor.key).toBe(DEFAULT_FISCAL_SPONSOR)
+  })
+
+  it("flips live=true when FBM_FISCAL_SPONSOR_LIVE=true", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_LIVE: "true",
+    })
+    expect(sponsor.live).toBe(true)
+  })
+
+  it("does not flip live on stray truthy strings (must be exactly 'true')", () => {
+    expect(
+      resolveActiveFiscalSponsor({ FBM_FISCAL_SPONSOR_LIVE: "1" }).live
+    ).toBe(false)
+    expect(
+      resolveActiveFiscalSponsor({ FBM_FISCAL_SPONSOR_LIVE: "yes" }).live
+    ).toBe(false)
+  })
+
+  it("explicitly accepts 'false' to assert live=false even if registry flips later", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_LIVE: "false",
+    })
+    expect(sponsor.live).toBe(false)
+  })
+
+  it("picks up ledger_account_id from env when provided", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_LEDGER_ACCOUNT_ID: "ledger_amp_donation_account",
+    })
+    expect(sponsor.ledger_account_id).toBe("ledger_amp_donation_account")
+  })
+
+  it("ignores empty-string ledger override (treated as not set)", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_LEDGER_ACCOUNT_ID: "",
+    })
+    expect(sponsor.ledger_account_id).toBeNull()
+  })
+
+  it("composes env overrides with the chosen provider", () => {
+    const sponsor = resolveActiveFiscalSponsor({
+      FBM_FISCAL_SPONSOR_PROVIDER: "neo_philanthropy",
+      FBM_FISCAL_SPONSOR_LIVE: "true",
+      FBM_FISCAL_SPONSOR_LEDGER_ACCOUNT_ID: "ledger_neo_test",
+    })
+    expect(sponsor.key).toBe("neo_philanthropy")
+    expect(sponsor.live).toBe(true)
+    expect(sponsor.ledger_account_id).toBe("ledger_neo_test")
+  })
+})
+
+describe("fiscal-sponsors: deriveDonationSettingsFields", () => {
+  const baseSponsor: FiscalSponsor = {
+    key: "allied_media_projects",
+    name: "Allied Media Projects",
+    url: "https://alliedmedia.org",
+    tagline: "—",
+    live: false,
+    ledger_account_id: "ledger_amp_pending",
+  }
+
+  it("surfaces display fields", () => {
+    const fields = deriveDonationSettingsFields(baseSponsor)
+    expect(fields.fiscal_sponsor_name).toBe("Allied Media Projects")
+    expect(fields.fiscal_sponsor_url).toBe("https://alliedmedia.org")
+  })
+
+  it("withholds ledger_account_id until the sponsor is live", () => {
+    expect(
+      deriveDonationSettingsFields({ ...baseSponsor, live: false })
+        .fiscal_sponsor_account_id
+    ).toBeNull()
+  })
+
+  it("surfaces ledger_account_id only when live=true", () => {
+    expect(
+      deriveDonationSettingsFields({ ...baseSponsor, live: true })
+        .fiscal_sponsor_account_id
+    ).toBe("ledger_amp_pending")
+  })
+
+  it("null ledger + live=true still resolves to null (defensive)", () => {
+    expect(
+      deriveDonationSettingsFields({
+        ...baseSponsor,
+        live: true,
+        ledger_account_id: null,
+      }).fiscal_sponsor_account_id
+    ).toBeNull()
+  })
+})

--- a/backend/src/modules/donation/fiscal-sponsors.ts
+++ b/backend/src/modules/donation/fiscal-sponsors.ts
@@ -1,0 +1,165 @@
+/**
+ * Fiscal-sponsor registry.
+ *
+ * FBM does not maintain the donor-recipient relationship directly — a
+ * 501(c)(3) fiscal sponsor receives donations of record, issues donor
+ * receipts, and handles state charity registration. This module is the
+ * single source of truth for which sponsors FBM knows how to route to,
+ * which one is the active default, and what display copy to surface to
+ * donors.
+ *
+ * The active sponsor is selected via env (FBM_FISCAL_SPONSOR_PROVIDER).
+ * A registry entry encodes:
+ *   - display fields safe to surface to the storefront
+ *     (`name`, `url`, `tagline`)
+ *   - the agreement status (`live` true once the signed fiscal
+ *     sponsorship agreement and test transfer are in place)
+ *   - the LedgerAccount id the disbursement job credits (only set
+ *     once the sponsor is live; until then, donations accrue in
+ *     pending state on FBM's books)
+ *
+ * Selection rationale and the AMP-as-default recommendation live in
+ * `docs/FISCAL_SPONSOR_DECISION.md`.
+ */
+
+export type FiscalSponsorKey =
+  | "allied_media_projects"
+  | "neo_philanthropy"
+  | "tides_foundation"
+  | "selc_local"
+
+export type FiscalSponsor = {
+  /** Stable registry key — also the value of FBM_FISCAL_SPONSOR_PROVIDER. */
+  key: FiscalSponsorKey
+  /** Display name for the storefront donation widget. */
+  name: string
+  /** Optional public URL (sponsor's about page, 501c3 status). */
+  url: string | null
+  /** One-line tagline shown alongside the name. */
+  tagline: string
+  /**
+   * The signed fiscal sponsorship agreement + test transfer are in
+   * place. False entries are recorded so we can pre-stage candidates
+   * and switch via env without a deploy.
+   */
+  live: boolean
+  /**
+   * LedgerAccount id the donation-batch-disbursement job credits.
+   * Null until the agreement is in place. Read at runtime; never
+   * surfaced to the storefront.
+   */
+  ledger_account_id: string | null
+}
+
+export const FISCAL_SPONSORS: Record<FiscalSponsorKey, FiscalSponsor> = {
+  allied_media_projects: {
+    key: "allied_media_projects",
+    name: "Allied Media Projects",
+    url: "https://alliedmedia.org",
+    tagline:
+      "Detroit-rooted fiscal sponsor for movement and solidarity-economy projects.",
+    live: false,
+    ledger_account_id: null,
+  },
+  neo_philanthropy: {
+    key: "neo_philanthropy",
+    name: "NEO Philanthropy",
+    url: "https://neophilanthropy.org",
+    tagline: "National fiscal sponsor for social-change initiatives.",
+    live: false,
+    ledger_account_id: null,
+  },
+  tides_foundation: {
+    key: "tides_foundation",
+    name: "Tides Foundation",
+    url: "https://tides.org",
+    tagline: "Broad-spectrum 501(c)(3) fiscal sponsor at scale.",
+    live: false,
+    ledger_account_id: null,
+  },
+  selc_local: {
+    key: "selc_local",
+    name: "SELC-recommended local sponsor",
+    url: "https://www.theselc.org",
+    tagline:
+      "Local fiscal sponsor recommended by the Sustainable Economies Law Center; specific entity selected per launch region.",
+    live: false,
+    ledger_account_id: null,
+  },
+}
+
+export const FISCAL_SPONSOR_KEYS: readonly FiscalSponsorKey[] = [
+  "allied_media_projects",
+  "neo_philanthropy",
+  "tides_foundation",
+  "selc_local",
+] as const
+
+/**
+ * Per `docs/FISCAL_SPONSOR_DECISION.md`, AMP is the default
+ * recommendation. Override via env for staging / future transitions.
+ */
+export const DEFAULT_FISCAL_SPONSOR: FiscalSponsorKey = "allied_media_projects"
+
+export function isFiscalSponsorKey(value: unknown): value is FiscalSponsorKey {
+  return (
+    typeof value === "string" &&
+    (FISCAL_SPONSOR_KEYS as readonly string[]).includes(value)
+  )
+}
+
+/**
+ * Resolve the active sponsor entry by reading
+ * FBM_FISCAL_SPONSOR_PROVIDER and falling back to the default. Pass an
+ * explicit `env` arg (or the FBM_FISCAL_SPONSOR_LIVE / _LEDGER vars) to
+ * override; useful in tests.
+ */
+export function resolveActiveFiscalSponsor(
+  env: NodeJS.ProcessEnv = process.env
+): FiscalSponsor {
+  const requested = env.FBM_FISCAL_SPONSOR_PROVIDER
+  const key = isFiscalSponsorKey(requested) ? requested : DEFAULT_FISCAL_SPONSOR
+  const base = FISCAL_SPONSORS[key]
+
+  // Env overrides for the operational fields. These come from deploy
+  // config (so flipping a sponsor "live" doesn't require a code
+  // change). Display fields stay in the registry.
+  const liveOverride =
+    env.FBM_FISCAL_SPONSOR_LIVE === "true"
+      ? true
+      : env.FBM_FISCAL_SPONSOR_LIVE === "false"
+        ? false
+        : null
+
+  const ledgerOverride =
+    typeof env.FBM_FISCAL_SPONSOR_LEDGER_ACCOUNT_ID === "string" &&
+    env.FBM_FISCAL_SPONSOR_LEDGER_ACCOUNT_ID.length > 0
+      ? env.FBM_FISCAL_SPONSOR_LEDGER_ACCOUNT_ID
+      : null
+
+  return {
+    ...base,
+    live: liveOverride !== null ? liveOverride : base.live,
+    ledger_account_id: ledgerOverride ?? base.ledger_account_id,
+  }
+}
+
+/**
+ * The shape that `donation_settings.fiscal_sponsor_*` columns should be
+ * seeded with. `fiscal_sponsor_account_id` is intentionally only set
+ * when live — pre-live, the column stays null and the disbursement
+ * job no-ops.
+ */
+export function deriveDonationSettingsFields(
+  sponsor: FiscalSponsor
+): {
+  fiscal_sponsor_name: string
+  fiscal_sponsor_url: string | null
+  fiscal_sponsor_account_id: string | null
+} {
+  return {
+    fiscal_sponsor_name: sponsor.name,
+    fiscal_sponsor_url: sponsor.url,
+    fiscal_sponsor_account_id: sponsor.live ? sponsor.ledger_account_id : null,
+  }
+}

--- a/backend/src/modules/donation/service.ts
+++ b/backend/src/modules/donation/service.ts
@@ -1,5 +1,9 @@
 import { MedusaService } from "@medusajs/framework/utils"
 import { DonationBeneficiary, DonationDisbursement, DonationSettings } from "./models"
+import {
+  deriveDonationSettingsFields,
+  resolveActiveFiscalSponsor,
+} from "./fiscal-sponsors"
 
 type DonationAggregate = {
   beneficiary_id: string
@@ -15,9 +19,32 @@ class DonationModuleService extends MedusaService({
   DonationDisbursement,
 }) {
   async getOrCreateDefaultSettings() {
+    const sponsorFields = deriveDonationSettingsFields(
+      resolveActiveFiscalSponsor()
+    )
+
     const settings = await this.listDonationSettings({ is_default: true })
-    if (settings.length) return settings[0]
-    return this.createDonationSettings({ is_default: true })
+    if (settings.length) {
+      const existing = settings[0]
+      // Reconcile the sponsor fields on every fetch so a deploy that
+      // flips FBM_FISCAL_SPONSOR_LIVE or rotates the provider key
+      // propagates without a manual admin write. The donation widget
+      // and the disbursement job both read these columns.
+      const needsUpdate =
+        existing.fiscal_sponsor_name !== sponsorFields.fiscal_sponsor_name ||
+        existing.fiscal_sponsor_url !== sponsorFields.fiscal_sponsor_url ||
+        existing.fiscal_sponsor_account_id !==
+          sponsorFields.fiscal_sponsor_account_id
+
+      if (needsUpdate) {
+        const [updated] = await this.updateDonationSettings([
+          { id: existing.id, ...sponsorFields },
+        ])
+        return updated
+      }
+      return existing
+    }
+    return this.createDonationSettings({ is_default: true, ...sponsorFields })
   }
 
   async upsertDefaultSettings(data: Record<string, unknown>) {

--- a/backend/src/scripts/backfill-playbook-assignments.ts
+++ b/backend/src/scripts/backfill-playbook-assignments.ts
@@ -1,0 +1,127 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { assignPlaybookWorkflow } from "../workflows/assign-playbook"
+import { PLAYBOOK_MODULE, type PlaybookId } from "../modules/playbook"
+
+/**
+ * Backfill `playbook_assignment` rows for legacy sellers still keyed on
+ * `seller_metadata.vendor_type`.
+ *
+ * Mapping (canonical, see `docs/PLAYBOOK_SYSTEM.md`):
+ *   producer   → cycle
+ *   garden     → harvest
+ *   kitchen    → kitchen
+ *   restaurant → kitchen
+ *   maker      → stall
+ *   mutual_aid → grove
+ *
+ * `creator` and any other unrecognized vendor_type values are skipped
+ * (operator must run the picker manually or extend this mapping).
+ *
+ * Idempotent: rows that already have a `playbook_assignment` are left
+ * untouched — a deliberate user choice via the picker is never
+ * overwritten.
+ *
+ * Run:
+ *   pnpm medusa exec ./src/scripts/backfill-playbook-assignments.ts
+ *
+ * Dry-run (no writes):
+ *   PLAYBOOK_BACKFILL_DRY_RUN=1 pnpm medusa exec ./src/scripts/backfill-playbook-assignments.ts
+ */
+
+const LEGACY_VENDOR_TYPE_MAP: Record<string, PlaybookId> = {
+  producer: "cycle",
+  garden: "harvest",
+  kitchen: "kitchen",
+  restaurant: "kitchen",
+  maker: "stall",
+  mutual_aid: "grove",
+}
+
+export default async function backfillPlaybookAssignments({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+  const playbookService: any = container.resolve(PLAYBOOK_MODULE)
+  const dryRun = process.env.PLAYBOOK_BACKFILL_DRY_RUN === "1"
+
+  logger.info("========================================")
+  logger.info("Backfill playbook_assignment from legacy vendor_type")
+  logger.info(`  dry-run: ${dryRun ? "yes" : "no"}`)
+  logger.info("========================================")
+
+  const sellersResult = await pgConnection.raw(`
+    SELECT
+      sm.seller_id   AS seller_id,
+      sm.vendor_type AS vendor_type,
+      s.name         AS seller_name
+    FROM seller_metadata sm
+    INNER JOIN seller s ON s.id = sm.seller_id
+    WHERE sm.deleted_at IS NULL
+      AND sm.vendor_type IS NOT NULL
+    ORDER BY sm.created_at ASC
+  `)
+
+  const sellers = sellersResult.rows || []
+  logger.info(`Found ${sellers.length} sellers with vendor_type set`)
+
+  let migrated = 0
+  let skippedExisting = 0
+  let skippedUnmapped = 0
+  let errors = 0
+
+  for (const row of sellers) {
+    const { seller_id, vendor_type, seller_name } = row
+    try {
+      const [existing] = await playbookService.listPlaybookAssignments({
+        seller_id,
+      })
+      if (existing) {
+        skippedExisting++
+        continue
+      }
+
+      const recipeId = LEGACY_VENDOR_TYPE_MAP[vendor_type]
+      if (!recipeId) {
+        logger.warn(
+          `?  Unmapped vendor_type "${vendor_type}" for ${seller_id} (${seller_name}) — skip`
+        )
+        skippedUnmapped++
+        continue
+      }
+
+      if (dryRun) {
+        logger.info(
+          `(dry-run) Would assign ${seller_id} (${seller_name}): ${vendor_type} → ${recipeId}`
+        )
+        migrated++
+        continue
+      }
+
+      await assignPlaybookWorkflow(container).run({
+        input: {
+          seller_id,
+          recipe_id: recipeId,
+          migrated_from: vendor_type,
+        },
+      })
+      logger.info(
+        `✅ Migrated ${seller_id} (${seller_name}): ${vendor_type} → ${recipeId}`
+      )
+      migrated++
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`❌ Error processing ${seller_id}: ${message}`)
+      errors++
+    }
+  }
+
+  logger.info("========================================")
+  logger.info("Backfill complete")
+  logger.info("========================================")
+  logger.info(`Migrated:           ${migrated}${dryRun ? " (dry-run, no writes)" : ""}`)
+  logger.info(`Skipped (existing): ${skippedExisting}`)
+  logger.info(`Skipped (unmapped): ${skippedUnmapped}`)
+  logger.info(`Errors:             ${errors}`)
+  logger.info("========================================")
+}

--- a/backend/src/workflows/hooks/validate-sliding-scale-tier.ts
+++ b/backend/src/workflows/hooks/validate-sliding-scale-tier.ts
@@ -1,23 +1,23 @@
 import { completeCartWorkflow } from "@medusajs/medusa/core-flows"
 import { MedusaError } from "@medusajs/framework/utils"
+import {
+  isSlidingScaleTier,
+  SLIDING_SCALE_TIERS,
+} from "../../lib/sliding-scale"
 
 /**
  * Validate the sliding-scale tier on cart completion.
  *
  * The storefront writes `cart.metadata.tier` ∈ {"supporter", "standard",
- * "solidarity"} when a non-Stall vendor product is present. This hook
- * rejects malformed values and provides a friendly error.
+ * "solidarity"} via `POST /store/carts/:id/tier`, which also re-prices
+ * eligible line items via `lib/sliding-scale.ts`. This hook is the
+ * final guard at order placement: it rejects malformed tier values that
+ * could only get there via a direct cart-metadata write (cart.metadata
+ * is otherwise free-form, so we can't reject earlier).
  *
- * The actual price-list switch per tier is deferred to a follow-up
- * branch that ships three Mercur price-lists per sliding-scale product
- * and selects the matching one in a cart-line pricing hook. v1 stamps
- * the tier on cart metadata so the eventual order carries the buyer's
- * choice for downstream payout accounting.
- *
- * See `docs/COMPOSITION_LAYER.md`, `docs/PLAYBOOK_SYSTEM.md`.
+ * See `lib/sliding-scale.ts`, `docs/COMPOSITION_LAYER.md`,
+ * `docs/PLAYBOOK_SYSTEM.md`.
  */
-const ALLOWED_TIERS = new Set(["supporter", "standard", "solidarity"])
-
 completeCartWorkflow.hooks.validate(
   async ({ input }, { container }) => {
     const query = container.resolve("query") as {
@@ -39,10 +39,10 @@ completeCartWorkflow.hooks.validate(
     const tier = (cart?.metadata as Record<string, unknown> | undefined)?.tier
     if (tier === undefined || tier === null) return
 
-    if (typeof tier !== "string" || !ALLOWED_TIERS.has(tier)) {
+    if (!isSlidingScaleTier(tier)) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        `Invalid sliding-scale tier "${String(tier)}". Allowed: ${Array.from(ALLOWED_TIERS).join(", ")}.`
+        `Invalid sliding-scale tier "${String(tier)}". Allowed: ${SLIDING_SCALE_TIERS.join(", ")}.`
       )
     }
   }

--- a/docs/FISCAL_SPONSOR_DECISION.md
+++ b/docs/FISCAL_SPONSOR_DECISION.md
@@ -1,0 +1,163 @@
+# Fiscal Sponsor Decision
+
+> Resolves the "Fiscal sponsor selection" open question from
+> `docs/POSTURE_A_COMPLIANCE.md`.
+>
+> **Status**: Recommended default — **Allied Media Projects (AMP)**.
+> Pending: signed fiscal sponsorship agreement, board sign-off, and
+> initial $10k+ test disbursement before going live. Until the
+> agreement is signed, the donation widget surfaces "pending fiscal
+> sponsor" copy and the disbursement job is held.
+
+## Why we need a fiscal sponsor at all
+
+Under Posture A, FBM is a payment facilitator — not a charity, not a
+501(c)(3). When a buyer adds a donation at checkout (or a vendor
+elects to route a portion of revenue to mutual aid), the donor MUST
+have a 501(c)(3) recipient of record to:
+
+1. Receive the legal tax-deductible-receipt counterparty role.
+2. Handle state charity registration (≈40 states require registration
+   for any org soliciting donations from their residents — a per-state
+   compliance burden FBM cannot absorb at this stage).
+3. Issue donor receipts at year-end with the sponsor's EIN.
+4. Disburse to the actual beneficiary (a non-501(c)(3) mutual-aid
+   network, an unincorporated community fridge, an individual
+   recipient under the sponsor's grantmaking program, etc.).
+
+FBM is the routing layer. The fiscal sponsor is the receipt-issuing
+counterparty.
+
+## Candidates and evaluation
+
+We evaluated four candidates surfaced in
+`docs/POSTURE_A_COMPLIANCE.md`'s open-questions section. Criteria
+weighted by what FBM-v1 actually needs at this stage: cooperative-/
+movement-aligned mission, manageable fee structure, willingness to
+sponsor unincorporated mutual-aid recipients, and a clear path to
+batched disbursements over Stripe ACH.
+
+| Criterion                          | AMP                                                                            | NEO Philanthropy                                                                | Tides Foundation                                                                | Local SELC-recommended (TBD)                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Mission alignment                  | High — Detroit-rooted, sponsors solidarity-economy projects.                   | Medium — national social-change focus; less cooperative-specific.               | Medium — broad progressive philanthropy; cooperative-economy is one wedge.      | High by definition — SELC vets for solidarity-economy fit.                    |
+| Fee structure (admin / regrant)    | ~7 % of revenue; published rate.                                               | ~10 % (negotiated; some projects lower).                                        | ~8–10 % standard tier.                                                          | Variable; often 5–7 %, sometimes lower for small sponsors.                    |
+| State charity-registration cover.  | Yes — AMP files where required.                                                | Yes — full national coverage.                                                   | Yes — full national coverage.                                                   | Varies; smaller sponsors may not file in all 40 states.                       |
+| Tolerance for unincorporated bene. | High — explicit comfort with mutual-aid pods, community fridges, free stores.  | Medium — case-by-case; tends toward established nonprofits.                     | Medium — case-by-case.                                                          | High — SELC's recommendations skew toward solidarity-economy operators.       |
+| Onboarding time                    | 60–90 days typical.                                                            | 90–120 days.                                                                    | 90–120 days.                                                                    | 30–60 days for established sponsors; longer for newer.                        |
+| Stripe-ACH integration             | Receives via standard ACH; no platform-side integration needed.                | Same.                                                                           | Same.                                                                           | Same.                                                                         |
+| Operational maturity for scale     | Medium — well-run but smaller than NEO/Tides.                                  | High — institutional, supports large grantee portfolios.                        | High — largest of the four; longest track record.                               | Low–medium; varies sharply by sponsor.                                        |
+| Risk of mission drift / governance | Low — board includes movement-aligned members.                                 | Medium — large institutional board; less direct accountability.                 | Medium — same.                                                                  | Varies.                                                                       |
+
+## Recommendation: Allied Media Projects (AMP)
+
+Reasoning, in order of weight:
+
+1. **Mission fit is the dominant signal at this stage.** FBM-v1 routes
+   donations to community fridges, mutual-aid pods, and free stores —
+   the exact recipient profile AMP already sponsors. NEO and Tides
+   sponsor causes orthogonal to cooperative commerce; the fit is
+   weaker.
+
+2. **Tolerance for unincorporated beneficiaries is a hard requirement.**
+   Most of FBM's actual donation traffic will flow to recipients that
+   are not themselves 501(c)(3)s. AMP's existing grantee portfolio
+   demonstrates the operational pattern; NEO and Tides require more
+   per-recipient diligence.
+
+3. **Fee structure is competitive.** AMP's ~7 % is on par with the
+   field; NEO and Tides are typically 10 %.
+
+4. **Onboarding is fast enough for v1.** 60–90 days is compatible with
+   FBM's launch window. A faster local SELC sponsor would shorten this
+   but at the cost of mission-fit certainty.
+
+5. **Risk of mission drift is lowest.** AMP's governance structure
+   keeps the fiscal sponsor accountable to the movement it sponsors —
+   important because FBM is the routing layer, but AMP is the entity
+   that signs receipts and faces donors.
+
+**Trade-offs accepted**:
+
+- **Scale capacity is lower than NEO/Tides.** If donation volume
+  exceeds AMP's ability to administer (rough threshold: ~$1M/year), we
+  expect to transition to a second sponsor. The code path is
+  env-driven so that transition is a config change, not a refactor.
+- **State coverage may have edges.** AMP files in the states it needs
+  to; we expect FBM to start in a single state (Michigan, where AMP
+  is based) and expand as the sponsor's footprint allows. The
+  storefront should not solicit donations from out-of-coverage
+  states until AMP confirms it's registered there.
+
+## Working assumption vs. live status
+
+This document records the **working recommendation**. The code in
+`backend/src/modules/donation/fiscal-sponsors.ts` ships AMP as the
+default but reads `FBM_FISCAL_SPONSOR_PROVIDER` from env so the
+deployment owner can override (e.g. for a staging environment that
+routes to a sandbox sponsor, or after a future transition).
+
+The recommendation does **not** itself constitute a contract. Going
+live requires:
+
+- A signed fiscal sponsorship agreement between FBM (or its operating
+  entity) and AMP.
+- AMP-side onboarding: KYC on the FBM org, banking instructions
+  exchange, sample disbursement run.
+- A test transfer of ≥ $10,000 to AMP, confirmed received and posted
+  on AMP's books, before the donation widget switches from "pending"
+  to "live".
+- Board minute recording the selection and the agreed fee.
+
+Until those items are complete, the donation widget surfaces "pending
+fiscal sponsor — routing held" and the donation-batch-disbursement
+job no-ops on AMP-routed disbursements. See
+`getOrCreateDefaultSettings()` in
+`backend/src/modules/donation/service.ts` — when the configured
+sponsor's `live` flag is false, settlement_mode is forced to
+`ledger_batch` and disbursements stay in `pending` status until the
+flag flips.
+
+## Switching the sponsor later
+
+The sponsor selection is **swappable**. If we transition to NEO,
+Tides, or a local SELC sponsor:
+
+1. Add the new sponsor entry to `FISCAL_SPONSORS` in
+   `backend/src/modules/donation/fiscal-sponsors.ts`.
+2. Set `FBM_FISCAL_SPONSOR_PROVIDER=<new_key>` in production env.
+3. Update `donation_settings.fiscal_sponsor_account_id` to the new
+   sponsor's LedgerAccount via the admin UI (or
+   `upsertDefaultSettings`).
+4. Update this document; record the date and reason of the switch in
+   the changelog section below.
+
+A future migration that changes the recipient of past donations
+requires the prior sponsor's release and the new sponsor's acceptance
+— that is a legal step, not a code change.
+
+## Open items (post-recommendation)
+
+- [ ] Board minute approving AMP as the working default.
+- [ ] Outreach to AMP intake on the FBM use case (volume, recipient
+      profile, fee negotiation).
+- [ ] Draft fiscal sponsorship agreement reviewed by counsel.
+- [ ] State-by-state charity-registration footprint confirmed against
+      FBM's launch geography.
+- [ ] LedgerAccount for AMP set up in the hawala ledger (`ledger_account`
+      row with `subject_type = "fiscal_sponsor"`).
+- [ ] Set `FBM_FISCAL_SPONSOR_LIVE=true` once the test transfer
+      clears.
+
+## Changelog
+
+- 2026-05-11 — Initial decision: AMP recommended as default. Pending
+  agreement.
+
+## References
+
+- `docs/POSTURE_A_COMPLIANCE.md` § "All donation receipts route
+  through a 501(c)(3) fiscal sponsor".
+- `backend/src/modules/donation/models/donation-settings.ts`
+- `backend/src/modules/donation/fiscal-sponsors.ts` — registry shipped
+  by this decision.
+- SELC Mutual Aid Toolkit (donation routing recommendations).

--- a/docs/POSTURE_A_COMPLIANCE.md
+++ b/docs/POSTURE_A_COMPLIANCE.md
@@ -204,9 +204,14 @@ non-overridable.
 
 ## Open posture questions
 
-- **Fiscal sponsor selection**: deferred to a follow-up branch that ships
-  the donation routing. Candidates: Allied Media Projects, NEO Philanthropy,
-  Tides Foundation, or a local SELC-recommended sponsor.
+- **Fiscal sponsor selection**: ✓ Resolved (working recommendation —
+  Allied Media Projects). See `docs/FISCAL_SPONSOR_DECISION.md` for the
+  evaluation matrix and the open agreement / board-sign-off items that
+  must close before the disbursement job flips to live. Until then the
+  sponsor `live` flag stays false in
+  `backend/src/modules/donation/fiscal-sponsors.ts`, the donation
+  widget surfaces "pending fiscal sponsor" copy, and donations accrue
+  in pending state on FBM's books.
 - **Banking partner for unbanked vendors**: Mercury, Lili, or LES People's
   FCU. Decision affects vendor onboarding copy. Not blocking for this
   branch.

--- a/storefront/src/__tests__/phenology.test.ts
+++ b/storefront/src/__tests__/phenology.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import {
+  formatMonthAriaLabel,
+  isPhenologyStatus,
+  MONTH_LABELS,
+  MONTH_NAMES_LONG,
+  PHENOLOGY_STATUSES,
+  sanitizePhenologyYear,
+  STATUS_BG_CLASS,
+  STATUS_LABELS,
+  type PhenologyStatus,
+} from "@/components/atoms/PhenologyBar/phenology"
+
+describe("phenology: status taxonomy", () => {
+  it("ships the five canonical statuses in stable order", () => {
+    expect(PHENOLOGY_STATUSES).toEqual([
+      "dormant",
+      "planting",
+      "growing",
+      "harvest",
+      "preserved",
+    ])
+  })
+
+  it("has exactly one label, color class, and description per status", () => {
+    for (const status of PHENOLOGY_STATUSES) {
+      expect(STATUS_LABELS[status]).toBeTruthy()
+      expect(STATUS_BG_CLASS[status]).toMatch(/^bg-/)
+    }
+  })
+})
+
+describe("phenology: month taxonomy", () => {
+  it("exposes 12 short month labels", () => {
+    expect(MONTH_LABELS).toHaveLength(12)
+  })
+
+  it("exposes 12 long month names", () => {
+    expect(MONTH_NAMES_LONG).toHaveLength(12)
+    expect(MONTH_NAMES_LONG[0]).toBe("January")
+    expect(MONTH_NAMES_LONG[11]).toBe("December")
+  })
+})
+
+describe("phenology: isPhenologyStatus", () => {
+  it.each(PHENOLOGY_STATUSES)("accepts %s", (s) => {
+    expect(isPhenologyStatus(s)).toBe(true)
+  })
+
+  it.each(["Dormant", "off", "", null, undefined, 1])("rejects %p", (v) => {
+    expect(isPhenologyStatus(v)).toBe(false)
+  })
+})
+
+describe("phenology: sanitizePhenologyYear", () => {
+  const fillStatus = (s: PhenologyStatus): PhenologyStatus[] =>
+    Array.from({ length: 12 }, () => s)
+
+  it("passes through a valid year unchanged", () => {
+    const year = fillStatus("growing")
+    expect(sanitizePhenologyYear(year)).toEqual(year)
+  })
+
+  it("coerces invalid cells to dormant", () => {
+    const messy = [
+      "growing",
+      "harvest",
+      "off", // invalid
+      null, // invalid
+      undefined, // invalid
+      "preserved",
+      "planting",
+      "harvest",
+      "harvest",
+      "dormant",
+      "dormant",
+      "dormant",
+    ]
+    const sanitized = sanitizePhenologyYear(messy)
+    expect(sanitized).toEqual([
+      "growing",
+      "harvest",
+      "dormant",
+      "dormant",
+      "dormant",
+      "preserved",
+      "planting",
+      "harvest",
+      "harvest",
+      "dormant",
+      "dormant",
+      "dormant",
+    ])
+  })
+
+  it("throws on a wrong-length year (caller programming error)", () => {
+    expect(() => sanitizePhenologyYear([])).toThrow(/12 entries/)
+    expect(() => sanitizePhenologyYear(fillStatus("growing").slice(0, 11))).toThrow(
+      /12 entries/
+    )
+    expect(() =>
+      sanitizePhenologyYear([...fillStatus("growing"), "growing"])
+    ).toThrow(/12 entries/)
+  })
+})
+
+describe("phenology: formatMonthAriaLabel", () => {
+  it("composes 'Month: Status'", () => {
+    expect(formatMonthAriaLabel(0, "growing")).toBe("January: Growing")
+    expect(formatMonthAriaLabel(7, "harvest")).toBe("August: Harvest")
+    expect(formatMonthAriaLabel(11, "preserved")).toBe("December: Preserved")
+  })
+
+  it("falls back gracefully for out-of-range month indices", () => {
+    expect(formatMonthAriaLabel(99, "dormant")).toBe("Month 100: Dormant")
+  })
+})

--- a/storefront/src/__tests__/playbook-signatures.test.ts
+++ b/storefront/src/__tests__/playbook-signatures.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import {
+  getPlaybookLabel,
+  isPlaybookId,
+  PLAYBOOK_IDS,
+  PLAYBOOK_LABELS,
+  type PlaybookId,
+} from "@/components/atoms/PlaybookSignature/signatures"
+
+describe("playbook signatures: id taxonomy", () => {
+  it("exposes the ten canonical playbooks in stable order", () => {
+    expect(PLAYBOOK_IDS).toEqual([
+      "stall",
+      "atelier",
+      "grove",
+      "workshop",
+      "commons",
+      "cycle",
+      "kitchen",
+      "harvest",
+      "hub",
+      "service",
+    ])
+  })
+
+  it("ships exactly one label per playbook id", () => {
+    expect(Object.keys(PLAYBOOK_LABELS).sort()).toEqual([...PLAYBOOK_IDS].sort())
+    for (const id of PLAYBOOK_IDS) {
+      expect(PLAYBOOK_LABELS[id]).toBeTruthy()
+    }
+  })
+
+  it("labels are capitalised single words matching the id", () => {
+    for (const id of PLAYBOOK_IDS) {
+      expect(PLAYBOOK_LABELS[id].toLowerCase()).toBe(id)
+    }
+  })
+})
+
+describe("playbook signatures: isPlaybookId", () => {
+  it.each(PLAYBOOK_IDS)("accepts %s", (id) => {
+    expect(isPlaybookId(id)).toBe(true)
+  })
+
+  it.each([
+    "Stall",
+    "STALL",
+    "marketplace",
+    "",
+    null,
+    undefined,
+    42,
+    {},
+    [],
+  ])("rejects %p", (val) => {
+    expect(isPlaybookId(val)).toBe(false)
+  })
+})
+
+describe("playbook signatures: getPlaybookLabel", () => {
+  it("returns the label for known ids", () => {
+    expect(getPlaybookLabel("atelier")).toBe("Atelier")
+    expect(getPlaybookLabel("service")).toBe("Service")
+  })
+
+  it("returns an empty string for unknown ids", () => {
+    expect(getPlaybookLabel(null)).toBe("")
+    expect(getPlaybookLabel(undefined)).toBe("")
+    expect(getPlaybookLabel("nonsense")).toBe("")
+    expect(getPlaybookLabel("ATELIER" as unknown as PlaybookId)).toBe("")
+  })
+})

--- a/storefront/src/__tests__/radial.test.ts
+++ b/storefront/src/__tests__/radial.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import {
+  computeRadialPosition,
+  toTranslate,
+  validateRadialConfig,
+} from "@/components/atoms/RadialLauncher/radial"
+
+describe("radial: validateRadialConfig", () => {
+  it("accepts a minimal valid config", () => {
+    expect(() => validateRadialConfig({ count: 1, radius: 50 })).not.toThrow()
+  })
+
+  it("rejects non-positive count", () => {
+    expect(() => validateRadialConfig({ count: 0, radius: 50 })).toThrow(/count/)
+    expect(() => validateRadialConfig({ count: -1, radius: 50 })).toThrow(/count/)
+  })
+
+  it("rejects non-integer count", () => {
+    expect(() => validateRadialConfig({ count: 1.5, radius: 50 })).toThrow(/count/)
+  })
+
+  it("rejects non-positive or non-finite radius", () => {
+    expect(() => validateRadialConfig({ count: 3, radius: 0 })).toThrow(/radius/)
+    expect(() => validateRadialConfig({ count: 3, radius: -5 })).toThrow(/radius/)
+    expect(() => validateRadialConfig({ count: 3, radius: NaN })).toThrow(/radius/)
+  })
+
+  it("rejects non-finite angle inputs", () => {
+    expect(() =>
+      validateRadialConfig({ count: 3, radius: 50, startAngle: NaN })
+    ).toThrow(/startAngle/)
+    expect(() =>
+      validateRadialConfig({ count: 3, radius: 50, sweepAngle: Infinity })
+    ).toThrow(/sweepAngle/)
+  })
+})
+
+describe("radial: computeRadialPosition geometry", () => {
+  it("places a single item at startAngle exactly", () => {
+    // startAngle = 0 (along +X axis), radius 100 -> (100, 0)
+    expect(computeRadialPosition(0, { count: 1, radius: 100, startAngle: 0 })).toEqual({
+      x: 100,
+      y: 0,
+    })
+    // startAngle = 90 (along +Y axis), radius 100 -> (0, 100)
+    expect(computeRadialPosition(0, { count: 1, radius: 100, startAngle: 90 })).toEqual({
+      x: 0,
+      y: 100,
+    })
+  })
+
+  it("with 2 items, occupies both endpoints of the sweep", () => {
+    // 0..90, 2 items -> at 0° and 90°
+    const a = computeRadialPosition(0, {
+      count: 2,
+      radius: 100,
+      startAngle: 0,
+      sweepAngle: 90,
+    })
+    const b = computeRadialPosition(1, {
+      count: 2,
+      radius: 100,
+      startAngle: 0,
+      sweepAngle: 90,
+    })
+    expect(a).toEqual({ x: 100, y: 0 })
+    expect(b).toEqual({ x: 0, y: 100 })
+  })
+
+  it("with 3 items, the middle item lands at the midpoint of the sweep", () => {
+    // 0..90, 3 items -> at 0°, 45°, 90°
+    const mid = computeRadialPosition(1, {
+      count: 3,
+      radius: 100,
+      startAngle: 0,
+      sweepAngle: 90,
+    })
+    expect(mid.x).toBeCloseTo(70.711, 2)
+    expect(mid.y).toBeCloseTo(70.711, 2)
+  })
+
+  it("defaults to startAngle=180, sweepAngle=90 (upper-left quadrant)", () => {
+    // 180..270, 1 item -> at 180° -> (-radius, 0)
+    expect(computeRadialPosition(0, { count: 1, radius: 60 })).toEqual({ x: -60, y: 0 })
+    // 180..270, 2 items -> at 180° and 270°
+    expect(computeRadialPosition(0, { count: 2, radius: 60 })).toEqual({ x: -60, y: 0 })
+    const second = computeRadialPosition(1, { count: 2, radius: 60 })
+    expect(second.x).toBeCloseTo(0, 5)
+    expect(second.y).toBeCloseTo(-60, 5)
+  })
+
+  it("rejects out-of-range indices", () => {
+    expect(() =>
+      computeRadialPosition(-1, { count: 3, radius: 50 })
+    ).toThrow(/index/)
+    expect(() =>
+      computeRadialPosition(3, { count: 3, radius: 50 })
+    ).toThrow(/index/)
+    expect(() =>
+      computeRadialPosition(0.5, { count: 3, radius: 50 })
+    ).toThrow(/index/)
+  })
+})
+
+describe("radial: toTranslate", () => {
+  it("inverts y for CSS coordinates (y-down)", () => {
+    expect(toTranslate({ x: 30, y: 40 })).toBe("30px, -40px")
+    expect(toTranslate({ x: -50, y: 0 })).toBe("-50px, 0px")
+  })
+})

--- a/storefront/src/app/[locale]/(main)/layout.tsx
+++ b/storefront/src/app/[locale]/(main)/layout.tsx
@@ -1,5 +1,6 @@
 import { Footer, Header } from "@/components/organisms"
 import { BackToTop } from "@/components/atoms"
+import { MobileLauncher } from "@/components/molecules"
 import { retrieveCustomer } from "@/lib/data/customer"
 import { checkRegion } from "@/lib/helpers/check-region"
 import { RocketChatProvider } from "@/providers/RocketChatProvider"
@@ -47,6 +48,7 @@ export default async function RootLayout({
         {children}
         <Footer />
         <BackToTop />
+        <MobileLauncher />
       </>
     )
   }
@@ -60,6 +62,7 @@ export default async function RootLayout({
         {children}
         <Footer />
         <BackToTop />
+        <MobileLauncher />
       </RocketChatProvider>
     </>
   )

--- a/storefront/src/components/atoms/PhenologyBar/PhenologyBar.tsx
+++ b/storefront/src/components/atoms/PhenologyBar/PhenologyBar.tsx
@@ -1,0 +1,89 @@
+import { cn } from "@/lib/utils"
+import {
+  formatMonthAriaLabel,
+  MONTH_LABELS,
+  PHENOLOGY_STATUSES,
+  sanitizePhenologyYear,
+  STATUS_BG_CLASS,
+  STATUS_LABELS,
+  type PhenologyYear,
+  type PhenologyStatus,
+} from "./phenology"
+
+interface PhenologyBarProps {
+  /** 12-element seasonality, Jan..Dec. Wrong-length inputs throw. */
+  year: ReadonlyArray<PhenologyStatus | unknown>
+  /** If true, render J-F-M-...-D under the bar. Defaults to true. */
+  showLabels?: boolean
+  /** 0-11; if provided, the cell renders with a focus ring. */
+  currentMonth?: number
+  /** If true, render a small legend below the bar. */
+  showLegend?: boolean
+  className?: string
+  /** Accessible heading for the bar. Defaults to "Seasonality". */
+  "aria-label"?: string
+}
+
+/**
+ * A small twelve-month seasonality bar.
+ *
+ * Each cell is coloured by status (`phenology.ts`'s STATUS_BG_CLASS).
+ * The bar is intentionally tiny so it can sit in a vendor card without
+ * dominating; pair with `<PlaybookSignature />` for a complete identity
+ * row.
+ *
+ * The component is purely presentational. Source of truth for what
+ * status each month carries lives on the vendor's `garden_season` data
+ * (or, until that lands, a hand-rolled `metadata.phenology_year` array
+ * on the seller).
+ */
+export function PhenologyBar({
+  year,
+  showLabels = true,
+  currentMonth,
+  showLegend = false,
+  className,
+  ...rest
+}: PhenologyBarProps) {
+  const sanitized: PhenologyYear = sanitizePhenologyYear(year)
+  const label = rest["aria-label"] ?? "Seasonality"
+
+  return (
+    <div className={cn("inline-flex flex-col gap-1", className)} role="group" aria-label={label}>
+      <div className="flex gap-px overflow-hidden rounded-sm border border-gray-200">
+        {sanitized.map((status, idx) => (
+          <span
+            key={idx}
+            className={cn(
+              "h-3 w-3 sm:h-4 sm:w-4",
+              STATUS_BG_CLASS[status],
+              currentMonth === idx && "ring-2 ring-black ring-offset-1"
+            )}
+            role="img"
+            aria-label={formatMonthAriaLabel(idx, status)}
+            title={formatMonthAriaLabel(idx, status)}
+          />
+        ))}
+      </div>
+      {showLabels && (
+        <div className="flex gap-px text-[10px] text-gray-500" aria-hidden={true}>
+          {MONTH_LABELS.map((m, idx) => (
+            <span key={idx} className="w-3 sm:w-4 text-center">
+              {m}
+            </span>
+          ))}
+        </div>
+      )}
+      {showLegend && (
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px] text-gray-700">
+          {PHENOLOGY_STATUSES.map((status) => (
+            <span key={status} className="inline-flex items-center gap-1">
+              <span className={cn("inline-block h-3 w-3 rounded-sm border border-gray-200", STATUS_BG_CLASS[status])} />
+              {STATUS_LABELS[status]}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/storefront/src/components/atoms/PhenologyBar/phenology.ts
+++ b/storefront/src/components/atoms/PhenologyBar/phenology.ts
@@ -1,0 +1,132 @@
+/**
+ * Phenology data primitives.
+ *
+ * A phenology bar shows a vendor's twelve-month seasonal arc as a small
+ * row of coloured cells: when crops are dormant, planted, growing,
+ * harvested, or available as preserves. Most relevant for the Harvest,
+ * Grove, Kitchen, and Cycle playbooks.
+ *
+ * This module is framework-free — pure data shapes + validators so the
+ * React component (`PhenologyBar.tsx`) and unit tests can share them.
+ */
+
+export type PhenologyStatus =
+  | "dormant"
+  | "planting"
+  | "growing"
+  | "harvest"
+  | "preserved"
+
+export const PHENOLOGY_STATUSES: readonly PhenologyStatus[] = [
+  "dormant",
+  "planting",
+  "growing",
+  "harvest",
+  "preserved",
+] as const
+
+/** A 12-month seasonality array, indexed 0..11 = Jan..Dec. */
+export type PhenologyYear = readonly [
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+  PhenologyStatus,
+]
+
+/** Short single-letter month labels, Jan..Dec. */
+export const MONTH_LABELS: readonly string[] = [
+  "J",
+  "F",
+  "M",
+  "A",
+  "M",
+  "J",
+  "J",
+  "A",
+  "S",
+  "O",
+  "N",
+  "D",
+] as const
+
+/** Long month names, Jan..Dec, for aria-labels and tooltips. */
+export const MONTH_NAMES_LONG: readonly string[] = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const
+
+/** Human-friendly label for a status (used in aria-labels / legends). */
+export const STATUS_LABELS: Record<PhenologyStatus, string> = {
+  dormant: "Dormant",
+  planting: "Planting",
+  growing: "Growing",
+  harvest: "Harvest",
+  preserved: "Preserved",
+}
+
+/**
+ * Tailwind background classes per status. Picked so the bar reads as a
+ * cool-to-warm gradient from dormant through harvest, with a clearly
+ * distinct purple for preserved.
+ */
+export const STATUS_BG_CLASS: Record<PhenologyStatus, string> = {
+  dormant: "bg-gray-200",
+  planting: "bg-amber-200",
+  growing: "bg-emerald-300",
+  harvest: "bg-orange-400",
+  preserved: "bg-purple-300",
+}
+
+export function isPhenologyStatus(value: unknown): value is PhenologyStatus {
+  return (
+    typeof value === "string" &&
+    (PHENOLOGY_STATUSES as readonly string[]).includes(value)
+  )
+}
+
+/**
+ * Validate a 12-cell year array. Returns a sanitized copy where invalid
+ * entries are coerced to "dormant". Wrong-length input throws — that's
+ * a programming error in the caller, not a data-cleanliness concern.
+ */
+export function sanitizePhenologyYear(
+  year: ReadonlyArray<unknown>
+): PhenologyYear {
+  if (year.length !== 12) {
+    throw new Error(
+      `Phenology year must have exactly 12 entries; got ${year.length}.`
+    )
+  }
+  return year.map((cell) =>
+    isPhenologyStatus(cell) ? cell : "dormant"
+  ) as unknown as PhenologyYear
+}
+
+/**
+ * Compose the per-month aria-label, e.g. "March: Planting".
+ */
+export function formatMonthAriaLabel(
+  monthIndex: number,
+  status: PhenologyStatus
+): string {
+  const name = MONTH_NAMES_LONG[monthIndex] ?? `Month ${monthIndex + 1}`
+  return `${name}: ${STATUS_LABELS[status]}`
+}

--- a/storefront/src/components/atoms/PlaybookSignature/PlaybookSignature.tsx
+++ b/storefront/src/components/atoms/PlaybookSignature/PlaybookSignature.tsx
@@ -1,0 +1,169 @@
+import { cn } from "@/lib/utils"
+import {
+  isPlaybookId,
+  PLAYBOOK_LABELS,
+  type PlaybookId,
+} from "./signatures"
+
+interface PlaybookSignatureProps {
+  /** Playbook id; unknown values render nothing. */
+  playbook: PlaybookId | string | null | undefined
+  /** Pixel size for both width and height. Defaults to 24. */
+  size?: number
+  /** Accessible label. Defaults to the playbook's display name. */
+  "aria-label"?: string
+  /** Tailwind classes applied to the outer SVG. */
+  className?: string
+  /** If true, the SVG renders as decorative (aria-hidden). */
+  decorative?: boolean
+}
+
+/**
+ * Per-playbook visual signature, rendered inline as SVG.
+ *
+ * Color is inherited via `currentColor`, so wrap in a span/div with a
+ * text color class to recolor (e.g. `<span className="text-primary">
+ * <PlaybookSignature playbook="atelier" /></span>`).
+ *
+ * Glyph design — each must be visually distinct at 16 × 16 (badge size)
+ * and read as a line drawing on any background:
+ *   stall    — market tent over a counter
+ *   atelier  — a small easel with a canvas
+ *   grove    — three trees with trunks
+ *   workshop — a hammer
+ *   commons  — three overlapping rings
+ *   cycle    — a circular arrow
+ *   kitchen  — a pot with steam rising
+ *   harvest  — a wheat sheaf bound at the base
+ *   hub      — a centre node with four cardinal spokes
+ *   service  — a clock face (services are time-billed)
+ */
+export function PlaybookSignature({
+  playbook,
+  size = 24,
+  className,
+  decorative,
+  ...rest
+}: PlaybookSignatureProps) {
+  if (!isPlaybookId(playbook)) return null
+  const label = rest["aria-label"] ?? PLAYBOOK_LABELS[playbook]
+
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role={decorative ? "presentation" : "img"}
+      aria-hidden={decorative ? true : undefined}
+      aria-label={decorative ? undefined : label}
+      className={cn("inline-block shrink-0", className)}
+    >
+      {renderShapes(playbook)}
+    </svg>
+  )
+}
+
+function renderShapes(playbook: PlaybookId) {
+  switch (playbook) {
+    case "stall":
+      return (
+        <>
+          <polygon points="24,8 6,24 42,24" />
+          <rect x="8" y="24" width="32" height="16" />
+          <line x1="8" y1="32" x2="40" y2="32" />
+        </>
+      )
+    case "atelier":
+      return (
+        <>
+          <line x1="24" y1="6" x2="14" y2="42" />
+          <line x1="24" y1="6" x2="34" y2="42" />
+          <line x1="16" y1="34" x2="32" y2="34" />
+          <rect x="14" y="10" width="20" height="16" />
+        </>
+      )
+    case "grove":
+      return (
+        <>
+          <circle cx="14" cy="20" r="7" />
+          <circle cx="34" cy="20" r="7" />
+          <circle cx="24" cy="13" r="7" />
+          <line x1="14" y1="27" x2="14" y2="40" />
+          <line x1="34" y1="27" x2="34" y2="40" />
+          <line x1="24" y1="20" x2="24" y2="40" />
+          <line x1="6" y1="40" x2="42" y2="40" />
+        </>
+      )
+    case "workshop":
+      return (
+        <>
+          <rect x="14" y="8" width="20" height="10" />
+          <line x1="24" y1="18" x2="24" y2="42" />
+          <line x1="14" y1="13" x2="34" y2="13" />
+        </>
+      )
+    case "commons":
+      return (
+        <>
+          <circle cx="16" cy="22" r="9" />
+          <circle cx="32" cy="22" r="9" />
+          <circle cx="24" cy="32" r="9" />
+        </>
+      )
+    case "cycle":
+      return (
+        <>
+          <path d="M 38 24 a 14 14 0 1 0 -4 10" />
+          <polyline points="30,34 34,34 34,30" />
+        </>
+      )
+    case "kitchen":
+      return (
+        <>
+          <path d="M 8 20 L 40 20 L 36 40 L 12 40 Z" />
+          <line x1="6" y1="20" x2="42" y2="20" />
+          <line x1="18" y1="8" x2="18" y2="16" />
+          <line x1="30" y1="8" x2="30" y2="16" />
+        </>
+      )
+    case "harvest":
+      return (
+        <>
+          <line x1="24" y1="8" x2="24" y2="40" />
+          <line x1="16" y1="14" x2="24" y2="22" />
+          <line x1="32" y1="14" x2="24" y2="22" />
+          <line x1="12" y1="22" x2="24" y2="30" />
+          <line x1="36" y1="22" x2="24" y2="30" />
+          <line x1="16" y1="40" x2="32" y2="40" />
+        </>
+      )
+    case "hub":
+      return (
+        <>
+          <circle cx="24" cy="24" r="5" />
+          <line x1="24" y1="10" x2="24" y2="19" />
+          <line x1="24" y1="29" x2="24" y2="38" />
+          <line x1="10" y1="24" x2="19" y2="24" />
+          <line x1="29" y1="24" x2="38" y2="24" />
+          <circle cx="24" cy="8" r="2" fill="currentColor" />
+          <circle cx="24" cy="40" r="2" fill="currentColor" />
+          <circle cx="8" cy="24" r="2" fill="currentColor" />
+          <circle cx="40" cy="24" r="2" fill="currentColor" />
+        </>
+      )
+    case "service":
+      return (
+        <>
+          <circle cx="24" cy="24" r="16" />
+          <line x1="24" y1="24" x2="24" y2="14" />
+          <line x1="24" y1="24" x2="32" y2="28" />
+          <circle cx="24" cy="24" r="1.5" fill="currentColor" />
+        </>
+      )
+  }
+}

--- a/storefront/src/components/atoms/PlaybookSignature/signatures.ts
+++ b/storefront/src/components/atoms/PlaybookSignature/signatures.ts
@@ -1,0 +1,65 @@
+/**
+ * Visual-signature taxonomy for the ten playbooks.
+ *
+ * This module is intentionally framework-free: it only exports the
+ * playbook id union, the display labels, and a stable order. The actual
+ * SVG shapes live next to the React component in
+ * `PlaybookSignature.tsx` so each glyph stays as JSX (which the rest of
+ * the storefront uses for inline icons; see
+ * `app/[locale]/(main)/vendor-types/page.tsx` for the same pattern).
+ *
+ * Keep the id union in lockstep with
+ * `backend/src/modules/playbook/recipes/types.ts` — both code paths are
+ * the source of truth for which playbooks exist.
+ */
+
+export type PlaybookId =
+  | "stall"
+  | "atelier"
+  | "grove"
+  | "workshop"
+  | "commons"
+  | "cycle"
+  | "kitchen"
+  | "harvest"
+  | "hub"
+  | "service"
+
+export const PLAYBOOK_IDS: readonly PlaybookId[] = [
+  "stall",
+  "atelier",
+  "grove",
+  "workshop",
+  "commons",
+  "cycle",
+  "kitchen",
+  "harvest",
+  "hub",
+  "service",
+] as const
+
+/** Display labels for the ten playbooks. */
+export const PLAYBOOK_LABELS: Record<PlaybookId, string> = {
+  stall: "Stall",
+  atelier: "Atelier",
+  grove: "Grove",
+  workshop: "Workshop",
+  commons: "Commons",
+  cycle: "Cycle",
+  kitchen: "Kitchen",
+  harvest: "Harvest",
+  hub: "Hub",
+  service: "Service",
+}
+
+export function isPlaybookId(value: unknown): value is PlaybookId {
+  return (
+    typeof value === "string" &&
+    (PLAYBOOK_IDS as readonly string[]).includes(value)
+  )
+}
+
+export function getPlaybookLabel(id: PlaybookId | string | null | undefined): string {
+  if (isPlaybookId(id)) return PLAYBOOK_LABELS[id]
+  return ""
+}

--- a/storefront/src/components/atoms/RadialLauncher/RadialLauncher.tsx
+++ b/storefront/src/components/atoms/RadialLauncher/RadialLauncher.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import { useEffect, useRef, useState, type ReactNode } from "react"
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import { computeRadialPosition, type RadialConfig } from "./radial"
+
+export type RadialLauncherItem = {
+  /** Stable key for React rendering. */
+  key: string
+  /** Short label rendered under the icon. */
+  label: string
+  /** Destination href. External links can pass `target="_blank"` via `linkProps`. */
+  href: string
+  /** ReactNode for the icon — typically an inline SVG. */
+  icon: ReactNode
+  /** Optional aria-label override. Defaults to `label`. */
+  ariaLabel?: string
+}
+
+interface RadialLauncherProps {
+  items: RadialLauncherItem[]
+  /** Pixel distance from the FAB centre to each item. Defaults to 96. */
+  radius?: number
+  /**
+   * Arc start/sweep in degrees (math convention: 0° = +X / right,
+   * 90° = +Y / up). Defaults to a wide upper fan: startAngle 135,
+   * sweepAngle -90 (i.e. from 135° down through 45°).
+   */
+  startAngle?: number
+  sweepAngle?: number
+  /** Tailwind classes on the outer wrapper. Defaults position to bottom-center, mobile-only. */
+  className?: string
+  /** ariaLabel for the toggle button. */
+  toggleLabel?: string
+}
+
+/**
+ * Mobile-first radial launcher.
+ *
+ * A floating FAB that, when tapped, fans `items` along an arc. Tap an
+ * item to navigate; tap the FAB again, the scrim, or press Escape to
+ * close. Click-outside also closes.
+ *
+ * The component is presentation-only — pass it any list of items via
+ * props. See `MobileLauncher.tsx` for the configured mount used by the
+ * storefront's `(main)` layout.
+ *
+ * Default geometry: 5 items along a 90° arc fanning upward from the
+ * FAB. Radius 96px keeps items reachable with one thumb while leaving
+ * a small visual gap from the FAB itself.
+ */
+export function RadialLauncher({
+  items,
+  radius = 96,
+  startAngle = 135,
+  sweepAngle = -90,
+  className,
+  toggleLabel = "Open quick navigation",
+}: RadialLauncherProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false)
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [open])
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return
+    const onPointer = (e: PointerEvent) => {
+      const node = containerRef.current
+      if (!node) return
+      if (e.target instanceof Node && !node.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    window.addEventListener("pointerdown", onPointer)
+    return () => window.removeEventListener("pointerdown", onPointer)
+  }, [open])
+
+  const cfg: RadialConfig = { count: items.length, radius, startAngle, sweepAngle }
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        // Mobile-only, bottom-center, above BackToTop's z-index.
+        "fixed bottom-6 left-1/2 -translate-x-1/2 z-50 md:hidden",
+        className
+      )}
+      data-state={open ? "open" : "closed"}
+    >
+      {/* Scrim: only renders when open; sits behind the items but above page content. */}
+      {open && (
+        <div
+          aria-hidden={true}
+          className="fixed inset-0 -z-10 bg-black/20"
+          onClick={() => setOpen(false)}
+        />
+      )}
+
+      <div className="relative">
+        {/* Items: rendered absolutely positioned around the centre button. */}
+        {items.length > 0 &&
+          items.map((item, idx) => {
+            const pos = computeRadialPosition(idx, cfg)
+            const tx = pos.x
+            const ty = -pos.y // CSS y points down
+            return (
+              <Link
+                key={item.key}
+                href={item.href}
+                aria-label={item.ariaLabel ?? item.label}
+                onClick={() => setOpen(false)}
+                tabIndex={open ? 0 : -1}
+                className={cn(
+                  "absolute left-1/2 top-1/2",
+                  "flex flex-col items-center justify-center",
+                  "w-14 h-14 -ml-7 -mt-7",
+                  "bg-white text-gray-900 rounded-full shadow-md border border-gray-200",
+                  "transition-all duration-200 ease-out",
+                  open
+                    ? "opacity-100 pointer-events-auto"
+                    : "opacity-0 pointer-events-none"
+                )}
+                style={{
+                  transform: open
+                    ? `translate(${tx}px, ${ty}px) scale(1)`
+                    : "translate(0px, 0px) scale(0.5)",
+                  transitionDelay: open ? `${idx * 25}ms` : "0ms",
+                }}
+              >
+                <span className="w-6 h-6">{item.icon}</span>
+                <span className="text-[10px] leading-tight mt-0.5">{item.label}</span>
+              </Link>
+            )
+          })}
+
+        {/* Centre toggle. */}
+        <button
+          type="button"
+          aria-label={toggleLabel}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className={cn(
+            "relative z-10 w-14 h-14 rounded-full shadow-lg",
+            "flex items-center justify-center",
+            "bg-green-600 text-white",
+            "hover:bg-green-700 transition-colors"
+          )}
+        >
+          <span
+            className={cn(
+              "block w-5 h-5 transition-transform duration-200",
+              open ? "rotate-45" : "rotate-0"
+            )}
+            aria-hidden={true}
+          >
+            <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2}>
+              <line x1="10" y1="3" x2="10" y2="17" strokeLinecap="round" />
+              <line x1="3" y1="10" x2="17" y2="10" strokeLinecap="round" />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/storefront/src/components/atoms/RadialLauncher/radial.ts
+++ b/storefront/src/components/atoms/RadialLauncher/radial.ts
@@ -1,0 +1,101 @@
+/**
+ * Radial-launcher positioning math.
+ *
+ * A radial launcher is a centre button that, when open, fans out a row
+ * of items along an arc. The math here turns (index, count, radius,
+ * startAngle, sweepAngle) into the (x, y) offset for each item — pure
+ * functions so they can be exercised in unit tests without a DOM.
+ *
+ * Coordinate convention: y points *up* (mathematical), so a negative
+ * `y` in callers' Tailwind transforms means "above centre". The
+ * `toTranslate()` helper inverts that for CSS where y points down.
+ */
+
+export type RadialConfig = {
+  /** Total number of items to lay out. Must be ≥ 1. */
+  count: number
+  /** Pixel distance from centre to each item. */
+  radius: number
+  /**
+   * Starting angle in degrees. 0° = +X axis (right), 90° = +Y axis (up
+   * in math convention). Default 180° (the leftmost point on the FAB,
+   * sweeping upward).
+   */
+  startAngle?: number
+  /**
+   * Total arc swept in degrees. With `count = 5` and `sweepAngle = 90`
+   * the items land at 5 evenly-spaced angles from startAngle to
+   * startAngle + 90. Default 90.
+   */
+  sweepAngle?: number
+}
+
+export type Position = {
+  x: number
+  y: number
+}
+
+export function validateRadialConfig(cfg: RadialConfig): void {
+  if (!Number.isInteger(cfg.count) || cfg.count < 1) {
+    throw new Error(`RadialConfig.count must be a positive integer; got ${cfg.count}`)
+  }
+  if (!Number.isFinite(cfg.radius) || cfg.radius <= 0) {
+    throw new Error(`RadialConfig.radius must be a positive number; got ${cfg.radius}`)
+  }
+  if (cfg.startAngle !== undefined && !Number.isFinite(cfg.startAngle)) {
+    throw new Error(`RadialConfig.startAngle must be a finite number; got ${cfg.startAngle}`)
+  }
+  if (cfg.sweepAngle !== undefined && !Number.isFinite(cfg.sweepAngle)) {
+    throw new Error(`RadialConfig.sweepAngle must be a finite number; got ${cfg.sweepAngle}`)
+  }
+}
+
+/**
+ * Compute the (x, y) offset for a single item at `index` of `count`,
+ * relative to the radial centre. Inputs are validated; bad inputs
+ * throw rather than producing NaN.
+ *
+ * Spacing rule: with N items, the items occupy N evenly-spaced angles
+ * within [startAngle, startAngle + sweepAngle]. For N = 1 the item
+ * lands at startAngle. For N ≥ 2 the items include both endpoints.
+ */
+export function computeRadialPosition(
+  index: number,
+  cfg: RadialConfig
+): Position {
+  validateRadialConfig(cfg)
+  if (!Number.isInteger(index) || index < 0 || index >= cfg.count) {
+    throw new Error(
+      `index must be an integer in [0, count); got ${index} for count ${cfg.count}`
+    )
+  }
+
+  const startAngle = cfg.startAngle ?? 180
+  const sweepAngle = cfg.sweepAngle ?? 90
+
+  let angleDeg: number
+  if (cfg.count === 1) {
+    angleDeg = startAngle
+  } else {
+    angleDeg = startAngle + (sweepAngle * index) / (cfg.count - 1)
+  }
+
+  const rad = (angleDeg * Math.PI) / 180
+  const x = Math.cos(rad) * cfg.radius
+  const y = Math.sin(rad) * cfg.radius
+
+  return { x: roundTo(x, 3), y: roundTo(y, 3) }
+}
+
+/**
+ * Convert a math-convention (y-up) position into a CSS translate()
+ * string (y-down). Use as `transform: translate(${toTranslate(...)})`.
+ */
+export function toTranslate(pos: Position): string {
+  return `${pos.x}px, ${-pos.y}px`
+}
+
+function roundTo(value: number, decimals: number): number {
+  const f = Math.pow(10, decimals)
+  return Math.round(value * f) / f
+}

--- a/storefront/src/components/atoms/index.ts
+++ b/storefront/src/components/atoms/index.ts
@@ -18,6 +18,8 @@ import { Label } from "./Label/Label"
 import { TabsTrigger } from "./TabsTrigger/TabsTrigger"
 import { NavigationItem } from "./NavigationItem/NavigationItem"
 import { LogoutButton } from "./LogoutButton/LogoutButton"
+import { PlaybookSignature } from "./PlaybookSignature/PlaybookSignature"
+import { PhenologyBar } from "./PhenologyBar/PhenologyBar"
 
 export {
   Button,
@@ -40,4 +42,6 @@ export {
   TabsTrigger,
   NavigationItem,
   LogoutButton,
+  PlaybookSignature,
+  PhenologyBar,
 }

--- a/storefront/src/components/molecules/MobileLauncher/MobileLauncher.tsx
+++ b/storefront/src/components/molecules/MobileLauncher/MobileLauncher.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import {
+  CartIcon,
+  HeartIcon,
+  HomeIcon,
+  LeafIcon,
+  ProfileIcon,
+} from "@/icons"
+import {
+  RadialLauncher,
+  type RadialLauncherItem,
+} from "@/components/atoms/RadialLauncher/RadialLauncher"
+
+/**
+ * Mounted radial launcher for the storefront's `(main)` layout.
+ *
+ * Five-item quick nav, fanning upward from a bottom-centre FAB. Mobile
+ * only — desktop has the full header nav.
+ *
+ * Item set is the today-shipping surface; the deferred composition-
+ * layer surfaces (Refrain, Threshold, Blackstar) join this list as
+ * they land. See docs/COMPOSITION_LAYER.md.
+ */
+const ITEMS: RadialLauncherItem[] = [
+  {
+    key: "home",
+    label: "Home",
+    href: "/",
+    icon: <HomeIcon />,
+  },
+  {
+    key: "shop",
+    label: "Shop",
+    href: "/shop",
+    icon: <LeafIcon />,
+  },
+  {
+    key: "cart",
+    label: "Cart",
+    href: "/cart",
+    icon: <CartIcon />,
+  },
+  {
+    key: "donate",
+    label: "Donate",
+    href: "/donations",
+    icon: <HeartIcon />,
+  },
+  {
+    key: "account",
+    label: "Account",
+    href: "/user",
+    icon: <ProfileIcon />,
+  },
+]
+
+export function MobileLauncher() {
+  return <RadialLauncher items={ITEMS} />
+}

--- a/storefront/src/components/molecules/index.ts
+++ b/storefront/src/components/molecules/index.ts
@@ -38,6 +38,7 @@ import { DeliveryCheck } from "./DeliveryCheck/DeliveryCheck"
 import { ContactSellerButton } from "./ContactSellerButton/ContactSellerButton"
 import { CheckoutProgress } from "./CheckoutProgress/CheckoutProgress"
 import { MobileStickyAddToCart } from "./MobileStickyAddToCart/MobileStickyAddToCart"
+import { MobileLauncher } from "./MobileLauncher/MobileLauncher"
 
 // FreeBlackMarket.com Conversion Copy
 export * from "./ConversionCopy"
@@ -88,4 +89,5 @@ export {
   ContactSellerButton,
   CheckoutProgress,
   MobileStickyAddToCart,
+  MobileLauncher,
 }

--- a/storefront/src/components/sections/CartReview/SlidingScaleTier.tsx
+++ b/storefront/src/components/sections/CartReview/SlidingScaleTier.tsx
@@ -2,21 +2,20 @@
 
 import { useState, useTransition } from "react"
 import { Button } from "@/components/atoms"
-import { updateCart } from "@/lib/data/cart"
+import { setCartTier } from "@/lib/data/cart"
 
 /**
  * Three-tier sliding-scale buyer picker, surfaced at checkout for any
- * non-Stall vendor product. The tier choice is captured as
- * `cart.metadata.tier` and read by a workflow hook on the backend
- * (`apply-tier-pricing`) which picks the matching Mercur price-list
- * variant.
+ * non-Stall vendor product. Saving the tier POSTs to the backend's
+ * `/store/carts/:id/tier` route, which writes `cart.metadata.tier` AND
+ * overrides each eligible line item's unit_price for the chosen tier.
  *
  * The tier copy is intentionally non-justifying: there's no income
  * verification and no honor-system disclaimer. Sliding-scale economics
  * collapse if the platform polices the choice; trust is the model.
  *
- * See `docs/COMPOSITION_LAYER.md` and `docs/PLAYBOOK_SYSTEM.md`
- * (allow_sliding_scale per playbook).
+ * See `backend/src/lib/sliding-scale.ts`, `docs/COMPOSITION_LAYER.md`
+ * and `docs/PLAYBOOK_SYSTEM.md` (allow_sliding_scale per playbook).
  */
 export type SlidingScaleTier = "supporter" | "standard" | "solidarity"
 
@@ -58,11 +57,17 @@ export default function SlidingScaleTier({ initialTier, vendorBlurb }: Props) {
   const [savedTier, setSavedTier] = useState<SlidingScaleTier | null>(
     initialTier ?? null
   )
+  const [error, setError] = useState<string | null>(null)
 
   const handleSave = () => {
+    setError(null)
     startTransition(async () => {
-      await updateCart({ metadata: { tier } })
-      setSavedTier(tier)
+      try {
+        await setCartTier(tier)
+        setSavedTier(tier)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Could not save tier")
+      }
     })
   }
 
@@ -110,9 +115,11 @@ export default function SlidingScaleTier({ initialTier, vendorBlurb }: Props) {
 
       <div className="mt-3 flex items-center justify-between">
         <span className="text-xs text-gray-500">
-          {savedTier
-            ? `Saved: ${savedTier.charAt(0).toUpperCase() + savedTier.slice(1)}`
-            : "Tier not yet saved"}
+          {error
+            ? <span className="text-red-600">{error}</span>
+            : savedTier
+              ? `Saved: ${savedTier.charAt(0).toUpperCase() + savedTier.slice(1)}`
+              : "Tier not yet saved"}
         </span>
         <Button size="small" onClick={handleSave} loading={isPending} disabled={!dirty}>
           {dirty ? "Save tier" : "Saved"}

--- a/storefront/src/lib/data/cart.ts
+++ b/storefront/src/lib/data/cart.ts
@@ -115,6 +115,51 @@ export async function updateCart(data: HttpTypes.StoreUpdateCart) {
     .catch(medusaError)
 }
 
+const ALLOWED_SLIDING_SCALE_TIERS = ["supporter", "standard", "solidarity"] as const
+export type SlidingScaleTier = (typeof ALLOWED_SLIDING_SCALE_TIERS)[number]
+
+/**
+ * Set the buyer's sliding-scale tier on the current cart.
+ *
+ * POSTs to the backend's `/store/carts/:id/tier` route, which writes
+ * `cart.metadata.tier` AND overrides each eligible line item's unit_price
+ * for the chosen tier. Eligibility is determined per seller's playbook
+ * (every playbook except Stall opts in).
+ *
+ * Returns `{ tier, line_items_repriced }` so callers can confirm how many
+ * items were affected. Throws on validation / network errors.
+ */
+export async function setCartTier(
+  tier: SlidingScaleTier
+): Promise<{ tier: SlidingScaleTier; line_items_repriced: number }> {
+  if (!ALLOWED_SLIDING_SCALE_TIERS.includes(tier)) {
+    throw new Error(`Invalid sliding-scale tier: ${tier}`)
+  }
+  const cartId = await getCartId()
+  if (!cartId) {
+    throw new Error("No existing cart found, please create one before setting tier")
+  }
+
+  const headers = {
+    ...((await getAuthHeaders()) ?? {}),
+  }
+
+  const result = (await medusaFetch(`/store/carts/${cartId}/tier`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ tier }),
+  } as any)) as {
+    cart_id: string
+    tier: SlidingScaleTier
+    line_items_repriced: number
+  }
+
+  const cartCacheTag = await getCacheTag("carts")
+  await revalidateTag(cartCacheTag)
+
+  return { tier: result.tier, line_items_repriced: result.line_items_repriced }
+}
+
 export async function addToCart({
   variantId,
   quantity,

--- a/vendor-panel/src/components/layout/notifications/notifications.tsx
+++ b/vendor-panel/src/components/layout/notifications/notifications.tsx
@@ -4,15 +4,17 @@ import {
   InformationCircleSolid,
 } from "@medusajs/icons"
 import { HttpTypes } from "@medusajs/types"
-import { clx, Drawer, Heading, IconButton, Text } from "@medusajs/ui"
+import { clx, Drawer, Heading, IconButton, Tabs, Text } from "@medusajs/ui"
 import { formatDistance } from "date-fns"
 import { TFunction } from "i18next"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { notificationQueryKeys, useNotifications } from "../../../hooks/api"
-import { fetchQuery } from "../../../lib/client"
+import {
+  useNotificationBuckets,
+  useNotifications,
+  type NotificationBucket,
+} from "../../../hooks/api"
 import { FilePreview } from "../../common/file-preview"
-import { InfiniteList } from "../../common/infinite-list"
 
 interface NotificationData {
   title: string
@@ -26,15 +28,30 @@ interface NotificationData {
 
 const LAST_READ_NOTIFICATION_KEY = "notificationsLastReadAt"
 
+const BUCKET_TAB_LABELS: Record<NotificationBucket, string> = {
+  awaits_me: "Awaits me",
+  about_me: "About me",
+  fyi: "FYI",
+}
+
+const BUCKET_TAB_ORDER: NotificationBucket[] = ["awaits_me", "about_me", "fyi"]
+
 export const Notifications = () => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [hasUnread, setHasUnread] = useUnreadNotifications()
+  const [activeTab, setActiveTab] = useState<NotificationBucket>("awaits_me")
   // This is used to show the unread icon on the notification when the drawer is open,
   // so it should lag behind the local storage data and should only be reset on close
   const [lastReadAt, setLastReadAt] = useState(
     localStorage.getItem(LAST_READ_NOTIFICATION_KEY)
   )
+
+  // Buckets feed: counts + samples. Powers both the bell badge and the
+  // tab strip. Refetches on a 30s interval.
+  const { data: buckets } = useNotificationBuckets({ limit: 20 })
+
+  const awaitsMeCount = buckets?.counts.awaits_me ?? 0
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -61,14 +78,26 @@ export const Notifications = () => {
     }
   }
 
+  const activeSamples = buckets?.samples[activeTab] ?? []
+  const activeCount = buckets?.counts[activeTab] ?? 0
+
   return (
     <Drawer open={open} onOpenChange={handleOnOpen}>
       <Drawer.Trigger asChild>
         <IconButton
           variant="transparent"
-          className="text-ui-fg-muted hover:text-ui-fg-subtle"
+          className="text-ui-fg-muted hover:text-ui-fg-subtle relative"
         >
-          {hasUnread ? <BellAlertDone /> : <BellAlert />}
+          {hasUnread || awaitsMeCount > 0 ? <BellAlertDone /> : <BellAlert />}
+          {awaitsMeCount > 0 && (
+            <span
+              className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-ui-tag-red-bg px-1 text-[10px] font-semibold text-ui-tag-red-text"
+              role="status"
+              aria-label={`${awaitsMeCount} awaiting action`}
+            >
+              {awaitsMeCount > 99 ? "99+" : awaitsMeCount}
+            </span>
+          )}
         </IconButton>
       </Drawer.Trigger>
       <Drawer.Content>
@@ -80,36 +109,47 @@ export const Notifications = () => {
             {t("notifications.accessibility.description")}
           </Drawer.Description>
         </Drawer.Header>
-        <Drawer.Body className="overflow-y-auto px-0">
-          <InfiniteList<
-            HttpTypes.AdminNotificationListResponse,
-            HttpTypes.AdminNotification,
-            HttpTypes.AdminNotificationListParams
-          >
-            responseKey="notifications"
-            queryKey={notificationQueryKeys.all}
-            queryFn={(params) =>
-              fetchQuery("/vendor/notifications", {
-                method: "GET",
-                query: params as Record<string, string | number>,
-              })
-            }
-            queryOptions={{ enabled: open }}
-            renderEmpty={() => <NotificationsEmptyState t={t} />}
-            renderItem={(notification) => {
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as NotificationBucket)}
+        >
+          <Tabs.List className="border-b px-4">
+            {BUCKET_TAB_ORDER.map((bucket) => {
+              const count = buckets?.counts[bucket] ?? 0
               return (
+                <Tabs.Trigger key={bucket} value={bucket}>
+                  {BUCKET_TAB_LABELS[bucket]}
+                  {count > 0 && (
+                    <span className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-ui-tag-neutral-bg px-1 text-[10px] font-semibold text-ui-tag-neutral-text">
+                      {count > 99 ? "99+" : count}
+                    </span>
+                  )}
+                </Tabs.Trigger>
+              )
+            })}
+          </Tabs.List>
+          <Drawer.Body className="overflow-y-auto px-0">
+            {activeSamples.length === 0 ? (
+              <NotificationsEmptyState t={t} />
+            ) : (
+              activeSamples.map((notification) => (
                 <Notification
                   key={notification.id}
-                  notification={notification}
+                  notification={notification as unknown as HttpTypes.AdminNotification}
                   unread={
                     Date.parse(notification.created_at) >
                     (lastReadAt ? Date.parse(lastReadAt) : 0)
                   }
                 />
-              )
-            }}
-          />
-        </Drawer.Body>
+              ))
+            )}
+            {activeCount > activeSamples.length && (
+              <p className="text-ui-fg-muted px-6 py-3 text-xs">
+                Showing the {activeSamples.length} most recent of {activeCount}.
+              </p>
+            )}
+          </Drawer.Body>
+        </Tabs>
       </Drawer.Content>
     </Drawer>
   )

--- a/vendor-panel/src/components/layout/shell/shell.tsx
+++ b/vendor-panel/src/components/layout/shell/shell.tsx
@@ -19,6 +19,7 @@ import { ProgressBar } from "../../common/progress-bar"
 import { Notifications } from "../notifications"
 import { AdminChat } from "../admin-chat"
 import { VendorHermesChat } from "../vendor-hermes-chat"
+import { PlaybookSetupBanner } from "../../playbook/playbook-setup-banner"
 import { useMe } from "../../../hooks/api"
 
 export const Shell = ({ children }: PropsWithChildren) => {
@@ -55,6 +56,7 @@ export const Shell = ({ children }: PropsWithChildren) => {
               )}
             >
               <Gutter>
+                <PlaybookSetupBanner />
                 <Outlet />
               </Gutter>
             </main>

--- a/vendor-panel/src/components/onboarding/launch-wizard.tsx
+++ b/vendor-panel/src/components/onboarding/launch-wizard.tsx
@@ -14,6 +14,11 @@ import {
 } from "@medusajs/ui"
 import { ArrowLeft, ArrowRight, CheckCircleSolid } from "@medusajs/icons"
 import { backendUrl, getAuthToken } from "../../lib/client"
+import { PlaybookPicker } from "../playbook/playbook-picker"
+import {
+  usePlaybookAssignment,
+  useAssignPlaybook,
+} from "../../hooks/api/playbook"
 
 /**
  * Sprint A (FEATURE_BUILD_PLAN.md A1-A10) launch-first onboarding wizard.
@@ -105,6 +110,14 @@ export function LaunchWizard() {
   const [loading, setLoading] = useState(true)
   const [advanced, setAdvanced] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+
+  // Playbook gate — picker shows first when seller has no assignment.
+  const {
+    data: assignmentData,
+    isPending: assignmentLoading,
+  } = usePlaybookAssignment()
+  const { mutateAsync: assignPlaybook, isPending: assigning } = useAssignPlaybook()
+  const hasPlaybook = !!assignmentData?.playbook_assignment
 
   // Step 1
   const [sellingType, setSellingType] = useState<SellingType | "">("")
@@ -224,10 +237,41 @@ export function LaunchWizard() {
     </Text>
   )
 
-  if (loading) {
+  if (loading || assignmentLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
         <Text>Loading…</Text>
+      </div>
+    )
+  }
+
+  if (!hasPlaybook && state?.wizard_step !== "published") {
+    return (
+      <div className="min-h-screen bg-ui-bg-base">
+        <Container className="py-8">
+          <PlaybookPicker
+            onComplete={async (result) => {
+              try {
+                await assignPlaybook({
+                  recipe_id: result.recipe_id,
+                  answers: result.answers,
+                  recommended_recipe_id: result.recommended_recipe_id,
+                  overridden: result.overridden,
+                })
+                toast.success("Playbook saved — let's get your listing up")
+              } catch (err) {
+                toast.error("Could not save playbook", {
+                  description: (err as Error).message,
+                })
+              }
+            }}
+          />
+          {assigning ? (
+            <div className="text-center mt-4">
+              <Text size="small" className="text-ui-fg-subtle">Saving…</Text>
+            </div>
+          ) : null}
+        </Container>
       </div>
     )
   }

--- a/vendor-panel/src/components/onboarding/quick-path.tsx
+++ b/vendor-panel/src/components/onboarding/quick-path.tsx
@@ -11,6 +11,11 @@ import {
   toast,
 } from "@medusajs/ui"
 import { backendUrl, getAuthToken } from "../../lib/client"
+import { PlaybookPicker } from "../playbook/playbook-picker"
+import {
+  usePlaybookAssignment,
+  useAssignPlaybook,
+} from "../../hooks/api/playbook"
 
 /**
  * Slice C — 60-second creator onboarding quick path.
@@ -58,6 +63,13 @@ export function QuickPath() {
   const [productTitle, setProductTitle] = useState("")
   const [productPrice, setProductPrice] = useState("")
 
+  const {
+    data: assignmentData,
+    isPending: assignmentLoading,
+  } = usePlaybookAssignment()
+  const { mutateAsync: assignPlaybook, isPending: assigning } = useAssignPlaybook()
+  const hasPlaybook = !!assignmentData?.playbook_assignment
+
   const onSubmit = async () => {
     if (!sellingType) {
       toast.error("Pick a selling type")
@@ -102,6 +114,43 @@ export function QuickPath() {
     } finally {
       setSubmitting(false)
     }
+  }
+
+  if (assignmentLoading) {
+    return (
+      <Container className="mx-auto max-w-2xl p-6">
+        <Text>Loading…</Text>
+      </Container>
+    )
+  }
+
+  if (!hasPlaybook) {
+    return (
+      <Container className="mx-auto max-w-2xl p-6">
+        <PlaybookPicker
+          onComplete={async (result) => {
+            try {
+              await assignPlaybook({
+                recipe_id: result.recipe_id,
+                answers: result.answers,
+                recommended_recipe_id: result.recommended_recipe_id,
+                overridden: result.overridden,
+              })
+              toast.success("Playbook saved")
+            } catch (err) {
+              toast.error("Could not save playbook", {
+                description: (err as Error).message,
+              })
+            }
+          }}
+        />
+        {assigning ? (
+          <div className="text-center mt-4">
+            <Text size="small" className="text-ui-fg-subtle">Saving…</Text>
+          </div>
+        ) : null}
+      </Container>
+    )
   }
 
   return (

--- a/vendor-panel/src/components/playbook/playbook-setup-banner/index.ts
+++ b/vendor-panel/src/components/playbook/playbook-setup-banner/index.ts
@@ -1,0 +1,1 @@
+export { PlaybookSetupBanner } from "./playbook-setup-banner"

--- a/vendor-panel/src/components/playbook/playbook-setup-banner/playbook-setup-banner.tsx
+++ b/vendor-panel/src/components/playbook/playbook-setup-banner/playbook-setup-banner.tsx
@@ -1,0 +1,104 @@
+import { Alert, Button, FocusModal, Text, toast } from "@medusajs/ui"
+import { useState } from "react"
+import { useLocation } from "react-router-dom"
+
+import { PlaybookPicker } from "../playbook-picker"
+import { useMe } from "../../../hooks/api/users"
+import {
+  useAssignPlaybook,
+  usePlaybookAssignment,
+} from "../../../hooks/api/playbook"
+
+/**
+ * Dashboard banner shown to sellers who don't yet have a playbook
+ * assignment. Surfaces the 3-question picker in a focus modal so legacy
+ * sellers (and any backfill miss) can migrate themselves without
+ * needing operator intervention.
+ *
+ * Skipped on `/onboarding/*` because the wizard there mounts the picker
+ * as a gate already — showing both would be redundant.
+ */
+export const PlaybookSetupBanner = () => {
+  const location = useLocation()
+  const { seller, isPending: meLoading } = useMe()
+  const {
+    data: assignmentData,
+    isPending: assignmentLoading,
+  } = usePlaybookAssignment()
+  const { mutateAsync: assignPlaybook, isPending: assigning } = useAssignPlaybook()
+  const [open, setOpen] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  if (meLoading || assignmentLoading) return null
+  if (!seller) return null
+  if (assignmentData?.playbook_assignment) return null
+  if (location.pathname.startsWith("/onboarding")) return null
+  if (dismissed) return null
+
+  return (
+    <>
+      <Alert variant="warning" className="bg-ui-bg-base">
+        <div className="flex flex-col gap-y-3">
+          <div className="flex flex-col">
+            <Text size="small" leading="compact" weight="plus" asChild>
+              <h2>Pick your playbook</h2>
+            </Text>
+            <Text size="small" leading="compact" className="text-pretty">
+              We've updated how vendors are categorized. Spend 30 seconds picking
+              the playbook that matches your operation — it unlocks the right
+              tools for your shape of work.
+            </Text>
+          </div>
+          <div className="flex items-center gap-x-3">
+            <Button variant="secondary" size="small" onClick={() => setOpen(true)}>
+              Pick your playbook
+            </Button>
+            <Button
+              variant="transparent"
+              size="small"
+              onClick={() => setDismissed(true)}
+            >
+              Not now
+            </Button>
+          </div>
+        </div>
+      </Alert>
+
+      <FocusModal open={open} onOpenChange={setOpen}>
+        <FocusModal.Content>
+          <FocusModal.Header />
+          <FocusModal.Body className="overflow-y-auto">
+            <PlaybookPicker
+              onCancel={() => setOpen(false)}
+              onComplete={async (result) => {
+                try {
+                  await assignPlaybook({
+                    recipe_id: result.recipe_id,
+                    answers: result.answers,
+                    recommended_recipe_id: result.recommended_recipe_id,
+                    overridden: result.overridden,
+                  })
+                  toast.success("Playbook saved")
+                  setOpen(false)
+                } catch (err) {
+                  toast.error("Could not save playbook", {
+                    description: (err as Error).message,
+                  })
+                }
+              }}
+            />
+            {assigning ? (
+              <div className="text-center mt-4">
+                <Text size="small" className="text-ui-fg-subtle">
+                  Saving…
+                </Text>
+              </div>
+            ) : null}
+          </FocusModal.Body>
+        </FocusModal.Content>
+      </FocusModal>
+    </>
+  )
+}
+
+export default PlaybookSetupBanner

--- a/vendor-panel/src/hooks/api/notification.tsx
+++ b/vendor-panel/src/hooks/api/notification.tsx
@@ -54,3 +54,44 @@ export const useNotifications = (
 
   return { ...data, ...rest }
 }
+
+export type NotificationBucket = "awaits_me" | "about_me" | "fyi"
+
+export type NotificationBucketsResponse = {
+  counts: Record<NotificationBucket, number>
+  samples: Record<
+    NotificationBucket,
+    Array<{
+      id: string
+      template: string | null
+      data: Record<string, unknown> | null
+      created_at: string
+    }>
+  >
+}
+
+/**
+ * Three-bucket notification counts + per-bucket samples. Backed by
+ * `GET /vendor/notifications/buckets`. Refetches on a 30s interval so
+ * the bell badge stays accurate without forcing the drawer open.
+ */
+export const useNotificationBuckets = (
+  query?: { limit?: number; since?: string },
+  options?: Omit<
+    UseQueryOptions<NotificationBucketsResponse, FetchError, NotificationBucketsResponse, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery<NotificationBucketsResponse, FetchError>({
+    queryFn: () =>
+      fetchQuery("/vendor/notifications/buckets", {
+        method: "GET",
+        query: query as Record<string, string | number>,
+      }) as Promise<NotificationBucketsResponse>,
+    queryKey: [...notificationQueryKeys.lists(), "buckets", query] as QueryKey,
+    refetchInterval: 30_000,
+    ...options,
+  })
+
+  return { data, ...rest }
+}

--- a/vendor-panel/src/hooks/api/playbook.ts
+++ b/vendor-panel/src/hooks/api/playbook.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { fetchQuery, getAuthToken } from "../../lib/client"
+import { usersQueryKeys } from "./users"
+import type { Playbook } from "../../providers/playbook-provider"
+
+export type PlaybookAssignment = {
+  id: string
+  seller_id: string
+  playbook_id: string
+  recipe_id: Exclude<Playbook, "default">
+  q1_size: string | null
+  q2_governance: string | null
+  q3_offering: string | null
+  recommended_recipe_id: string | null
+  overridden: boolean
+  migrated_from: string | null
+  assigned_at: string | null
+}
+
+export type AssignPlaybookBody = {
+  recipe_id: Exclude<Playbook, "default">
+  answers?: {
+    size: string
+    governance: string
+    offering: string
+  }
+  recommended_recipe_id?: Exclude<Playbook, "default">
+  overridden?: boolean
+}
+
+export const playbookQueryKeys = {
+  assignment: ["playbook", "assignment", "me"] as const,
+}
+
+export const usePlaybookAssignment = () => {
+  return useQuery<{ playbook_assignment: PlaybookAssignment | null }>({
+    queryKey: playbookQueryKeys.assignment,
+    queryFn: () => fetchQuery("/vendor/playbook/assign", { method: "GET" }),
+    enabled: Boolean(getAuthToken()),
+    retry: false,
+  })
+}
+
+export const useAssignPlaybook = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: AssignPlaybookBody) =>
+      fetchQuery("/vendor/playbook/assign", {
+        method: "POST",
+        body,
+      }) as Promise<{ playbook_assignment: PlaybookAssignment }>,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: playbookQueryKeys.assignment })
+      // The seller's resolved playbook (used by usePlaybook()) is derived
+      // from seller fields fetched via useMe(); refresh it so the gate
+      // and any consumer (banner, sidebar) re-render with the new value.
+      queryClient.invalidateQueries({ queryKey: usersQueryKeys.me() })
+    },
+  })
+}


### PR DESCRIPTION
Mount the playbook picker as a gate in both launch-wizard and quick-path
onboarding flows so new vendors pick a playbook before stepping into the
existing selling_type wizard. Add a dashboard banner that surfaces the
same picker for legacy sellers whose vendor_type didn't map cleanly to
a playbook.

Backend
- POST /vendor/playbook/assign upserts via assignPlaybookWorkflow with
  validated recipe_id and 3-question answers. migrated_from is server-
  controlled; client values are discarded.
- GET /vendor/playbook/assign returns the current assignment (or null)
  so the gate and banner can decide whether to surface the picker.
- scripts/backfill-playbook-assignments.ts maps legacy
  seller_metadata.vendor_type to playbook recipe_ids
  (producer→cycle, garden→harvest, kitchen+restaurant→kitchen,
  maker→stall, mutual_aid→grove), idempotent against existing rows,
  with a PLAYBOOK_BACKFILL_DRY_RUN=1 mode.

Vendor-panel
- usePlaybookAssignment + useAssignPlaybook hooks; mutation invalidates
  the assignment query and useMe so usePlaybook() re-resolves.
- Launch wizard renders PlaybookPicker before its existing step 1 when
  the seller has no assignment.
- Quick path mirrors the gate.
- PlaybookSetupBanner shown on the dashboard (Shell layout) when seller
  is logged in, has no assignment, and is not on /onboarding/*.
  Opens the picker in a FocusModal.

Tests
- 9 new unit tests for the route (GET/POST happy paths, idempotent
  upsert via workflow, 400 validation for recipe_id/answers, 401 for
  unauthenticated, server-controlled migrated_from). 221/221 backend
  unit tests pass.
- Vendor-panel typecheck clean.

https://claude.ai/code/session_016etzB3joWXJaiN6jjFrAYc