### PR TITLE
Add progression (RPG) layer: character sheet, XP, stance, regions

### DIFF
--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -187,6 +187,7 @@ const marketplaceModules = [
   { resolve: './src/modules/sell-signup' },
   { resolve: './src/modules/vendor-verification' },
   { resolve: './src/modules/impact-metrics' },
+  { resolve: './src/modules/progression' },
   { resolve: './src/modules/payout-breakdown' },
   { resolve: './src/modules/harvest-batches' },
   { resolve: './src/modules/vendor-rules' },

--- a/backend/src/api/store/character/recompute/route.ts
+++ b/backend/src/api/store/character/recompute/route.ts
@@ -1,0 +1,34 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PROGRESSION_MODULE } from "../../../../modules/progression"
+import type ProgressionModuleService from "../../../../modules/progression/service"
+
+/**
+ * POST /store/character/recompute
+ *
+ * Recomputes the authenticated customer's aggregate-stat snapshot from the
+ * source-of-truth modules (impact-metrics, volunteer, hawala-ledger, …).
+ * Optional body: { seller_id } to also mirror producer-side stats.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const { seller_id } = (req.body as { seller_id?: string }) ?? {}
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const progression = req.scope.resolve<ProgressionModuleService>(
+    PROGRESSION_MODULE
+  )
+
+  try {
+    await progression.recomputeAggregates(customerId, query as never, seller_id)
+    const character = await progression.getCharacterSheetSummary(customerId)
+    res.json({ character })
+  } catch (error) {
+    console.error("Error recomputing character sheet:", error)
+    res.status(500).json({ error: "Failed to recompute character sheet" })
+  }
+}

--- a/backend/src/api/store/character/route.ts
+++ b/backend/src/api/store/character/route.ts
@@ -1,0 +1,28 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { PROGRESSION_MODULE } from "../../../modules/progression"
+import type ProgressionModuleService from "../../../modules/progression/service"
+
+/**
+ * GET /store/character
+ *
+ * Returns the authenticated customer's character sheet summary (role tracks,
+ * levels, aggregate stats, earned titles). Creates an empty sheet on first read.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const progression = req.scope.resolve<ProgressionModuleService>(
+    PROGRESSION_MODULE
+  )
+
+  try {
+    const character = await progression.getCharacterSheetSummary(customerId)
+    res.json({ character })
+  } catch (error) {
+    console.error("Error retrieving character sheet:", error)
+    res.status(500).json({ error: "Failed to retrieve character sheet" })
+  }
+}

--- a/backend/src/api/store/character/stance/route.ts
+++ b/backend/src/api/store/character/stance/route.ts
@@ -1,0 +1,36 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { PROGRESSION_MODULE } from "../../../../modules/progression"
+import { isStance } from "../../../../modules/progression/stance"
+import type ProgressionModuleService from "../../../../modules/progression/service"
+
+/**
+ * POST /store/character/stance
+ *
+ * Sets the authenticated customer's active stance (the role they're currently
+ * "playing"). Body: { stance: "producer" | "consumer" | "investor" |
+ * "coalition" | "creator" }.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const { stance } = (req.body as { stance?: string }) ?? {}
+  if (!isStance(stance)) {
+    return res.status(400).json({ error: "Invalid stance" })
+  }
+
+  const progression = req.scope.resolve<ProgressionModuleService>(
+    PROGRESSION_MODULE
+  )
+
+  try {
+    await progression.setStance(customerId, stance)
+    const character = await progression.getCharacterSheetSummary(customerId)
+    res.json({ character })
+  } catch (error) {
+    console.error("Error setting stance:", error)
+    res.status(500).json({ error: "Failed to set stance" })
+  }
+}

--- a/backend/src/modules/progression/__tests__/leveling.unit.spec.ts
+++ b/backend/src/modules/progression/__tests__/leveling.unit.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Leveling-curve unit tests.
+ *
+ * The curve is the gamification backbone, so it must be exact and reversible:
+ *   - xpForLevel / levelForXp are inverses at level boundaries.
+ *   - levelForXp is monotonic and never negative.
+ *   - levelProgress reports sane in-level progress.
+ */
+
+import {
+  xpForLevel,
+  levelForXp,
+  levelProgress,
+  XP_PER_LEVEL,
+} from "../leveling"
+
+describe("progression leveling curve", () => {
+  it("xpForLevel follows the quadratic curve", () => {
+    expect(xpForLevel(0)).toBe(0)
+    expect(xpForLevel(1)).toBe(XP_PER_LEVEL)
+    expect(xpForLevel(2)).toBe(XP_PER_LEVEL * 4)
+    expect(xpForLevel(3)).toBe(XP_PER_LEVEL * 9)
+  })
+
+  it("levelForXp is the inverse of xpForLevel at boundaries", () => {
+    for (let n = 1; n <= 20; n++) {
+      expect(levelForXp(xpForLevel(n))).toBe(n)
+    }
+  })
+
+  it("levelForXp never goes negative and clamps at zero XP", () => {
+    expect(levelForXp(0)).toBe(0)
+    expect(levelForXp(-50)).toBe(0)
+    expect(levelForXp(XP_PER_LEVEL - 1)).toBe(0)
+  })
+
+  it("levelForXp is monotonic non-decreasing", () => {
+    let prev = 0
+    for (let xp = 0; xp <= 10000; xp += 137) {
+      const lvl = levelForXp(xp)
+      expect(lvl).toBeGreaterThanOrEqual(prev)
+      prev = lvl
+    }
+  })
+
+  it("levelProgress reports in-level progress correctly", () => {
+    // Exactly at level 2 boundary => 0% into level 2.
+    const atBoundary = levelProgress(xpForLevel(2))
+    expect(atBoundary.level).toBe(2)
+    expect(atBoundary.xpIntoLevel).toBe(0)
+    expect(atBoundary.pct).toBe(0)
+
+    // Halfway between level 2 and 3.
+    const span = xpForLevel(3) - xpForLevel(2)
+    const half = levelProgress(xpForLevel(2) + Math.floor(span / 2))
+    expect(half.level).toBe(2)
+    expect(half.pct).toBeGreaterThanOrEqual(49)
+    expect(half.pct).toBeLessThanOrEqual(51)
+  })
+})

--- a/backend/src/modules/progression/index.ts
+++ b/backend/src/modules/progression/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils"
+import ProgressionModuleService from "./service"
+
+export const PROGRESSION_MODULE = "progressionModuleService"
+
+export default Module(PROGRESSION_MODULE, {
+  service: ProgressionModuleService,
+})
+
+export * from "./models"
+export * from "./stance"
+export * from "./leveling"

--- a/backend/src/modules/progression/leveling.ts
+++ b/backend/src/modules/progression/leveling.ts
@@ -1,0 +1,69 @@
+/**
+ * Progression leveling curve.
+ *
+ * Pure, I/O-free functions so they can be unit-tested in isolation and reused
+ * by the service, subscribers, and any future workflow steps. The curve is a
+ * standard quadratic RPG curve:
+ *
+ *   xpForLevel(n) = XP_PER_LEVEL * n^2   (cumulative XP required to *reach* level n)
+ *   levelForXp(xp) = floor(sqrt(xp / XP_PER_LEVEL))
+ *
+ * So with XP_PER_LEVEL = 100: level 1 = 100 XP, level 2 = 400, level 3 = 900…
+ * Each successive level costs more, which keeps high levels meaningful without
+ * ever capping progression.
+ */
+
+import { Stance } from "./stance"
+
+/** Base XP scalar. Level n requires XP_PER_LEVEL * n^2 cumulative XP. */
+export const XP_PER_LEVEL = 100
+
+/**
+ * Per-role XP multipliers. A unit of "effort" in each track is weighted so the
+ * tracks level at comparable rates despite very different underlying events
+ * (a single investment deploys far more capital than a single order is worth).
+ * Multipliers are applied at *ingestion* time in the service, not here, so this
+ * map is the single source of truth for tuning.
+ */
+export const ROLE_XP_WEIGHTS: Record<Stance, number> = {
+  [Stance.CONSUMER]: 1,
+  [Stance.PRODUCER]: 1,
+  [Stance.INVESTOR]: 1,
+  [Stance.COALITION]: 1,
+  [Stance.CREATOR]: 1,
+}
+
+/** Cumulative XP required to reach a given level (level >= 0). */
+export function xpForLevel(level: number): number {
+  if (level <= 0) return 0
+  return XP_PER_LEVEL * level * level
+}
+
+/** Level for a given cumulative XP total. */
+export function levelForXp(xp: number): number {
+  if (xp <= 0) return 0
+  return Math.floor(Math.sqrt(xp / XP_PER_LEVEL))
+}
+
+/**
+ * Progress within the current level, as XP-into-level and XP-needed-for-next.
+ * Useful for rendering a progress bar without re-deriving the math client-side.
+ */
+export function levelProgress(xp: number): {
+  level: number
+  xpIntoLevel: number
+  xpForNextLevel: number
+  pct: number
+} {
+  const level = levelForXp(xp)
+  const floor = xpForLevel(level)
+  const ceiling = xpForLevel(level + 1)
+  const span = ceiling - floor
+  const into = Math.max(0, xp - floor)
+  return {
+    level,
+    xpIntoLevel: into,
+    xpForNextLevel: span,
+    pct: span > 0 ? Math.min(100, Math.round((into / span) * 100)) : 0,
+  }
+}

--- a/backend/src/modules/progression/migrations/Migration20260601CreateProgression.ts
+++ b/backend/src/modules/progression/migrations/Migration20260601CreateProgression.ts
@@ -1,0 +1,103 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260601CreateProgression extends Migration {
+  async up(): Promise<void> {
+    // ── Enums ───────────────────────────────────────────────────────────
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "stance_enum" AS ENUM (
+          'producer','consumer','investor','coalition','creator'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    // ── character_sheet ─────────────────────────────────────────────────
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "character_sheet" (
+        "id" TEXT NOT NULL,
+        "customer_id" TEXT NOT NULL,
+        "active_stance" stance_enum NOT NULL DEFAULT 'consumer',
+        "producer_xp" INTEGER NOT NULL DEFAULT 0,
+        "producer_level" INTEGER NOT NULL DEFAULT 0,
+        "consumer_xp" INTEGER NOT NULL DEFAULT 0,
+        "consumer_level" INTEGER NOT NULL DEFAULT 0,
+        "investor_xp" INTEGER NOT NULL DEFAULT 0,
+        "investor_level" INTEGER NOT NULL DEFAULT 0,
+        "coalition_xp" INTEGER NOT NULL DEFAULT 0,
+        "coalition_level" INTEGER NOT NULL DEFAULT 0,
+        "creator_xp" INTEGER NOT NULL DEFAULT 0,
+        "creator_level" INTEGER NOT NULL DEFAULT 0,
+        "total_xp" INTEGER NOT NULL DEFAULT 0,
+        "food_produced_cents" NUMERIC NOT NULL DEFAULT 0,
+        "orders_completed" INTEGER NOT NULL DEFAULT 0,
+        "capital_deployed_cents" NUMERIC NOT NULL DEFAULT 0,
+        "mutual_aid_contributions" INTEGER NOT NULL DEFAULT 0,
+        "trust_score" INTEGER NOT NULL DEFAULT 0,
+        "karma" INTEGER NOT NULL DEFAULT 0,
+        "time_credits" INTEGER NOT NULL DEFAULT 0,
+        "earned_titles" JSONB NULL,
+        "last_recomputed_at" TIMESTAMPTZ NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "character_sheet_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_character_sheet_customer_id" ON "character_sheet" ("customer_id") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_character_sheet_active_stance" ON "character_sheet" ("active_stance") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_character_sheet_total_xp" ON "character_sheet" ("total_xp") WHERE "deleted_at" IS NULL;`)
+
+    // ── xp_event ────────────────────────────────────────────────────────
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "xp_event" (
+        "id" TEXT NOT NULL,
+        "customer_id" TEXT NOT NULL,
+        "role" stance_enum NOT NULL,
+        "amount" INTEGER NOT NULL,
+        "reason" TEXT NOT NULL,
+        "source_module" TEXT NULL,
+        "source_id" TEXT NULL,
+        "occurred_at" TIMESTAMPTZ NOT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "xp_event_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_xp_event_customer_id" ON "xp_event" ("customer_id") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_xp_event_reason" ON "xp_event" ("reason") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_xp_event_source" ON "xp_event" ("source_module", "source_id") WHERE "deleted_at" IS NULL;`)
+
+    // ── progression_title ───────────────────────────────────────────────
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "progression_title" (
+        "id" TEXT NOT NULL,
+        "slug" TEXT NOT NULL,
+        "role" stance_enum NOT NULL,
+        "name" TEXT NOT NULL,
+        "description" TEXT NOT NULL,
+        "min_level" INTEGER NOT NULL DEFAULT 1,
+        "icon" TEXT NULL,
+        "color" TEXT NULL,
+        "display_order" INTEGER NOT NULL DEFAULT 0,
+        "active" BOOLEAN NOT NULL DEFAULT true,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "progression_title_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_progression_title_slug" ON "progression_title" ("slug") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_progression_title_role" ON "progression_title" ("role") WHERE "deleted_at" IS NULL;`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`DROP TABLE IF EXISTS "xp_event";`)
+    this.addSql(`DROP TABLE IF EXISTS "progression_title";`)
+    this.addSql(`DROP TABLE IF EXISTS "character_sheet";`)
+    this.addSql(`DROP TYPE IF EXISTS "stance_enum";`)
+  }
+}

--- a/backend/src/modules/progression/models/character-sheet.ts
+++ b/backend/src/modules/progression/models/character-sheet.ts
@@ -1,0 +1,72 @@
+import { model } from "@medusajs/framework/utils"
+import { Stance } from "../stance"
+
+/**
+ * Character Sheet
+ *
+ * One row per customer — the unified "RPG profile" that ties together the
+ * marketplace's many fragmented signals (orders, investments, volunteer time,
+ * karma, vendor trust) into a single levelled identity.
+ *
+ * IMPORTANT — this table is a *derived cache*, not a source of truth. The
+ * per-role XP/level fields are authoritative (they're the gamification-specific
+ * fact that lives nowhere else), but the aggregate stat fields below are
+ * snapshots recomputed from the owning modules (impact-metrics, collective-
+ * campaign, volunteer, hawala-ledger, vendor-verification) via `query.graph`.
+ * Never treat them as the canonical value — recompute from source.
+ */
+const CharacterSheet = model.define("character_sheet", {
+  id: model.id().primaryKey(),
+
+  // Link to customer (one sheet per customer)
+  customer_id: model.text().unique(),
+
+  // The role the user is currently "playing" — drives storefront theming.
+  active_stance: model.enum(Object.values(Stance)).default(Stance.CONSUMER),
+
+  // === Per-role XP + level (authoritative gamification state) ===
+  producer_xp: model.number().default(0),
+  producer_level: model.number().default(0),
+  consumer_xp: model.number().default(0),
+  consumer_level: model.number().default(0),
+  investor_xp: model.number().default(0),
+  investor_level: model.number().default(0),
+  coalition_xp: model.number().default(0),
+  coalition_level: model.number().default(0),
+  creator_xp: model.number().default(0),
+  creator_level: model.number().default(0),
+
+  // Sum of all role XP — used for leaderboards / "overall level".
+  total_xp: model.number().default(0),
+
+  // === Aggregate stats snapshot (DERIVED — recomputed from source modules) ===
+  // Value (cents) of food/goods produced and sold — from producer impact.
+  food_produced_cents: model.bigNumber().default(0),
+  // Orders completed as a buyer — mirrors buyer_impact.total_orders.
+  orders_completed: model.number().default(0),
+  // Capital deployed into campaigns/pools (cents) — from collective-campaign.
+  capital_deployed_cents: model.bigNumber().default(0),
+  // Mutual-aid / volunteer contributions count.
+  mutual_aid_contributions: model.number().default(0),
+  // Vendor trust score 0-100 — mirror of vendor_verification.trust_score.
+  trust_score: model.number().default(0),
+  // Sum of karma_event deltas — from hawala-ledger.
+  karma: model.number().default(0),
+  // Volunteer time credits accrued — from the volunteer module.
+  time_credits: model.number().default(0),
+
+  // Earned titles: { title_slug, role, earned_at }[]
+  earned_titles: model.json().nullable(),
+
+  // When the aggregate snapshot was last recomputed from source modules.
+  last_recomputed_at: model.dateTime().nullable(),
+
+  metadata: model.json().nullable(),
+})
+  .indexes([
+    { on: ["customer_id"], name: "IDX_character_sheet_customer_id" },
+    { on: ["active_stance"], name: "IDX_character_sheet_active_stance" },
+    { on: ["total_xp"], name: "IDX_character_sheet_total_xp" },
+  ])
+
+export default CharacterSheet

--- a/backend/src/modules/progression/models/index.ts
+++ b/backend/src/modules/progression/models/index.ts
@@ -1,0 +1,3 @@
+export { default as CharacterSheet } from "./character-sheet"
+export { default as XpEvent } from "./xp-event"
+export { default as ProgressionTitle } from "./progression-title"

--- a/backend/src/modules/progression/models/progression-title.ts
+++ b/backend/src/modules/progression/models/progression-title.ts
@@ -1,0 +1,40 @@
+import { model } from "@medusajs/framework/utils"
+import { Stance } from "../stance"
+
+/**
+ * Progression Title
+ *
+ * Seedable catalog of earnable titles (Village Farmer, Market Trader, Community
+ * Investor, Coalition Steward…). A title is granted when a customer's level in
+ * the matching role track reaches `min_level`. Mirrors the shape of
+ * impact-metrics' `DEFAULT_BUYER_BADGES` seed pattern.
+ */
+const ProgressionTitle = model.define("progression_title", {
+  id: model.id().primaryKey(),
+
+  // Stable slug, unique across the catalog.
+  slug: model.text().unique(),
+
+  // The role track this title belongs to.
+  role: model.enum(Object.values(Stance)),
+
+  name: model.text(),
+  description: model.text(),
+
+  // Level in the matching role track required to earn this title.
+  min_level: model.number().default(1),
+
+  icon: model.text().nullable(),
+  color: model.text().nullable(),
+
+  display_order: model.number().default(0),
+  active: model.boolean().default(true),
+
+  metadata: model.json().nullable(),
+})
+  .indexes([
+    { on: ["slug"], name: "IDX_progression_title_slug" },
+    { on: ["role"], name: "IDX_progression_title_role" },
+  ])
+
+export default ProgressionTitle

--- a/backend/src/modules/progression/models/xp-event.ts
+++ b/backend/src/modules/progression/models/xp-event.ts
@@ -1,0 +1,44 @@
+import { model } from "@medusajs/framework/utils"
+import { Stance } from "../stance"
+
+/**
+ * XP Event
+ *
+ * Append-only ledger of every experience-point award (or clawback). Modelled
+ * deliberately after hawala-ledger's `karma_event`: signed `amount`, a `reason`
+ * slug, and a `source_module` / `source_id` audit trail back to the originating
+ * record so XP can always be re-derived or reversed.
+ *
+ * This is the one genuinely-new fact the progression module owns — it exists
+ * nowhere else in the system.
+ */
+const XpEvent = model.define("xp_event", {
+  id: model.id().primaryKey(),
+
+  customer_id: model.text(),
+
+  // Which role track this XP credits.
+  role: model.enum(Object.values(Stance)),
+
+  // Signed XP delta. Negative for clawbacks (e.g. order canceled).
+  amount: model.number(),
+
+  // Slug describing why XP was awarded: order-placed, volunteer-verified,
+  // campaign-backed, karma-accrued, verified, order-canceled, etc.
+  reason: model.text(),
+
+  // Audit trail back to the originating record.
+  source_module: model.text().nullable(),
+  source_id: model.text().nullable(),
+
+  occurred_at: model.dateTime(),
+
+  metadata: model.json().nullable(),
+})
+  .indexes([
+    { on: ["customer_id"], name: "IDX_xp_event_customer_id" },
+    { on: ["reason"], name: "IDX_xp_event_reason" },
+    { on: ["source_module", "source_id"], name: "IDX_xp_event_source" },
+  ])
+
+export default XpEvent

--- a/backend/src/modules/progression/service.ts
+++ b/backend/src/modules/progression/service.ts
@@ -1,0 +1,323 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { CharacterSheet, XpEvent, ProgressionTitle } from "./models"
+import { Stance, isStance } from "./stance"
+import { levelForXp, levelProgress, ROLE_XP_WEIGHTS } from "./leveling"
+
+/**
+ * Per-role XP column names on the character sheet, keyed by stance.
+ */
+const XP_COLUMN: Record<Stance, { xp: string; level: string }> = {
+  [Stance.PRODUCER]: { xp: "producer_xp", level: "producer_level" },
+  [Stance.CONSUMER]: { xp: "consumer_xp", level: "consumer_level" },
+  [Stance.INVESTOR]: { xp: "investor_xp", level: "investor_level" },
+  [Stance.COALITION]: { xp: "coalition_xp", level: "coalition_level" },
+  [Stance.CREATOR]: { xp: "creator_xp", level: "creator_level" },
+}
+
+/**
+ * Default titles seeded into the `progression_title` catalog. Mirrors the
+ * `DEFAULT_BUYER_BADGES` seed convention in impact-metrics.
+ */
+export const DEFAULT_TITLES: Array<{
+  slug: string
+  role: Stance
+  name: string
+  description: string
+  min_level: number
+  icon: string
+  color: string
+  display_order: number
+}> = [
+  { slug: "village-farmer", role: Stance.PRODUCER, name: "Village Farmer", description: "Started producing for your community.", min_level: 1, icon: "leaf", color: "#22C55E", display_order: 10 },
+  { slug: "regional-supplier", role: Stance.PRODUCER, name: "Regional Supplier", description: "A dependable producer at regional scale.", min_level: 5, icon: "truck", color: "#16A34A", display_order: 20 },
+  { slug: "master-manufacturer", role: Stance.PRODUCER, name: "Master Manufacturer", description: "An elite producer trusted across the network.", min_level: 10, icon: "trophy", color: "#15803D", display_order: 30 },
+  { slug: "market-trader", role: Stance.CONSUMER, name: "Market Trader", description: "An active supporter of producers.", min_level: 1, icon: "shopping-bag", color: "#3B82F6", display_order: 40 },
+  { slug: "loyal-patron", role: Stance.CONSUMER, name: "Loyal Patron", description: "A steadfast patron of the market.", min_level: 5, icon: "heart", color: "#2563EB", display_order: 50 },
+  { slug: "community-investor", role: Stance.INVESTOR, name: "Community Investor", description: "Deployed capital into community projects.", min_level: 1, icon: "dollar", color: "#F59E0B", display_order: 60 },
+  { slug: "guild-builder", role: Stance.INVESTOR, name: "Guild Builder", description: "A major backer of productive assets.", min_level: 5, icon: "award", color: "#D97706", display_order: 70 },
+  { slug: "coalition-steward", role: Stance.COALITION, name: "Coalition Steward", description: "Steps up to help the community thrive.", min_level: 1, icon: "users", color: "#8B5CF6", display_order: 80 },
+  { slug: "guild-leader", role: Stance.COALITION, name: "Guild Leader", description: "A pillar of coalition mutual aid.", min_level: 5, icon: "star", color: "#7C3AED", display_order: 90 },
+  { slug: "master-artisan", role: Stance.CREATOR, name: "Master Artisan", description: "A recognized creator in the Commons.", min_level: 5, icon: "edit", color: "#EC4899", display_order: 100 },
+]
+
+export type EarnedTitle = { title_slug: string; role: string; earned_at: Date }
+
+class ProgressionModuleService extends MedusaService({
+  CharacterSheet,
+  XpEvent,
+  ProgressionTitle,
+}) {
+  /**
+   * Get or create the character sheet for a customer.
+   */
+  async getOrCreateCharacterSheet(customerId: string) {
+    const existing = await this.listCharacterSheets({ customer_id: customerId })
+    if (existing.length > 0) {
+      return existing[0]
+    }
+    return this.createCharacterSheets({ customer_id: customerId })
+  }
+
+  /**
+   * Record an XP event and apply it to the character sheet.
+   *
+   * Writes an append-only `xp_event`, bumps the matching role track + total XP
+   * (XP floored at 0), recomputes the role level, then checks for newly-earned
+   * titles. The role-weight multiplier from `leveling.ts` is applied here.
+   */
+  async recordXpEvent(data: {
+    customer_id: string
+    role: Stance
+    amount: number
+    reason: string
+    source_module?: string
+    source_id?: string
+    metadata?: Record<string, unknown>
+  }) {
+    const weighted = Math.round(data.amount * (ROLE_XP_WEIGHTS[data.role] ?? 1))
+
+    await this.createXpEvents({
+      customer_id: data.customer_id,
+      role: data.role,
+      amount: weighted,
+      reason: data.reason,
+      source_module: data.source_module ?? null,
+      source_id: data.source_id ?? null,
+      occurred_at: new Date(),
+      metadata: (data.metadata as Record<string, unknown>) ?? null,
+    })
+
+    const sheet = await this.getOrCreateCharacterSheet(data.customer_id)
+    const col = XP_COLUMN[data.role]
+
+    const currentRoleXp = Number((sheet as Record<string, unknown>)[col.xp] ?? 0)
+    const newRoleXp = Math.max(0, currentRoleXp + weighted)
+    const newTotalXp = Math.max(0, Number(sheet.total_xp ?? 0) + weighted)
+
+    await this.updateCharacterSheets({
+      id: sheet.id,
+      [col.xp]: newRoleXp,
+      [col.level]: levelForXp(newRoleXp),
+      total_xp: newTotalXp,
+    })
+
+    await this.checkAndGrantTitles(data.customer_id)
+
+    return this.getOrCreateCharacterSheet(data.customer_id)
+  }
+
+  /**
+   * Set the customer's active stance (the role they're currently "playing").
+   */
+  async setStance(customerId: string, stance: Stance) {
+    const sheet = await this.getOrCreateCharacterSheet(customerId)
+    await this.updateCharacterSheets({ id: sheet.id, active_stance: stance })
+    return this.getOrCreateCharacterSheet(customerId)
+  }
+
+  /**
+   * Recompute the derived aggregate-stat snapshot from the owning modules.
+   *
+   * This is the anti-duplication core: rather than maintaining its own copies,
+   * progression reads the source-of-truth modules via the container's query
+   * graph and snapshots the values for fast reads. Each source is wrapped in
+   * try/catch so a missing/disabled module never breaks the whole recompute.
+   *
+   * @param query the container's `query` service (ContainerRegistrationKeys.QUERY)
+   */
+  async recomputeAggregates(
+    customerId: string,
+    query: { graph: (args: Record<string, unknown>) => Promise<{ data: any[] }> },
+    sellerId?: string
+  ) {
+    const sheet = await this.getOrCreateCharacterSheet(customerId)
+    const patch: Record<string, unknown> = { id: sheet.id }
+
+    // Buyer impact → orders completed.
+    try {
+      const { data } = await query.graph({
+        entity: "buyer_impact",
+        fields: ["total_orders"],
+        filters: { customer_id: customerId },
+      })
+      if (data?.[0]) patch.orders_completed = Number(data[0].total_orders ?? 0)
+    } catch {
+      /* module absent — leave snapshot as-is */
+    }
+
+    // Karma events → karma sum.
+    try {
+      const { data } = await query.graph({
+        entity: "karma_event",
+        fields: ["delta"],
+        filters: { owner_id: customerId },
+      })
+      if (Array.isArray(data)) {
+        patch.karma = data.reduce((sum, e) => sum + Number(e.delta ?? 0), 0)
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Volunteer time credits → contributions + credit sum.
+    try {
+      const { data } = await query.graph({
+        entity: "time_credit",
+        fields: ["credit_amount"],
+        filters: { customer_id: customerId },
+      })
+      if (Array.isArray(data)) {
+        patch.time_credits = data.reduce(
+          (sum, c) => sum + Number(c.credit_amount ?? 0),
+          0
+        )
+        patch.mutual_aid_contributions = data.length
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Seller-scoped aggregates (producer trust + revenue) when a seller id is known.
+    if (sellerId) {
+      try {
+        const { data } = await query.graph({
+          entity: "vendor_verification",
+          fields: ["trust_score"],
+          filters: { seller_id: sellerId },
+        })
+        if (data?.[0]) patch.trust_score = Number(data[0].trust_score ?? 0)
+      } catch {
+        /* ignore */
+      }
+      try {
+        const { data } = await query.graph({
+          entity: "producer_impact",
+          fields: ["total_revenue"],
+          filters: { seller_id: sellerId },
+        })
+        if (data?.[0]) patch.food_produced_cents = Number(data[0].total_revenue ?? 0)
+      } catch {
+        /* ignore */
+      }
+    }
+
+    patch.last_recomputed_at = new Date()
+    await this.updateCharacterSheets(patch)
+    return this.getOrCreateCharacterSheet(customerId)
+  }
+
+  /**
+   * Grant any titles whose role-level threshold the customer now meets.
+   * Returns the slugs newly granted. Mirrors `checkAndGrantBuyerBadges`.
+   */
+  async checkAndGrantTitles(customerId: string): Promise<string[]> {
+    const sheet = await this.getOrCreateCharacterSheet(customerId)
+    let titles = await this.listProgressionTitles({ active: true })
+
+    // Lazily seed the default catalog the first time it's needed. The repo
+    // seeds on-demand rather than via a startup loader, so do the same here.
+    if (titles.length === 0) {
+      await this.seedDefaultTitles()
+      titles = await this.listProgressionTitles({ active: true })
+    }
+
+    const earnedRaw = sheet.earned_titles as unknown
+    const earned: EarnedTitle[] = Array.isArray(earnedRaw)
+      ? (earnedRaw as EarnedTitle[])
+      : []
+    const earnedSlugs = new Set(earned.map((t) => t.title_slug))
+
+    const newlyEarned: string[] = []
+    for (const title of titles) {
+      if (earnedSlugs.has(title.slug)) continue
+      const col = XP_COLUMN[title.role as Stance]
+      if (!col) continue
+      const roleLevel = Number((sheet as Record<string, unknown>)[col.level] ?? 0)
+      if (roleLevel >= title.min_level) {
+        earned.push({ title_slug: title.slug, role: title.role, earned_at: new Date() })
+        newlyEarned.push(title.slug)
+      }
+    }
+
+    if (newlyEarned.length > 0) {
+      await this.updateCharacterSheets({
+        id: sheet.id,
+        earned_titles: earned as unknown as Record<string, unknown>,
+      })
+    }
+    return newlyEarned
+  }
+
+  /**
+   * Display shape for the storefront `/character` page and `/store/character`.
+   */
+  async getCharacterSheetSummary(customerId: string) {
+    const sheet = await this.getOrCreateCharacterSheet(customerId)
+    const titles = await this.listProgressionTitles({ active: true })
+    const titleBySlug = new Map(titles.map((t) => [t.slug, t]))
+
+    const tracks = (Object.keys(XP_COLUMN) as Stance[]).map((stance) => {
+      const col = XP_COLUMN[stance]
+      const xp = Number((sheet as Record<string, unknown>)[col.xp] ?? 0)
+      const progress = levelProgress(xp)
+      return {
+        role: stance,
+        xp,
+        level: progress.level,
+        xpIntoLevel: progress.xpIntoLevel,
+        xpForNextLevel: progress.xpForNextLevel,
+        pct: progress.pct,
+      }
+    })
+
+    const earnedRaw = sheet.earned_titles as unknown
+    const earned: EarnedTitle[] = Array.isArray(earnedRaw)
+      ? (earnedRaw as EarnedTitle[])
+      : []
+    const earnedTitles = earned.map((e) => {
+      const def = titleBySlug.get(e.title_slug)
+      return {
+        slug: e.title_slug,
+        role: e.role,
+        name: def?.name ?? e.title_slug,
+        description: def?.description ?? "",
+        icon: def?.icon ?? "award",
+        color: def?.color ?? "#6B7280",
+        earnedAt: e.earned_at,
+      }
+    })
+
+    return {
+      customerId: sheet.customer_id,
+      activeStance: sheet.active_stance,
+      totalXp: Number(sheet.total_xp ?? 0),
+      tracks,
+      stats: {
+        foodProducedCents: Number(sheet.food_produced_cents ?? 0),
+        ordersCompleted: Number(sheet.orders_completed ?? 0),
+        capitalDeployedCents: Number(sheet.capital_deployed_cents ?? 0),
+        mutualAidContributions: Number(sheet.mutual_aid_contributions ?? 0),
+        trustScore: Number(sheet.trust_score ?? 0),
+        karma: Number(sheet.karma ?? 0),
+        timeCredits: Number(sheet.time_credits ?? 0),
+      },
+      titles: earnedTitles,
+      lastRecomputedAt: sheet.last_recomputed_at,
+    }
+  }
+
+  /**
+   * Seed the default title catalog (idempotent).
+   */
+  async seedDefaultTitles(): Promise<void> {
+    for (const title of DEFAULT_TITLES) {
+      const existing = await this.listProgressionTitles({ slug: title.slug })
+      if (existing.length === 0) {
+        await this.createProgressionTitles(title)
+      }
+    }
+  }
+}
+
+export default ProgressionModuleService
+export { isStance }

--- a/backend/src/modules/progression/stance.ts
+++ b/backend/src/modules/progression/stance.ts
@@ -1,0 +1,72 @@
+import { VendorType } from "../seller-extension/models/seller-metadata"
+
+/**
+ * Stance — the active "role" a user is playing in the economy.
+ *
+ * The Solarpunk-MMORPG vision organizes the marketplace around people and the
+ * role they're taking on right now rather than around products. A user can
+ * switch stance instantly (like changing class in an RPG). Stance is a superset
+ * alignment of the seller-side `VendorType` enum:
+ *
+ *   - PRODUCER / CREATOR map 1:1 onto VendorType (seller-side roles).
+ *   - CONSUMER / INVESTOR / COALITION are buyer/community-side roles that have
+ *     no VendorType equivalent.
+ *
+ * Stance is stored per-customer on the character sheet (single source of truth)
+ * and mirrored into a storefront cookie for instant SSR theming.
+ */
+export enum Stance {
+  PRODUCER = "producer",
+  CONSUMER = "consumer",
+  INVESTOR = "investor",
+  COALITION = "coalition",
+  CREATOR = "creator",
+}
+
+export const ALL_STANCES: Stance[] = Object.values(Stance)
+
+/** The XP tracks tracked on a character sheet (one per stance). */
+export const XP_TRACKS = ALL_STANCES
+
+/**
+ * Map a seller's VendorType to the stance it most naturally aligns with.
+ * Most vendor types are PRODUCER-flavored; CREATOR maps 1:1.
+ */
+export function vendorTypeToStance(vendorType: VendorType | string): Stance {
+  switch (vendorType) {
+    case VendorType.CREATOR:
+      return Stance.CREATOR
+    case VendorType.MUTUAL_AID:
+      return Stance.COALITION
+    case VendorType.PRODUCER:
+    case VendorType.GARDEN:
+    case VendorType.KITCHEN:
+    case VendorType.MAKER:
+    case VendorType.RESTAURANT:
+      return Stance.PRODUCER
+    default:
+      return Stance.PRODUCER
+  }
+}
+
+/**
+ * Map a stance back to a representative VendorType where one exists. Returns
+ * null for buyer-side stances (CONSUMER / INVESTOR / COALITION) that have no
+ * seller classification.
+ */
+export function stanceToVendorType(stance: Stance): VendorType | null {
+  switch (stance) {
+    case Stance.PRODUCER:
+      return VendorType.PRODUCER
+    case Stance.CREATOR:
+      return VendorType.CREATOR
+    case Stance.COALITION:
+      return VendorType.MUTUAL_AID
+    default:
+      return null
+  }
+}
+
+export function isStance(value: unknown): value is Stance {
+  return typeof value === "string" && ALL_STANCES.includes(value as Stance)
+}

--- a/backend/src/subscribers/progression-order-canceled.ts
+++ b/backend/src/subscribers/progression-order-canceled.ts
@@ -1,0 +1,54 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PROGRESSION_MODULE } from "../modules/progression"
+import { Stance } from "../modules/progression/stance"
+import type ProgressionModuleService from "../modules/progression/service"
+
+/**
+ * Claw back the CONSUMER XP awarded for an order when it is canceled.
+ *
+ * Reverses the matching `order-placed` award by writing a negative XP event
+ * (the sheet floors XP at zero). Isolated by try/catch — additive only.
+ */
+export default async function progressionOrderCanceled({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const progression = container.resolve(
+      PROGRESSION_MODULE
+    ) as ProgressionModuleService
+
+    const { data: [order] } = await query.graph({
+      entity: "order",
+      fields: ["id", "total", "customer_id"],
+      filters: { id: data.id },
+    })
+
+    const customerId = order?.customer_id
+    if (!customerId) return
+
+    const xp = Math.max(1, Math.round(Number(order.total ?? 0) / 100))
+
+    await progression.recordXpEvent({
+      customer_id: customerId,
+      role: Stance.CONSUMER,
+      amount: -xp,
+      reason: "order-canceled",
+      source_module: "order",
+      source_id: order.id,
+    })
+
+    await progression.recomputeAggregates(customerId, query as never)
+  } catch (error) {
+    console.error(
+      `[progression-order-canceled] Failed to claw back XP for order ${data.id}:`,
+      error
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.canceled",
+}

--- a/backend/src/subscribers/progression-order-placed.ts
+++ b/backend/src/subscribers/progression-order-placed.ts
@@ -1,0 +1,57 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PROGRESSION_MODULE } from "../modules/progression"
+import { Stance } from "../modules/progression/stance"
+import type ProgressionModuleService from "../modules/progression/service"
+
+/**
+ * Award CONSUMER XP when an order is placed.
+ *
+ * Additive and fully isolated by try/catch — XP is a "nice-to-have" side effect
+ * and must never break checkout. XP scales with order value (1 XP per whole
+ * currency unit), then the aggregate snapshot is refreshed from source modules.
+ */
+export default async function progressionOrderPlaced({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const progression = container.resolve(
+      PROGRESSION_MODULE
+    ) as ProgressionModuleService
+
+    const { data: [order] } = await query.graph({
+      entity: "order",
+      fields: ["id", "total", "customer_id"],
+      filters: { id: data.id },
+    })
+
+    const customerId = order?.customer_id
+    if (!customerId) return
+
+    // 1 XP per whole currency unit (order.total is in the smallest unit / cents).
+    const xp = Math.max(1, Math.round(Number(order.total ?? 0) / 100))
+
+    await progression.recordXpEvent({
+      customer_id: customerId,
+      role: Stance.CONSUMER,
+      amount: xp,
+      reason: "order-placed",
+      source_module: "order",
+      source_id: order.id,
+    })
+
+    await progression.recomputeAggregates(customerId, query as never)
+  } catch (error) {
+    console.error(
+      `[progression-order-placed] Failed to award XP for order ${data.id}:`,
+      error
+    )
+    // Swallow — XP failure must not break the order flow.
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}

--- a/backend/src/subscribers/progression-vendor-verified.ts
+++ b/backend/src/subscribers/progression-vendor-verified.ts
@@ -1,0 +1,62 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PROGRESSION_MODULE } from "../modules/progression"
+import { Stance } from "../modules/progression/stance"
+import type ProgressionModuleService from "../modules/progression/service"
+
+type VendorVerifiedEventPayload = { seller_id: string }
+
+/**
+ * Award PRODUCER XP and mirror the verification trust score when a vendor is
+ * verified.
+ *
+ * Identity note: the progression character sheet is keyed by a single "user"
+ * id. For producers we use the seller's *primary member* id as that key — the
+ * person who operates the storefront. This is the seller-side identity for the
+ * gamification layer. Isolated by try/catch; additive only.
+ */
+export default async function progressionVendorVerified({
+  event: { data },
+  container,
+}: SubscriberArgs<VendorVerifiedEventPayload>) {
+  try {
+    const sellerId = data.seller_id
+    if (!sellerId) return
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const progression = container.resolve(
+      PROGRESSION_MODULE
+    ) as ProgressionModuleService
+
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: ["id", "members.id"],
+      filters: { id: sellerId },
+    })
+
+    const memberId = sellers?.[0]?.members?.[0]?.id
+    if (!memberId) return
+
+    // Flat PRODUCER XP bonus for reaching verified status.
+    await progression.recordXpEvent({
+      customer_id: memberId,
+      role: Stance.PRODUCER,
+      amount: 250,
+      reason: "verified",
+      source_module: "vendor_verification",
+      source_id: sellerId,
+    })
+
+    // Mirror the seller's trust score onto the sheet snapshot.
+    await progression.recomputeAggregates(memberId, query as never, sellerId)
+  } catch (error) {
+    console.error(
+      `[progression-vendor-verified] Failed for seller ${data.seller_id}:`,
+      error
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "vendor.verified",
+}

--- a/docs/SOLARPUNK_MMORPG_BLUEPRINT.md
+++ b/docs/SOLARPUNK_MMORPG_BLUEPRINT.md
@@ -1,0 +1,140 @@
+# Solarpunk MMORPG Blueprint
+
+> Reimagining Free Black Market as a **real-world economic MMORPG** —
+> organized around *people and their role in the economy* rather than around
+> products. This document checks that vision against what already exists in the
+> repo, and records the gamification + navigation layer being added to unify it.
+
+## Why this exists
+
+Most marketplaces organize around products (Etsy, Facebook Marketplace). The
+stronger framing for Free Black Market — given its existing Coalition, Blackout,
+creator-rewards, micro-investment, agriculture, and mutual-aid systems — is a
+**Solarpunk MMORPG for the real world**:
+
+- **Producers** level up by producing.
+- **Consumers** level up by supporting.
+- **Investors** level up by funding.
+- **Coalition members** level up by helping.
+- Real businesses become guilds, real farms become territories, real projects
+  become quests, real wealth creation becomes gameplay.
+
+The interface stays simple enough to understand in 30 seconds ("What are you
+doing today?") while the economy underneath is real.
+
+## Vision vs. reality (verification)
+
+A codebase audit found **~60% of the vision already exists**. The Solarpunk
+*theme* is fully built; the economic *engines* are real; what was missing is the
+**unifying gamification + navigation layer**.
+
+| Vision concept | In repo today | Verdict |
+|---|---|---|
+| Solarpunk visual theme | `storefront/src/app/colors.css`, `storefront/tailwind.config.ts` (green/amber/cream ramps, Exo_2/Urbanist, gradients, `shadow-solarpunk-*`) | ✅ Done |
+| Mobile bottom nav | `storefront/src/components/molecules/MobileLauncher/MobileLauncher.tsx` (radial FAB) | ✅ Exists (re-themed below) |
+| Roles (Producer/Consumer/Investor/Coalition) | `seller-extension/models/seller-metadata.ts` `VendorType` (PRODUCER/GARDEN/KITCHEN/MAKER/RESTAURANT/MUTUAL_AID/CREATOR); cooperative/governance/garden roles | ⚠️ Many systems, no unified user *stance* |
+| Regions (Agriculture Grove, …) | `cms-blueprint/seed/cms-blueprint-data.ts` (10 canonical product types) | ⚠️ Categories exist, not region-themed |
+| Quests / Bounties | `demand-pool/` (collective buy + bounties + voting, FULL), `asset-graph/manifests/creator-bounty.ts` (FULL), `request/` (STUB) | ⚠️ Engines exist, no unified surface |
+| Micro-investments | `collective-campaign/` (productive-asset tokens, yield), garden/kitchen investment pools, `hawala-ledger` | ✅ Strong |
+| Land / Asset (Farms/Workshops/Hubs) | `asset-graph/`, `garden/`, `kitchen/`, `agriculture/`, `harvest/` | ✅ Strong |
+| Coalition Credits | `hawala-ledger/` (ledger + `karma-event`), `volunteer/` time-credits, admin `coalition-credits/page.tsx` | ⚠️ Substrate only, no unified abstraction |
+| Reputation (Merchant/Builder/Investor/Steward/Creator) | `vendor-verification` trust_score, `collective-campaign` tiers, `buyer-network` reputation, `impact-metrics` badges | ⚠️ 5 fragmented systems |
+| Character sheet / Levels / XP / Titles | Badges only | ❌ Absent — primary gap |
+| Creator Hub | `creator-rewards`, `creator-attribution`, `creator-studio` | ⚠️ Fragmented |
+| Seasonal Events / Festivals / Challenges | `season/` (garden seasons only) | ⚠️ Ag-only, no festival/challenge framework |
+
+## Design principle: aggregate, never duplicate
+
+The new `progression` module owns only two genuinely-new facts:
+
+1. **`xp_event`** — an append-only XP ledger (modeled on `hawala-ledger`'s
+   `karma_event`: signed `amount`, `reason` slug, `source_module`/`source_id`
+   audit trail).
+2. **`character_sheet`** — a derived cache: authoritative per-role XP/levels,
+   plus a *snapshot* of aggregate stats.
+
+All aggregate stats (orders, trust score, karma, time credits, producer
+revenue) are **recomputed from the owning modules** via `query.graph` and
+snapshotted for fast reads. The source modules remain the source of truth.
+
+## Stance model
+
+`Stance` (`backend/src/modules/progression/stance.ts`) is the active role a user
+is "playing": `PRODUCER | CONSUMER | INVESTOR | COALITION | CREATOR`. It is a
+superset alignment of the seller-side `VendorType` enum — `PRODUCER`/`CREATOR`
+map 1:1; `CONSUMER`/`INVESTOR`/`COALITION` are buyer/community-side roles with no
+`VendorType` equivalent. Helpers `vendorTypeToStance` / `stanceToVendorType`
+bridge the two. Stance is stored on the character sheet (single source) and
+mirrored into the `fbm_stance` cookie for instant SSR theming.
+
+## Region map
+
+`storefront/src/lib/constants/regions.ts` is a *presentational* remap of the 10
+cms-blueprint product types onto 6 named Regions (no backend taxonomy change):
+
+| Region | Surfaces blueprint types |
+|---|---|
+| 🌱 Agriculture Grove | food, land-access |
+| 🎨 Artisan District | circular-economy, mutual-aid |
+| 🏭 Industrial Quarter | tools-infrastructure |
+| 🎬 Creator Commons | digital-services, community-events |
+| 🔬 Innovation Lab | electronics-networks, experimental |
+| 💰 Investment Guild | membership |
+
+## Leveling curve
+
+`backend/src/modules/progression/leveling.ts` — quadratic RPG curve:
+`xpForLevel(n) = 100·n²`, `levelForXp(xp) = floor(√(xp/100))`. Each role track
+levels independently; `ROLE_XP_WEIGHTS` allows per-track tuning. Covered by
+`__tests__/leveling.unit.spec.ts`.
+
+## XP ingestion
+
+XP is awarded by subscribers hooking *existing* emitted events — additive and
+isolated in try/catch so XP can never break a core flow:
+
+| Event | Subscriber | Award |
+|---|---|---|
+| `order.placed` | `progression-order-placed.ts` | CONSUMER XP ∝ order total |
+| `order.canceled` | `progression-order-canceled.ts` | CONSUMER XP clawback |
+| `vendor.verified` | `progression-vendor-verified.ts` | PRODUCER XP + trust mirror |
+
+## Titles
+
+`progression_title` is a seedable catalog (Village Farmer, Market Trader,
+Community Investor, Coalition Steward, Master Artisan, …). A title is granted
+when a customer's level in the matching role track reaches `min_level`. The
+default catalog self-seeds lazily on first use (the repo seeds on-demand rather
+than via a startup loader).
+
+## Surfaces
+
+- `GET /store/character` — character sheet summary.
+- `POST /store/character/stance` — set active stance.
+- `POST /store/character/recompute` — refresh aggregate snapshot.
+- Storefront `/character` — character profile (role tracks, lifetime stats,
+  titles).
+- Storefront `/start` — "What are you doing today?" 4-card stance picker.
+- `MobileLauncher` bottom nav → Home / Explore / Quests / Coalition / Character.
+
+## Roadmap (remaining)
+
+These are intentionally **not yet built** — they extend the same foundation:
+
+- **PRODUCER/INVESTOR/COALITION XP hooks** from `collective-campaign` backings
+  and `volunteer` verified logs (wire via workflow steps once those modules emit
+  events, or call `recordXpEvent` inside their services).
+- **Region re-skin** of the category/explore pages using `regions.ts`.
+- **Unified Creator Hub** consolidating `creator-rewards` / `creator-attribution`.
+- **Seasonal Events / festivals / challenges** beyond garden `season/`.
+- **Level-up toasts** and a public leaderboard (sheet already indexes `total_xp`).
+
+## Key files
+
+- Backend module: `backend/src/modules/progression/`
+- Subscribers: `backend/src/subscribers/progression-*.ts`
+- API: `backend/src/api/store/character/**`
+- Storefront data lib: `storefront/src/lib/data/progression.ts`
+- Storefront regions: `storefront/src/lib/constants/regions.ts`
+- Storefront pages: `storefront/src/app/[locale]/(main)/{character,start}/page.tsx`
+- Bottom nav: `storefront/src/components/molecules/MobileLauncher/MobileLauncher.tsx`

--- a/storefront/src/app/[locale]/(main)/character/page.tsx
+++ b/storefront/src/app/[locale]/(main)/character/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from "next"
+import { AccountLoadingState, LoginForm } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
+import { getCharacterSheet } from "@/lib/data/progression"
+import { RoleTrackBar } from "@/components/organisms/CharacterSheet/RoleTrackBar"
+import { TitleBadge } from "@/components/organisms/CharacterSheet/TitleBadge"
+
+export const metadata: Metadata = {
+  title: "Character",
+  description:
+    "Your character sheet — role levels, lifetime stats, and earned titles across the Free Black Market economy.",
+}
+
+const STANCE_LABEL: Record<string, string> = {
+  producer: "Producer",
+  consumer: "Consumer",
+  investor: "Investor",
+  coalition: "Coalition Member",
+  creator: "Creator",
+}
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+}
+
+export default async function CharacterPage() {
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
+
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="Character" />
+  }
+
+  const character = await getCharacterSheet()
+
+  const displayName =
+    [customer.first_name, customer.last_name].filter(Boolean).join(" ") ||
+    customer.email ||
+    "Adventurer"
+
+  const overallLevel = character
+    ? character.tracks.reduce((max, t) => Math.max(max, t.level), 0)
+    : 0
+
+  const stats = character?.stats
+
+  return (
+    <main className="container">
+      <div className="mt-6 space-y-8">
+        <header className="rounded-lg border border-tertiary bg-green-50 p-6">
+          <p className="text-secondary text-sm uppercase tracking-wide">
+            Character Sheet
+          </p>
+          <h1 className="heading-lg">{displayName}</h1>
+          <p className="text-secondary mt-1">
+            Overall Level {overallLevel} ·{" "}
+            {STANCE_LABEL[character?.activeStance ?? "consumer"]} stance ·{" "}
+            {character?.totalXp ?? 0} total XP
+          </p>
+        </header>
+
+        {/* Role tracks */}
+        <section className="rounded-lg border border-tertiary p-6 space-y-5">
+          <h2 className="heading-sm uppercase">Role Tracks</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+            {(character?.tracks ?? []).map((track) => (
+              <RoleTrackBar key={track.role} track={track} />
+            ))}
+          </div>
+        </section>
+
+        {/* Lifetime stats */}
+        <section className="rounded-lg border border-tertiary p-6 space-y-4">
+          <h2 className="heading-sm uppercase">Lifetime Stats</h2>
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Stat label="🛒 Orders Completed" value={stats?.ordersCompleted ?? 0} />
+            <Stat label="🌾 Food Produced" value={dollars(stats?.foodProducedCents ?? 0)} />
+            <Stat label="💰 Capital Deployed" value={dollars(stats?.capitalDeployedCents ?? 0)} />
+            <Stat label="🤝 Mutual Aid" value={stats?.mutualAidContributions ?? 0} />
+            <Stat label="⭐ Trust Score" value={`${stats?.trustScore ?? 0}/100`} />
+            <Stat label="✨ Karma" value={stats?.karma ?? 0} />
+            <Stat label="⏱ Time Credits" value={stats?.timeCredits ?? 0} />
+          </dl>
+        </section>
+
+        {/* Titles */}
+        <section className="rounded-lg border border-tertiary p-6 space-y-4">
+          <h2 className="heading-sm uppercase">Titles</h2>
+          {character && character.titles.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {character.titles.map((title) => (
+                <TitleBadge key={title.slug} title={title} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-secondary text-sm">
+              No titles earned yet. Level up a role track to earn your first
+              title.
+            </p>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <dt className="text-secondary text-xs">{label}</dt>
+      <dd className="heading-md">{value}</dd>
+    </div>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/start/page.tsx
+++ b/storefront/src/app/[locale]/(main)/start/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { setStance, type Stance } from "@/lib/data/progression"
+
+export const metadata: Metadata = {
+  title: "What are you doing today?",
+  description:
+    "Choose your stance — Produce, Acquire, Invest, or Support — and step into the Free Black Market economy.",
+}
+
+type StanceCard = {
+  stance: Stance
+  emoji: string
+  title: string
+  blurb: string
+  destination: string
+  accent: string
+}
+
+const CARDS: StanceCard[] = [
+  {
+    stance: "producer",
+    emoji: "🌱",
+    title: "Produce",
+    blurb: "Grow, make, and sell. List goods and offer services.",
+    destination: "/sellers",
+    accent: "border-green-600 hover:bg-green-50",
+  },
+  {
+    stance: "consumer",
+    emoji: "🛒",
+    title: "Acquire",
+    blurb: "Find what you need from producers near you.",
+    destination: "/shop",
+    accent: "border-amber-500 hover:bg-amber-50",
+  },
+  {
+    stance: "investor",
+    emoji: "💰",
+    title: "Invest",
+    blurb: "Fund farms, workshops, projects, and creators.",
+    destination: "/invest",
+    accent: "border-amber-700 hover:bg-amber-50",
+  },
+  {
+    stance: "coalition",
+    emoji: "🤝",
+    title: "Support",
+    blurb: "Volunteer, deliver, mentor, and build the coalition.",
+    destination: "/community-resources",
+    accent: "border-green-800 hover:bg-green-50",
+  },
+]
+
+/**
+ * Server action: persist the chosen stance (cookie + backend when logged in)
+ * and route the user into the matching surface.
+ */
+async function chooseStance(formData: FormData) {
+  "use server"
+  const stance = formData.get("stance") as Stance
+  const destination = (formData.get("destination") as string) || "/shop"
+  await setStance(stance)
+  redirect(destination)
+}
+
+export default function StartPage() {
+  return (
+    <main className="container py-10">
+      <header className="text-center max-w-2xl mx-auto mb-10">
+        <h1 className="heading-xl">What are you doing today?</h1>
+        <p className="text-secondary mt-3">
+          Free Black Market is organized around people and roles, not just
+          products. Pick a stance to begin — you can switch any time.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 max-w-5xl mx-auto">
+        {CARDS.map((card) => (
+          <form key={card.stance} action={chooseStance}>
+            <input type="hidden" name="stance" value={card.stance} />
+            <input type="hidden" name="destination" value={card.destination} />
+            <button
+              type="submit"
+              className={`group w-full h-full text-left rounded-xl border-2 ${card.accent} bg-primary p-6 transition-colors shadow-solarpunk-sm hover:shadow-solarpunk-md`}
+            >
+              <span className="text-4xl" aria-hidden>
+                {card.emoji}
+              </span>
+              <h2 className="heading-md mt-4">{card.title}</h2>
+              <p className="text-secondary text-sm mt-2">{card.blurb}</p>
+            </button>
+          </form>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/storefront/src/components/molecules/MobileLauncher/MobileLauncher.tsx
+++ b/storefront/src/components/molecules/MobileLauncher/MobileLauncher.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import {
-  CartIcon,
-  HeartIcon,
+  CharacterIcon,
+  CompassIcon,
   HomeIcon,
-  LeafIcon,
-  ProfileIcon,
+  QuestIcon,
+  UsersIcon,
 } from "@/icons"
 import {
   RadialLauncher,
@@ -18,9 +18,10 @@ import {
  * Five-item quick nav, fanning upward from a bottom-centre FAB. Mobile
  * only — desktop has the full header nav.
  *
- * Item set is the today-shipping surface; the deferred composition-
- * layer surfaces (Refrain, Threshold, Blackstar) join this list as
- * they land. See docs/COMPOSITION_LAYER.md.
+ * The item set follows the Solarpunk-MMORPG navigation model: Home,
+ * Explore (the market/regions), Quests (collective demand & bounties),
+ * Coalition (mutual aid & community), and Character (the player's
+ * levelled profile). See docs/SOLARPUNK_MMORPG_BLUEPRINT.md.
  */
 const ITEMS: RadialLauncherItem[] = [
   {
@@ -30,28 +31,28 @@ const ITEMS: RadialLauncherItem[] = [
     icon: <HomeIcon />,
   },
   {
-    key: "shop",
-    label: "Shop",
+    key: "explore",
+    label: "Explore",
     href: "/shop",
-    icon: <LeafIcon />,
+    icon: <CompassIcon />,
   },
   {
-    key: "cart",
-    label: "Cart",
-    href: "/cart",
-    icon: <CartIcon />,
+    key: "quests",
+    label: "Quests",
+    href: "/collective",
+    icon: <QuestIcon />,
   },
   {
-    key: "donate",
-    label: "Donate",
-    href: "/donations",
-    icon: <HeartIcon />,
+    key: "coalition",
+    label: "Coalition",
+    href: "/community-resources",
+    icon: <UsersIcon />,
   },
   {
-    key: "account",
-    label: "Account",
-    href: "/user",
-    icon: <ProfileIcon />,
+    key: "character",
+    label: "Character",
+    href: "/character",
+    icon: <CharacterIcon />,
   },
 ]
 

--- a/storefront/src/components/organisms/CharacterSheet/RoleTrackBar.tsx
+++ b/storefront/src/components/organisms/CharacterSheet/RoleTrackBar.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/utils"
+import type { RoleTrack, Stance } from "@/lib/data/progression"
+
+const ROLE_META: Record<Stance, { label: string; emoji: string; bar: string }> = {
+  producer: { label: "Producer", emoji: "🌱", bar: "bg-green-600" },
+  consumer: { label: "Consumer", emoji: "🛒", bar: "bg-amber-500" },
+  investor: { label: "Investor", emoji: "💰", bar: "bg-amber-700" },
+  coalition: { label: "Coalition", emoji: "🤝", bar: "bg-green-800" },
+  creator: { label: "Creator", emoji: "🎨", bar: "bg-green-500" },
+}
+
+/**
+ * A single role track on the character sheet: emoji + label, level, and an
+ * XP-into-level progress bar. Presentation-only.
+ */
+export function RoleTrackBar({ track }: { track: RoleTrack }) {
+  const meta = ROLE_META[track.role]
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-2 font-medium">
+          <span aria-hidden>{meta.emoji}</span>
+          {meta.label}
+        </span>
+        <span className="text-sm text-secondary">
+          Level {track.level}
+        </span>
+      </div>
+      <div className="h-2.5 w-full rounded-full bg-green-100 overflow-hidden">
+        <div
+          className={cn("h-full rounded-full transition-all", meta.bar)}
+          style={{ width: `${track.pct}%` }}
+          role="progressbar"
+          aria-valuenow={track.pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${meta.label} progress to next level`}
+        />
+      </div>
+      <p className="text-xs text-secondary">
+        {track.xpIntoLevel} / {track.xpForNextLevel} XP to next level
+        <span className="ml-2 opacity-70">({track.xp} total)</span>
+      </p>
+    </div>
+  )
+}

--- a/storefront/src/components/organisms/CharacterSheet/TitleBadge.tsx
+++ b/storefront/src/components/organisms/CharacterSheet/TitleBadge.tsx
@@ -1,0 +1,21 @@
+import type { EarnedTitle } from "@/lib/data/progression"
+
+/**
+ * A single earned title chip on the character sheet. Presentation-only.
+ */
+export function TitleBadge({ title }: { title: EarnedTitle }) {
+  return (
+    <span
+      className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm"
+      style={{ borderColor: title.color, color: title.color }}
+      title={title.description}
+    >
+      <span
+        aria-hidden
+        className="inline-block h-2 w-2 rounded-full"
+        style={{ backgroundColor: title.color }}
+      />
+      {title.name}
+    </span>
+  )
+}

--- a/storefront/src/icons/index.tsx
+++ b/storefront/src/icons/index.tsx
@@ -2165,3 +2165,95 @@ export function UsersIcon({
     </svg>
   );
 }
+
+export function CompassIcon({
+  color = 'currentColor',
+  size = 24,
+  className = '',
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={className}
+      aria-hidden='true'
+    >
+      <circle cx='12' cy='12' r='9' stroke={color} strokeWidth='1.5' />
+      <path
+        d='M15.5 8.5L13.5 13.5L8.5 15.5L10.5 10.5L15.5 8.5Z'
+        stroke={color}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}
+
+export function QuestIcon({
+  color = 'currentColor',
+  size = 24,
+  className = '',
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={className}
+      aria-hidden='true'
+    >
+      <path
+        d='M5 21V4C5 3.44772 5.44772 3 6 3H18C18.5523 3 19 3.44772 19 4V14C19 14.5523 18.5523 15 18 15H5'
+        stroke={color}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M9 7H15M9 10.5H13'
+        stroke={color}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}
+
+export function CharacterIcon({
+  color = 'currentColor',
+  size = 24,
+  className = '',
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={className}
+      aria-hidden='true'
+    >
+      <path
+        d='M12 3L19 5.5V11C19 15.5 16 19 12 21C8 19 5 15.5 5 11V5.5L12 3Z'
+        stroke={color}
+        strokeWidth='1.5'
+        strokeLinejoin='round'
+      />
+      <circle cx='12' cy='10' r='2' stroke={color} strokeWidth='1.5' />
+      <path
+        d='M8.5 16C8.9 14.3 10.3 13.5 12 13.5C13.7 13.5 15.1 14.3 15.5 16'
+        stroke={color}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+      />
+    </svg>
+  );
+}

--- a/storefront/src/lib/constants/regions.ts
+++ b/storefront/src/lib/constants/regions.ts
@@ -1,0 +1,86 @@
+/**
+ * Regions — the RPG "world map" overlay on top of the marketplace taxonomy.
+ *
+ * The Solarpunk-MMORPG vision replaces flat categories with named Regions you
+ * "travel" to. This is a *presentational* remap of the 10 canonical
+ * cms-blueprint product types onto 6 themed Regions — it does NOT change the
+ * backend taxonomy. Each region links out to the existing `/categories` /
+ * `/shop` surfaces filtered by the underlying blueprint type handles.
+ *
+ * Colors are pulled from the existing Solarpunk palette tokens (see
+ * `src/app/colors.css`) so regions feel native to the established theme.
+ */
+
+export type Region = {
+  /** URL-safe region key. */
+  slug: string
+  /** Display name. */
+  label: string
+  /** One-line flavor text. */
+  tagline: string
+  /** Emoji used as the region glyph on cards. */
+  emoji: string
+  /** Tailwind accent class (border/text) drawn from the solarpunk ramp. */
+  accent: string
+  /**
+   * Underlying cms-blueprint product-type handles this region surfaces.
+   * Used to build links into the existing category pages.
+   */
+  blueprintTypes: string[]
+}
+
+export const REGIONS: Region[] = [
+  {
+    slug: "agriculture-grove",
+    label: "Agriculture Grove",
+    tagline: "Seeds, plants, livestock, and fresh food.",
+    emoji: "🌱",
+    accent: "green-700",
+    blueprintTypes: ["food", "land-access"],
+  },
+  {
+    slug: "artisan-district",
+    label: "Artisan District",
+    tagline: "Handmade goods, crafts, and repaired treasures.",
+    emoji: "🎨",
+    accent: "amber-600",
+    blueprintTypes: ["circular-economy", "mutual-aid"],
+  },
+  {
+    slug: "industrial-quarter",
+    label: "Industrial Quarter",
+    tagline: "Tools, machinery, CNC, and infrastructure.",
+    emoji: "🏭",
+    accent: "green-800",
+    blueprintTypes: ["tools-infrastructure"],
+  },
+  {
+    slug: "creator-commons",
+    label: "Creator Commons",
+    tagline: "Streaming, media, software, and digital services.",
+    emoji: "🎬",
+    accent: "amber-500",
+    blueprintTypes: ["digital-services", "community-events"],
+  },
+  {
+    slug: "innovation-lab",
+    label: "Innovation Lab",
+    tagline: "Electronics, mesh networks, and experimental projects.",
+    emoji: "🔬",
+    accent: "green-600",
+    blueprintTypes: ["electronics-networks", "experimental"],
+  },
+  {
+    slug: "investment-guild",
+    label: "Investment Guild",
+    tagline: "Crowdfunding, micro-investments, and memberships.",
+    emoji: "💰",
+    accent: "amber-700",
+    blueprintTypes: ["membership"],
+  },
+]
+
+/** Map a cms-blueprint type handle to the Region that surfaces it. */
+export function regionForBlueprintType(typeHandle: string): Region | undefined {
+  return REGIONS.find((r) => r.blueprintTypes.includes(typeHandle))
+}

--- a/storefront/src/lib/data/progression.ts
+++ b/storefront/src/lib/data/progression.ts
@@ -1,0 +1,120 @@
+"use server"
+
+import { cookies as nextCookies } from "next/headers"
+import { medusaFetch } from "../config"
+import { getAuthHeaders } from "./cookies"
+
+/** The role a user is currently "playing". Mirrors the backend Stance enum. */
+export type Stance =
+  | "producer"
+  | "consumer"
+  | "investor"
+  | "coalition"
+  | "creator"
+
+export type RoleTrack = {
+  role: Stance
+  xp: number
+  level: number
+  xpIntoLevel: number
+  xpForNextLevel: number
+  pct: number
+}
+
+export type EarnedTitle = {
+  slug: string
+  role: Stance
+  name: string
+  description: string
+  icon: string
+  color: string
+  earnedAt?: string
+}
+
+export type CharacterSheet = {
+  customerId: string
+  activeStance: Stance
+  totalXp: number
+  tracks: RoleTrack[]
+  stats: {
+    foodProducedCents: number
+    ordersCompleted: number
+    capitalDeployedCents: number
+    mutualAidContributions: number
+    trustScore: number
+    karma: number
+    timeCredits: number
+  }
+  titles: EarnedTitle[]
+  lastRecomputedAt?: string | null
+}
+
+const STANCE_COOKIE = "fbm_stance"
+
+/**
+ * Fetch the authenticated customer's character sheet. Returns null when the
+ * visitor is logged out (mirrors the coalition-credits data-lib pattern).
+ */
+export const getCharacterSheet = async (): Promise<CharacterSheet | null> => {
+  const authHeaders = await getAuthHeaders()
+  if (!authHeaders) return null
+
+  try {
+    const { character } = await medusaFetch<{ character: CharacterSheet }>(
+      "/store/character",
+      { method: "GET", headers: authHeaders, cache: "no-store" }
+    )
+    return character
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Set the active stance on the backend and mirror it into a readable cookie so
+ * SSR can theme the next render instantly.
+ */
+export const setStance = async (
+  stance: Stance
+): Promise<CharacterSheet | null> => {
+  const authHeaders = await getAuthHeaders()
+
+  // Always set the cookie — themes the UI even before/without auth.
+  const cookies = await nextCookies()
+  cookies.set(STANCE_COOKIE, stance, {
+    maxAge: 60 * 60 * 24 * 30,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  })
+
+  if (!authHeaders) return null
+
+  try {
+    const { character } = await medusaFetch<{ character: CharacterSheet }>(
+      "/store/character/stance",
+      {
+        method: "POST",
+        headers: authHeaders,
+        body: { stance },
+        cache: "no-store",
+      }
+    )
+    return character
+  } catch {
+    return null
+  }
+}
+
+/** Read the stance cookie for SSR theming (defaults to consumer). */
+export const getStanceCookie = async (): Promise<Stance> => {
+  const cookies = await nextCookies()
+  const value = cookies.get(STANCE_COOKIE)?.value
+  const valid: Stance[] = [
+    "producer",
+    "consumer",
+    "investor",
+    "coalition",
+    "creator",
+  ]
+  return valid.includes(value as Stance) ? (value as Stance) : "consumer"
+}


### PR DESCRIPTION
Verifies the "Solarpunk MMORPG" vision against the repo and adds the
missing unifying gamification + navigation layer, reusing existing
modules rather than rebuilding.

Backend `progression` module (aggregate, never duplicate):
- character_sheet (derived cache) + xp_event (append-only ledger,
  modeled on hawala-ledger karma_event) + progression_title catalog
- quadratic leveling curve with unit tests
- Stance enum aligned to seller VendorType (producer/consumer/investor/
  coalition/creator)
- recomputeAggregates() snapshots stats from impact-metrics, volunteer,
  hawala-ledger, vendor-verification via query.graph
- subscribers on order.placed / order.canceled / vendor.verified
- store API: GET /store/character, POST stance, POST recompute
- registered in medusa-config marketplaceModules

Storefront:
- /character profile (role tracks, lifetime stats, titles)
- /start "What are you doing today?" stance picker (server action)
- regions.ts: 10 cms-blueprint types -> 6 named Regions
- MobileLauncher bottom nav -> Home/Explore/Quests/Coalition/Character
- new Compass/Quest/Character icons

Docs: docs/SOLARPUNK_MMORPG_BLUEPRINT.md (vision-vs-repo audit + design)