### PR TITLE
Panel parity (Medusa 2.14 + zod 4) and deep mercurjs vendor-flow tests

### DIFF
--- a/admin-panel/package.json
+++ b/admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medusajs/dashboard",
-  "version": "2.12.5",
+  "version": "2.14.2",
   "packageManager": "pnpm@10.13.1",
   "pnpm": {
     "overrides": {
@@ -9,7 +9,8 @@
       "lodash": ">=4.18.0",
       "picomatch": ">=4.0.4",
       "postcss": ">=8.5.10",
-      "@remix-run/router": ">=1.23.2"
+      "@remix-run/router": ">=1.23.2",
+      "zod": "4.2.0"
     }
   },
   "scripts": {
@@ -61,10 +62,10 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "3.4.2",
-    "@medusajs/admin-shared": "2.12.5",
-    "@medusajs/icons": "2.12.5",
-    "@medusajs/js-sdk": "2.12.5",
-    "@medusajs/ui": "4.0.28",
+    "@medusajs/admin-shared": "2.14.2",
+    "@medusajs/icons": "2.14.2",
+    "@medusajs/js-sdk": "2.14.2",
+    "@medusajs/ui": "4.1.9",
     "@radix-ui/react-dialog": "1.1.4",
     "@radix-ui/react-dismissable-layer": "1.1.4",
     "@tanstack/react-query": "5.64.2",
@@ -91,15 +92,15 @@
     "react-i18next": "13.5.0",
     "react-jwt": "^1.2.0",
     "react-router-dom": "6.30.2",
-    "zod": "3.25.76"
+    "zod": "^4.2.0"
   },
   "devDependencies": {
-    "@medusajs/admin-sdk": "2.12.5",
-    "@medusajs/admin-shared": "2.12.5",
-    "@medusajs/admin-vite-plugin": "2.12.5",
-    "@medusajs/framework": "2.12.5",
-    "@medusajs/types": "2.12.5",
-    "@medusajs/ui-preset": "2.12.5",
+    "@medusajs/admin-sdk": "2.14.2",
+    "@medusajs/admin-shared": "2.14.2",
+    "@medusajs/admin-vite-plugin": "2.14.2",
+    "@medusajs/framework": "2.14.2",
+    "@medusajs/types": "2.14.2",
+    "@medusajs/ui-preset": "2.14.2",
     "@sentry/browser": "^10.53.1",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/lodash": "^4.17.24",

--- a/admin-panel/pnpm-lock.yaml
+++ b/admin-panel/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   picomatch: '>=4.0.4'
   postcss: '>=8.5.10'
   '@remix-run/router': '>=1.23.2'
+  zod: 4.2.0
 
 importers:
 
@@ -35,17 +36,17 @@ importers:
         specifier: 3.4.2
         version: 3.4.2(react-hook-form@7.49.1(react@18.3.1))
       '@medusajs/admin-shared':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/icons':
-        specifier: 2.12.5
-        version: 2.12.5(react@18.3.1)
+        specifier: 2.14.2
+        version: 2.14.2(react@18.3.1)
       '@medusajs/js-sdk':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/ui':
-        specifier: 4.0.28
-        version: 4.0.28(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+        specifier: 4.1.9
+        version: 4.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@radix-ui/react-dialog':
         specifier: 1.1.4
         version: 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -125,24 +126,24 @@ importers:
         specifier: 6.30.2
         version: 6.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.2.0
+        version: 4.2.0
     devDependencies:
       '@medusajs/admin-sdk':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/admin-vite-plugin':
-        specifier: 2.12.5
-        version: 2.12.5(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
+        specifier: 2.14.2
+        version: 2.14.2(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
       '@medusajs/framework':
-        specifier: 2.12.5
-        version: 2.12.5(@medusajs/cli@2.12.5(@types/node@20.19.25))(@types/node@20.19.25)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
+        specifier: 2.14.2
+        version: 2.14.2(@medusajs/cli@2.12.5(@types/node@20.19.25))(@types/node@20.19.25)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))(zod@4.2.0)
       '@medusajs/types':
-        specifier: 2.12.5
-        version: 2.12.5(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
+        specifier: 2.14.2
+        version: 2.14.2(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
       '@medusajs/ui-preset':
-        specifier: 2.12.5
-        version: 2.12.5(tailwindcss@3.4.18)
+        specifier: 2.14.2
+        version: 2.14.2(tailwindcss@3.4.18)
       '@sentry/browser':
         specifier: ^10.53.1
         version: 10.53.1
@@ -262,6 +263,103 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-dynamodb@3.1058.0':
+    resolution: {integrity: sha512-mqPD7iaRXP64vdzKU5TVX5lBH2mGbjsZ7Ms+ztQWZseT9gYTj5p/HOop3Ossy1Kifkc+6sLUzmy8G5qPTBE6+w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.15':
+    resolution: {integrity: sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.41':
+    resolution: {integrity: sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    resolution: {integrity: sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.46':
+    resolution: {integrity: sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    resolution: {integrity: sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.48':
+    resolution: {integrity: sha512-QIbtJP0olSLZ2ImEu636pP+7JJbPfaL3xSJIFXhu472CWuondCc4bGOa8OeyhOFet8z4H1D/ZFKXc39FboWwYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    resolution: {integrity: sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    resolution: {integrity: sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    resolution: {integrity: sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/dynamodb-codec@3.973.15':
+    resolution: {integrity: sha512-R09IUytTrUKwsIiMVSHPZJz0zO9EsXHg/JZ+3AwQ+eSahRnHuPuZANMfeTb/j2+AKkZ7DhW2FcT6XuHLwC0cZw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/endpoint-cache@3.972.5':
+    resolution: {integrity: sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.15':
+    resolution: {integrity: sha512-L1wbvrAb0hv7Vx6eTEyqQwXaNETSj/L30BVCkSxD0k6Ve5cZUM0SLUvBn8aA/B4YtIpMzCbzNaVytZY7uOzJSw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.13':
+    resolution: {integrity: sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    resolution: {integrity: sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1056.0':
+    resolution: {integrity: sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -892,14 +990,14 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@medusajs/admin-sdk@2.12.5':
-    resolution: {integrity: sha512-KxNN/Iuu+o8TgWZHbR4RWxBNZF9bON5UWfBd2VDHvU5pdWewXuizroQSLL+QF+PCWmpxFijQy0v128XzgyHXZg==}
+  '@medusajs/admin-sdk@2.14.2':
+    resolution: {integrity: sha512-JYeV7BMGQ5VUnlJHFCjrHX7qO0skU9D0vGAbEwoJxyysqO1G6iDrAbB/KbQ+136qY71IVLvbQZ3UbtpDIMUflA==}
 
-  '@medusajs/admin-shared@2.12.5':
-    resolution: {integrity: sha512-LKO7QhMmCsvP0dGibBBjNxjwOhWnBTFYfb4y5zsejzzvrrcFhEn7dn9gg4L5XkqtgDRIuiDkEi45ng3xWPPIpQ==}
+  '@medusajs/admin-shared@2.14.2':
+    resolution: {integrity: sha512-NsYYI6aghCG6dY+jq0Qkhug7x0MVgGsZ38B+h+VO+C3jPIfwxwRafWd9ZSDioQDrRr3ua9MwQrRMjrWJLWfIgg==}
 
-  '@medusajs/admin-vite-plugin@2.12.5':
-    resolution: {integrity: sha512-gbt04lDMvclzBR52ugqid9BfI3okw2dg85Swj37EKvxhhV7788/no4MiQtBrsT1xcVms54V4HIwZ4L5jE9W5Yg==}
+  '@medusajs/admin-vite-plugin@2.14.2':
+    resolution: {integrity: sha512-NFlc8RrAI4rEnKxo0jr7/0nChGc9OqmQHcQ8IP07O6NCYVykjxUPpfIhcldmVab21HyE59yBJcuP8XBE9oV5bQ==}
     peerDependencies:
       vite: ^5.4.21
 
@@ -912,54 +1010,51 @@ packages:
     resolution: {integrity: sha512-xEQVhW/mCzYpenVsL1brjQpDOWZWsgrUiFwKJcrNPPK0rcZVO+F6GFX146z4mMitw9omlMtWm68AWf0fQrH9Bg==}
     engines: {node: '>=20'}
 
-  '@medusajs/framework@2.12.5':
-    resolution: {integrity: sha512-6gLrXzP4z+SmUXm377iHj2Fw4d2p+qTYmW4o6lXcpIsEiD6HAxu90VzSQhNvU3xbrFIubtxi+P67bAfaVkj8Bg==}
+  '@medusajs/deps@2.14.2':
+    resolution: {integrity: sha512-eYOZUgly4TvT7Zb7ta3mX0Lnjq+3c1ZI+caPaiZ42uK6tZpokQbsuki0EQ3IuPcg+TSUaz+G1+VJplPSJLU4GQ==}
+    engines: {node: '>=20'}
+
+  '@medusajs/framework@2.14.2':
+    resolution: {integrity: sha512-tEu1UvUvFmvpGqlszewzlIOP4vpql9VAJXddxdsaDOhkf+7pEUrfc5O9dXb7+mexObpVbdpTZ//0QZYixSkWmQ==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
-      '@aws-sdk/client-dynamodb': ^3.218.0
-      '@medusajs/cli': 2.12.5
-      connect-dynamodb: ^3.0.5
+      '@medusajs/cli': 2.14.2
       ioredis: ^5.4.1
       vite: '*'
     peerDependenciesMeta:
-      '@aws-sdk/client-dynamodb':
-        optional: true
-      connect-dynamodb:
-        optional: true
       ioredis:
         optional: true
       vite:
         optional: true
 
-  '@medusajs/icons@2.12.0':
-    resolution: {integrity: sha512-M+mKiTxSxtHOuy0VPgxIuB7y+V23ahXdhXcwpba5F+aG9N7rQ3Tty8KKuXv7M3MLbC7P9BH08E9Lm82j19yg/w==}
+  '@medusajs/icons@2.14.2':
+    resolution: {integrity: sha512-MdiX1Z3h9yMTqJ5Jmd4XC8goMzMttZJiDSPEBTzWAYpsfXn9G0Dp3bbFg2k7DiJPb4lOBzLPbw+LuwtnUCfpGA==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.2.5
 
-  '@medusajs/icons@2.12.5':
-    resolution: {integrity: sha512-aOhhT2xcIHVYBMGaNjHBCekP592xyM7N0BM9LVWohc9dk3Z5df6tHBn9D8dW7wqnvaDh0BIrAVanmaiOHJPqBg==}
-    peerDependencies:
-      react: ^18.3.1
-
-  '@medusajs/js-sdk@2.12.5':
-    resolution: {integrity: sha512-z7h1xxvx4lc1SMqOgihVAbqnZd0Yxq4u/s1JnI24e4kdr9A+lmbtajvpdD6/9gAf9HfL4qNDOJMb4rl8E+x8sQ==}
+  '@medusajs/js-sdk@2.14.2':
+    resolution: {integrity: sha512-nNpkzcQU8WhPEcXIoh7ET+1y8qSaRsAeoYtci+naCdT7U0/f4jT4vpBH1vI5E3P+sWvSO+fAVvkhVoHc0OY+bQ==}
     engines: {node: '>=20'}
 
-  '@medusajs/modules-sdk@2.12.5':
-    resolution: {integrity: sha512-qFfjYachhfQ2V3g671rj5tlkW5VUapmx2iJT21Fb/qWx6cEDki/kbVEaM17Fb765ZZ9Xf0q7dF9SgK/gR6SUPw==}
+  '@medusajs/modules-sdk@2.14.2':
+    resolution: {integrity: sha512-+uJMkKy/eXDa3N54Dzyy/R+1DR0HxnR0tfevEG3Wjw1a5btBw73y4igLlHVvlIBy/C5nmCzukECyObwe5Qfs7g==}
     engines: {node: '>=20'}
 
-  '@medusajs/orchestration@2.12.5':
-    resolution: {integrity: sha512-nomYyez6fCQT77JE07QQhmdxql0WTjy8w2ixAWSgk3WrFEh1S2PQhWHUkBNNWqVaCsBuPasFd+qLlj2Qf7aL7w==}
+  '@medusajs/orchestration@2.14.2':
+    resolution: {integrity: sha512-C2cjhBuVE95hitHTvn0ipASoU3bxpbhwZFaQVucuYUbib2LLiZ56AJz/k72ASpBKrAs5tUYRJZCJxQFyoTPMRg==}
     engines: {node: '>=20'}
 
   '@medusajs/telemetry@2.12.5':
     resolution: {integrity: sha512-+DZE/1U/9kq4X1MncKoPhdUxgWccKMJV+czYHSH73OxOJzLdQPgm4qUhi1d8j0YmoFETYRhYsuOeihE9zpyh1A==}
     engines: {node: '>=16'}
 
-  '@medusajs/types@2.12.5':
-    resolution: {integrity: sha512-8VyCFX2JQIHQxbHZla+nr4kAXuJB4d0rhrcGHGvx4h0dYcZlcl4DJWfdtn6/2rvEWMQwb5NDCBzH1tfEvj1lyQ==}
+  '@medusajs/telemetry@2.14.2':
+    resolution: {integrity: sha512-jyM2/FdJOm1NXXsF1mSojj82fAleMYzwDcLIyU8w/i2YlDycb2p3VtwHobea7RZcMMHDquQPFM+T2snGx3e74A==}
+    engines: {node: '>=16'}
+
+  '@medusajs/types@2.14.2':
+    resolution: {integrity: sha512-vWzzuG9hXrGMVhrwrUL+LiOi2cuvAoPRyDVdQeA7USdt7ooC+Tb6tWv6E9Sf1wFR3OoUa3S7Ft25qIXmVpV1AQ==}
     engines: {node: '>=20'}
     peerDependencies:
       ioredis: ^5.4.1
@@ -970,13 +1065,13 @@ packages:
       vite:
         optional: true
 
-  '@medusajs/ui-preset@2.12.5':
-    resolution: {integrity: sha512-kcZCJijVoLWqpouEDdEvAmju+nQmal9ee5dbHEM8KeyA7SRnopwOwyjlzRDVhYhAHTFY6C1lGVWebMTwexsMAw==}
+  '@medusajs/ui-preset@2.14.2':
+    resolution: {integrity: sha512-1+0xDeV8zJkmTN+vyHQY7YFF3JW+nmRETT5pnrJQtQOALVofYO0tM3hM8W15ahg8HJV8c5hKRVpoffplB1mU3w==}
     peerDependencies:
       tailwindcss: ^3.4.3
 
-  '@medusajs/ui@4.0.28':
-    resolution: {integrity: sha512-8bmO2ajhHm69y0zbY5Flauz/4EsJlmNqILdKnHQXIFrezh3ckwYoaopUYG9xVdm/epTjGcV3IN/090LQBa9ZMw==}
+  '@medusajs/ui@4.1.9':
+    resolution: {integrity: sha512-yMG+LfPH5hgmz5b/xbVYu1e9VPjqPl8uHU9I0IuLSVDiy+fqBlYbMtc8Ojk/UNeSpD8WPrp9aoLrPD+weL6Uvw==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -987,8 +1082,14 @@ packages:
     peerDependencies:
       express: ^4.21.0
 
-  '@medusajs/workflows-sdk@2.12.5':
-    resolution: {integrity: sha512-qGuL0uw9gLBbIIBhLgwBA8v0w5RruIfEMls5J6xYXw7keB7cO0nvdw5y412ni70g2B3M6JJnss8/l49ZbZOJ8g==}
+  '@medusajs/utils@2.14.2':
+    resolution: {integrity: sha512-kSLuteTaLwuZgDcOAoTSOAmFqidm+fUMckZeXs1pJ5pvUKBVY1XAwkKpaW7U2m/YXxp38YCVkP8++ME9T1psiw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      express: ^4.21.0
+
+  '@medusajs/workflows-sdk@2.14.2':
+    resolution: {integrity: sha512-VK21k3FQLi00yhNrUiIO2TcKPH+4mGSDlZWWLNQXkVkeXAucxyxh7NLIMybqrOVBWfFzV9DBE2+M+EYEFB6NOg==}
     engines: {node: '>=20.0.0'}
 
   '@mikro-orm/cli@6.4.16':
@@ -996,12 +1097,37 @@ packages:
     engines: {node: '>= 18.12.0'}
     hasBin: true
 
+  '@mikro-orm/cli@6.6.12':
+    resolution: {integrity: sha512-NDsPRFgthHz7yXfhADF/xeZDliY0lCjsZvTHLnXJe4PlPy4r8OeaOGILwJJMPrkjrq4EF9t4JrMi8XCEPoVHBg==}
+    engines: {node: '>= 18.12.0'}
+    hasBin: true
+
   '@mikro-orm/core@6.4.16':
     resolution: {integrity: sha512-BW/My1VlI0R25Eojdh0UiET8J+mEruThksGVfllEnjJQ0uwGs3mm/TbMclv0g+d7Qp4+mpzDQU4+lIo8okHYsw==}
     engines: {node: '>= 18.12.0'}
 
+  '@mikro-orm/core@6.6.12':
+    resolution: {integrity: sha512-LgLfRfaGdRUNkJ457H1GsuzoiZJuBY3HKgP+BZMTaFr/l6ah6JbyubodbVXxH+Ffji62TtbHFFRr0tj4wNwLRg==}
+    engines: {node: '>= 18.12.0'}
+
   '@mikro-orm/knex@6.4.16':
     resolution: {integrity: sha512-2xQodj3uh8maPGsLR7PZMmECtdyLutGxzzrGrrhSX2b+7v9k4MeMazTi4/627hJvivdUpuofypW5zMpw3TU1vQ==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+      better-sqlite3: '*'
+      libsql: '*'
+      mariadb: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      libsql:
+        optional: true
+      mariadb:
+        optional: true
+
+  '@mikro-orm/knex@6.6.12':
+    resolution: {integrity: sha512-4enhWqWEEt2ijFI9G7zg07gRNq/UkJ2ihCYfMWooQU5cZQZJl1DnKJae9Q/StoKP2Ttyg4e+GgQXFm94/9MhnQ==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
@@ -1022,11 +1148,26 @@ packages:
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
 
+  '@mikro-orm/migrations@6.6.12':
+    resolution: {integrity: sha512-uSF477rga32+7cnIxuixXPqupuDw8YtKkwbzrcuGmozeTSGc0Lw5MajZgPbmtaA+Fyu5B4Io7Z/gxDQDhWZdaw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+
   '@mikro-orm/postgresql@6.4.16':
     resolution: {integrity: sha512-i14CvyLrtMhQJMk/X3xTT2Mgc8j0VtSWPqhKBN+euiPxbee4u5k39TlJAly72k3luknFBCzpKCh3ZNSGDZ+j4Q==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
+
+  '@mikro-orm/postgresql@6.6.12':
+    resolution: {integrity: sha512-AB1ww3NqKcIlAgugJFImx8Z/KRg5S2ajtE2vS3HrIFl7Y9Ong7dMj3qAQw7sGlFDAUpeBqgYoDBl/M7YyAfzGg==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2801,6 +2942,42 @@ packages:
     resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.24.6':
+    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.7':
+    resolution: {integrity: sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.6':
+    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.6':
+    resolution: {integrity: sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.6':
+    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.3':
+    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
@@ -3263,6 +3440,9 @@ packages:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   boxen@5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
@@ -3498,6 +3678,9 @@ packages:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
 
+  connect-dynamodb@3.0.5:
+    resolution: {integrity: sha512-AQtXLmfpC/YMT7mJlxsgCrpfeXdgKQ2A7cbTBSE/HsRbJXf/d0ZhB3HmKT+JQaObI5DqnK/d0XlUBbFrcqlwTQ==}
+
   connect-redis@5.2.0:
     resolution: {integrity: sha512-wcv1lZWa2K7RbsdSlrvwApBQFLQx+cia+oirLIeim0axR3D/9ZJbHdeTM/j8tJYYKk34dVs2QPAuAqcIklWD+Q==}
     engines: {node: '>=10.0.0'}
@@ -3718,6 +3901,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -3987,6 +4174,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -4102,6 +4296,10 @@ packages:
 
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
   fs-extra@8.1.0:
@@ -4658,6 +4856,37 @@ packages:
       tedious:
         optional: true
 
+  knex@3.2.8:
+    resolution: {integrity: sha512-ElXXxu9Nq+5hWYdBUddYIWIT5yKKs5KNCsmKGbJSHPyaMpAABp3xs4L55GgdQoAs6QQ7dv72ai3M4pxYQ8utEg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '*'
+      mysql: '*'
+      mysql2: '*'
+      pg: '*'
+      pg-native: '*'
+      pg-query-stream: ^4.14.0
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
+
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
@@ -4765,6 +4994,10 @@ packages:
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -4877,6 +5110,10 @@ packages:
     resolution: {integrity: sha512-a+19cRuEPEJ3qf5Vpv4HO9TAxo/I6/rP1bZT93ln8YtNzAbCrcLC766EG6upLS6Sf7OLqdq0cXs5mUN9ESQQrg==}
     engines: {node: '>= 18.12.0'}
 
+  mikro-orm@6.6.12:
+    resolution: {integrity: sha512-gT1Qxpsa0NC8qZKodo5u54DzuaMJrCbN1GIpOfgADkCg9eru9LdMhFBIWIB7qKe5W2WFZCGPSxAa9LsSPB2W4Q==}
+    engines: {node: '>= 18.12.0'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -4922,6 +5159,9 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -5055,6 +5295,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -5132,6 +5375,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -5926,6 +6173,9 @@ packages:
       '@types/node':
         optional: true
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6380,6 +6630,10 @@ packages:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -6406,17 +6660,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-validation-error@3.5.1:
-    resolution: {integrity: sha512-ozT8jy2nHaeKjaRIEThwgRXBwm16hAy0BaTRx1I2IY1xrezPegmlFmYKb5tcvYqZDQm0sfZtDr2IR7CdCJzTGw==}
+  zod-validation-error@5.0.0:
+    resolution: {integrity: sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.25.0
+      zod: 4.2.0
 
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.2.0:
+    resolution: {integrity: sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==}
 
 snapshots:
 
@@ -6446,6 +6697,214 @@ snapshots:
       '@ariakit/react-core': 0.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-dynamodb@3.1058.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-node': 3.972.48
+      '@aws-sdk/dynamodb-codec': 3.973.15
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.15':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-login': 3.972.45
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.48':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-ini': 3.972.46
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/token-providers': 3.1056.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/dynamodb-codec@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/endpoint-cache@3.972.5':
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.15':
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.5
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.13':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1056.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
+      '@smithy/types': 4.14.3
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -7015,19 +7474,19 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@medusajs/admin-sdk@2.12.5':
+  '@medusajs/admin-sdk@2.14.2':
     dependencies:
-      '@medusajs/admin-shared': 2.12.5
-      zod: 3.25.76
+      '@medusajs/admin-shared': 2.14.2
+      zod: 4.2.0
 
-  '@medusajs/admin-shared@2.12.5': {}
+  '@medusajs/admin-shared@2.14.2': {}
 
-  '@medusajs/admin-vite-plugin@2.12.5(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
+  '@medusajs/admin-vite-plugin@2.14.2(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
-      '@medusajs/admin-shared': 2.12.5
+      '@medusajs/admin-shared': 2.14.2
       chokidar: 3.6.0
       fdir: 6.1.1(picomatch@4.0.4)
       magic-string: 0.30.5
@@ -7103,20 +7562,50 @@ snapshots:
       - supports-color
       - tedious
 
-  '@medusajs/framework@2.12.5(@medusajs/cli@2.12.5(@types/node@20.19.25))(@types/node@20.19.25)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
+  '@medusajs/deps@2.14.2(@types/node@20.19.25)':
     dependencies:
+      '@mikro-orm/cli': 6.6.12(pg@8.20.0)
+      '@mikro-orm/core': 6.6.12
+      '@mikro-orm/knex': 6.6.12(@mikro-orm/core@6.6.12)(pg@8.20.0)
+      '@mikro-orm/migrations': 6.6.12(@mikro-orm/core@6.6.12)(@types/node@20.19.25)(pg@8.20.0)
+      '@mikro-orm/postgresql': 6.6.12(@mikro-orm/core@6.6.12)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation-pg': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.200.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.1)
+      awilix: 8.0.1
+      pg: 8.20.0
+      zod: 4.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@medusajs/framework@2.14.2(@medusajs/cli@2.12.5(@types/node@20.19.25))(@types/node@20.19.25)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))(zod@4.2.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1058.0
       '@jercle/yargonaut': 1.1.5
       '@medusajs/cli': 2.12.5(@types/node@20.19.25)
-      '@medusajs/deps': 2.12.5(@types/node@20.19.25)
-      '@medusajs/modules-sdk': 2.12.5(@types/node@20.19.25)(express@4.22.2)
-      '@medusajs/orchestration': 2.12.5(@types/node@20.19.25)(express@4.22.2)
-      '@medusajs/telemetry': 2.12.5
-      '@medusajs/types': 2.12.5(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
-      '@medusajs/utils': 2.12.5(@types/node@20.19.25)(express@4.22.2)
-      '@medusajs/workflows-sdk': 2.12.5(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/deps': 2.14.2(@types/node@20.19.25)
+      '@medusajs/modules-sdk': 2.14.2(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/orchestration': 2.14.2(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/telemetry': 2.14.2
+      '@medusajs/types': 2.14.2(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
+      '@medusajs/utils': 2.14.2(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/workflows-sdk': 2.14.2(@types/node@20.19.25)(express@4.22.2)
       '@types/express': 4.17.25
       chokidar: 4.0.3
       compression: 1.8.1
+      connect-dynamodb: 3.0.5
       connect-redis: 5.2.0
       cookie-parser: 1.4.7
       cors: 2.8.6
@@ -7128,8 +7617,7 @@ snapshots:
       morgan: 1.10.1
       path-to-regexp: 8.4.2
       tsconfig-paths: 4.2.0
-      zod: 3.25.76
-      zod-validation-error: 3.5.1(zod@3.25.76)
+      zod-validation-error: 5.0.0(zod@4.2.0)
     optionalDependencies:
       vite: 5.4.21(@types/node@20.19.25)(lightningcss@1.32.0)
     transitivePeerDependencies:
@@ -7141,28 +7629,26 @@ snapshots:
       - mysql
       - mysql2
       - pg-native
+      - pg-query-stream
       - sqlite3
       - supports-color
       - tedious
+      - zod
 
-  '@medusajs/icons@2.12.0(react@18.3.1)':
+  '@medusajs/icons@2.14.2(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
-  '@medusajs/icons@2.12.5(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
-  '@medusajs/js-sdk@2.12.5':
+  '@medusajs/js-sdk@2.14.2':
     dependencies:
       fetch-event-stream: 0.1.6
       qs: 6.15.2
 
-  '@medusajs/modules-sdk@2.12.5(@types/node@20.19.25)(express@4.22.2)':
+  '@medusajs/modules-sdk@2.14.2(@types/node@20.19.25)(express@4.22.2)':
     dependencies:
-      '@medusajs/deps': 2.12.5(@types/node@20.19.25)
-      '@medusajs/orchestration': 2.12.5(@types/node@20.19.25)(express@4.22.2)
-      '@medusajs/utils': 2.12.5(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/deps': 2.14.2(@types/node@20.19.25)
+      '@medusajs/orchestration': 2.14.2(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/utils': 2.14.2(@types/node@20.19.25)(express@4.22.2)
     transitivePeerDependencies:
       - '@types/node'
       - better-sqlite3
@@ -7172,14 +7658,15 @@ snapshots:
       - mysql
       - mysql2
       - pg-native
+      - pg-query-stream
       - sqlite3
       - supports-color
       - tedious
 
-  '@medusajs/orchestration@2.12.5(@types/node@20.19.25)(express@4.22.2)':
+  '@medusajs/orchestration@2.14.2(@types/node@20.19.25)(express@4.22.2)':
     dependencies:
-      '@medusajs/deps': 2.12.5(@types/node@20.19.25)
-      '@medusajs/utils': 2.12.5(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/deps': 2.14.2(@types/node@20.19.25)
+      '@medusajs/utils': 2.14.2(@types/node@20.19.25)(express@4.22.2)
       ulid: 2.4.0
     transitivePeerDependencies:
       - '@types/node'
@@ -7190,6 +7677,7 @@ snapshots:
       - mysql
       - mysql2
       - pg-native
+      - pg-query-stream
       - sqlite3
       - supports-color
       - tedious
@@ -7208,30 +7696,45 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@medusajs/types@2.12.5(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
+  '@medusajs/telemetry@2.14.2':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      axios: 1.16.0
+      axios-retry: 3.9.1
+      boxen: 5.1.2
+      ci-info: 3.9.0
+      configstore: 5.0.1
+      is-docker: 2.2.1
+      remove-trailing-slash: 0.1.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+
+  '@medusajs/types@2.14.2(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       vite: 5.4.21(@types/node@20.19.25)(lightningcss@1.32.0)
 
-  '@medusajs/ui-preset@2.12.5(tailwindcss@3.4.18)':
+  '@medusajs/ui-preset@2.14.2(tailwindcss@3.4.18)':
     dependencies:
       '@tailwindcss/forms': 0.5.10(tailwindcss@3.4.18)
       tailwindcss: 3.4.18
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.18)
 
-  '@medusajs/ui@4.0.28(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@medusajs/ui@4.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
-      '@medusajs/icons': 2.12.0(react@18.3.1)
+      '@medusajs/icons': 2.14.2(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table': 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 1.2.1
       copy-to-clipboard: 3.3.3
       cva: 1.0.0-beta.1(typescript@5.2.2)
+      lodash.isequal: 4.5.0
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
       radix-ui: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7264,7 +7767,7 @@ snapshots:
       pg-connection-string: 2.12.0
       pluralize: 8.0.0
       ulid: 2.4.0
-      zod: 3.25.76
+      zod: 4.2.0
     transitivePeerDependencies:
       - '@types/node'
       - better-sqlite3
@@ -7277,12 +7780,42 @@ snapshots:
       - supports-color
       - tedious
 
-  '@medusajs/workflows-sdk@2.12.5(@types/node@20.19.25)(express@4.22.2)':
+  '@medusajs/utils@2.14.2(@types/node@20.19.25)(express@4.22.2)':
     dependencies:
-      '@medusajs/deps': 2.12.5(@types/node@20.19.25)
-      '@medusajs/modules-sdk': 2.12.5(@types/node@20.19.25)(express@4.22.2)
-      '@medusajs/orchestration': 2.12.5(@types/node@20.19.25)(express@4.22.2)
-      '@medusajs/utils': 2.12.5(@types/node@20.19.25)(express@4.22.2)
+      '@graphql-codegen/core': 4.0.2(graphql@16.14.0)
+      '@graphql-codegen/typescript': 4.1.6(graphql@16.14.0)
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.0)
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.0)
+      '@medusajs/deps': 2.14.2(@types/node@20.19.25)
+      '@types/pluralize': 0.0.33
+      bignumber.js: 9.3.1
+      dotenv: 16.6.1
+      dotenv-expand: 11.0.7
+      express: 4.22.2
+      graphql: 16.14.0
+      jsonwebtoken: 9.0.3
+      pg-connection-string: 2.12.0
+      pluralize: 8.0.0
+      ulid: 2.4.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@medusajs/workflows-sdk@2.14.2(@types/node@20.19.25)(express@4.22.2)':
+    dependencies:
+      '@medusajs/deps': 2.14.2(@types/node@20.19.25)
+      '@medusajs/modules-sdk': 2.14.2(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/orchestration': 2.14.2(@types/node@20.19.25)(express@4.22.2)
+      '@medusajs/utils': 2.14.2(@types/node@20.19.25)(express@4.22.2)
       ulid: 2.4.0
     transitivePeerDependencies:
       - '@types/node'
@@ -7293,6 +7826,7 @@ snapshots:
       - mysql
       - mysql2
       - pg-native
+      - pg-query-stream
       - sqlite3
       - supports-color
       - tedious
@@ -7317,6 +7851,27 @@ snapshots:
       - supports-color
       - tedious
 
+  '@mikro-orm/cli@6.6.12(pg@8.20.0)':
+    dependencies:
+      '@jercle/yargonaut': 1.1.5
+      '@mikro-orm/core': 6.6.12
+      '@mikro-orm/knex': 6.6.12(@mikro-orm/core@6.6.12)(pg@8.20.0)
+      fs-extra: 11.3.3
+      tsconfig-paths: 4.2.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@mikro-orm/core@6.4.16':
     dependencies:
       dataloader: 2.2.3
@@ -7325,6 +7880,16 @@ snapshots:
       fs-extra: 11.3.0
       globby: 11.1.0
       mikro-orm: 6.4.16
+      reflect-metadata: 0.2.2
+
+  '@mikro-orm/core@6.6.12':
+    dependencies:
+      dataloader: 2.2.3
+      dotenv: 17.3.1
+      esprima: 4.0.1
+      fs-extra: 11.3.3
+      globby: 11.1.0
+      mikro-orm: 6.6.12
       reflect-metadata: 0.2.2
 
   '@mikro-orm/knex@6.4.16(@mikro-orm/core@6.4.16)(pg@8.16.0)':
@@ -7357,6 +7922,22 @@ snapshots:
       - supports-color
       - tedious
 
+  '@mikro-orm/knex@6.6.12(@mikro-orm/core@6.6.12)(pg@8.20.0)':
+    dependencies:
+      '@mikro-orm/core': 6.6.12
+      fs-extra: 11.3.3
+      knex: 3.2.8(pg@8.20.0)
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@mikro-orm/migrations@6.4.16(@mikro-orm/core@6.4.16)(@types/node@20.19.25)(pg@8.20.0)':
     dependencies:
       '@mikro-orm/core': 6.4.16
@@ -7372,6 +7953,26 @@ snapshots:
       - mysql2
       - pg
       - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/migrations@6.6.12(@mikro-orm/core@6.6.12)(@types/node@20.19.25)(pg@8.20.0)':
+    dependencies:
+      '@mikro-orm/core': 6.6.12
+      '@mikro-orm/knex': 6.6.12(@mikro-orm/core@6.6.12)(pg@8.20.0)
+      fs-extra: 11.3.3
+      umzug: 3.8.2(@types/node@20.19.25)
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - pg-query-stream
       - sqlite3
       - supports-color
       - tedious
@@ -7394,6 +7995,28 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
+
+  '@mikro-orm/postgresql@6.6.12(@mikro-orm/core@6.6.12)':
+    dependencies:
+      '@mikro-orm/core': 6.6.12
+      '@mikro-orm/knex': 6.6.12(@mikro-orm/core@6.6.12)(pg@8.20.0)
+      pg: 8.20.0
+      postgres-array: 3.0.4
+      postgres-date: 2.1.0
+      postgres-interval: 4.0.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@nodable/entities@2.1.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9725,7 +10348,7 @@ snapshots:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
       ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.2
+      fs-extra: 11.3.3
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.11
@@ -9776,6 +10399,54 @@ snapshots:
       '@sentry/core': 10.53.1
 
   '@sentry/core@10.53.1': {}
+
+  '@smithy/core@3.24.6':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.7':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@so-ric/colorspace@1.1.6':
     dependencies:
@@ -10336,6 +11007,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   boxen@5.1.2:
     dependencies:
       ansi-align: 3.0.1
@@ -10629,6 +11302,10 @@ snapshots:
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
 
+  connect-dynamodb@3.0.5:
+    optionalDependencies:
+      '@aws-sdk/client-dynamodb': 3.1058.0
+
   connect-redis@5.2.0: {}
 
   consola@3.4.2: {}
@@ -10813,6 +11490,8 @@ snapshots:
   dotenv@16.5.0: {}
 
   dotenv@16.6.1: {}
+
+  dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -11282,6 +11961,18 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -11385,6 +12076,12 @@ snapshots:
       universalify: 2.0.1
 
   fs-extra@11.3.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.3:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -11959,6 +12656,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  knex@3.2.8(pg@8.20.0):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.18.1
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      pg: 8.20.0
+    transitivePeerDependencies:
+      - supports-color
+
   kuler@2.0.0: {}
 
   language-subtag-registry@0.3.23: {}
@@ -12037,6 +12755,8 @@ snapshots:
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4: {}
 
@@ -12134,6 +12854,8 @@ snapshots:
 
   mikro-orm@6.4.16: {}
 
+  mikro-orm@6.6.12: {}
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -12170,6 +12892,10 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  mnemonist@0.38.3:
+    dependencies:
+      obliterator: 1.6.1
 
   module-details-from-path@1.0.4: {}
 
@@ -12288,6 +13014,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obliterator@1.6.1: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -12385,6 +13113,8 @@ snapshots:
       tslib: 2.8.1
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -12558,7 +13288,7 @@ snapshots:
   prettier-plugin-classnames@0.8.5(prettier@3.6.2):
     dependencies:
       prettier: 3.6.2
-      zod: 3.22.4
+      zod: 4.2.0
 
   prettier-plugin-tailwindcss@0.7.1(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2):
     dependencies:
@@ -13261,6 +13991,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.25
 
+  strnum@2.3.0: {}
+
   sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -13770,6 +14502,8 @@ snapshots:
 
   xdg-basedir@4.0.0: {}
 
+  xml-naming@0.1.0: {}
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -13792,10 +14526,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@3.5.1(zod@3.25.76):
+  zod-validation-error@5.0.0(zod@4.2.0):
     dependencies:
-      zod: 3.25.76
+      zod: 4.2.0
 
-  zod@3.22.4: {}
-
-  zod@3.25.76: {}
+  zod@4.2.0: {}

--- a/admin-panel/src/dashboard-app/forms/form-extension-zone/utils.ts
+++ b/admin-panel/src/dashboard-app/forms/form-extension-zone/utils.ts
@@ -2,11 +2,11 @@ import type {
   ZodType} from "zod";
 import {
   ZodBoolean,
-  ZodEffects,
   ZodNull,
   ZodNullable,
   ZodNumber,
   ZodOptional,
+  ZodPipe,
   ZodString,
   ZodUndefined,
 } from "zod"
@@ -39,19 +39,18 @@ export function getFieldType(type: ZodType): FormFieldType {
   if (type instanceof ZodNullable) {
     const innerType = type.unwrap()
 
-    return getFieldType(innerType)
+    return getFieldType(innerType as ZodType)
   }
 
   if (type instanceof ZodOptional) {
     const innerType = type.unwrap()
 
-    return getFieldType(innerType)
+    return getFieldType(innerType as ZodType)
   }
 
-  if (type instanceof ZodEffects) {
-    const innerType = type.innerType()
-
-    return getFieldType(innerType)
+  if (type instanceof ZodPipe) {
+    // Zod 4 represents transforms/preprocess as ZodPipe; recurse into the input schema.
+    return getFieldType(type.in as ZodType)
   }
 
   return "unsupported"

--- a/admin-panel/src/dashboard-app/forms/hooks.tsx
+++ b/admin-panel/src/dashboard-app/forms/hooks.tsx
@@ -1,13 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import type { FieldValues, UseFormProps } from "react-hook-form";
 import { useForm } from "react-hook-form"
-import type { ZodObject } from "zod";
-import { z, ZodEffects } from "zod"
+import { z } from "zod"
 
 import type { ConfigField } from "@/dashboard-app/types"
 
 interface UseExtendableFormProps<
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
+  TSchema extends z.ZodType<any>,
   TContext = any,
   TData = any
 > extends Omit<UseFormProps<z.infer<TSchema>, TContext>, "resolver"> {
@@ -21,29 +20,19 @@ function createAdditionalDataSchema(configs: ConfigField[]) {
     acc[config.name] = config.validation
     
 return acc
-  }, {} as Record<string, z.ZodTypeAny>)
+  }, {} as Record<string, z.ZodType>)
 }
 
 function createExtendedSchema<
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>
->(baseSchema: TSchema, additionalDataSchema: Record<string, z.ZodTypeAny>) {
-  const extendedObjectSchema = z.object({
-    ...(baseSchema instanceof ZodEffects
-      ? baseSchema.innerType().shape
-      : baseSchema.shape),
-    additional_data: z.object(additionalDataSchema).optional(),
-  })
+  TSchema extends z.ZodType<any>
+>(baseSchema: TSchema, additionalDataSchema: Record<string, z.ZodType>) {
+  const additionalData = z.object(additionalDataSchema).optional()
 
-  return baseSchema instanceof ZodEffects
-    ? baseSchema
-        .superRefine((data, ctx) => {
-          const result = extendedObjectSchema.safeParse(data)
-          if (!result.success) {
-            result.error.issues.forEach((issue) => ctx.addIssue(issue))
-          }
-        })
-        .and(extendedObjectSchema)
-    : extendedObjectSchema
+  // Zod 4 removed ZodEffects: refined/superRefined objects stay ZodObjects and
+  // transforms become ZodPipe. Intersecting the base schema with the additional_data
+  // object preserves all of the base schema's fields and refinements while adding the
+  // optional extension data, without needing to branch on the schema's internal type.
+  return z.intersection(baseSchema, z.object({ additional_data: additionalData }))
 }
 
 function createExtendedDefaultValues<TData>(
@@ -64,7 +53,7 @@ return acc
 }
 
 export const useExtendableForm = <
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
+  TSchema extends z.ZodType<any>,
   TContext = any,
   TTransformedValues extends FieldValues | undefined = undefined
 >({

--- a/admin-panel/src/dashboard-app/types.ts
+++ b/admin-panel/src/dashboard-app/types.ts
@@ -8,7 +8,7 @@ import type {
 } from "@medusajs/admin-shared"
 import type { ComponentType } from "react"
 import type { LoaderFunction } from "react-router-dom"
-import type { ZodFirstPartySchemaTypes } from "zod"
+import type { ZodType } from "zod"
 import type { INavItem } from "@components/layout/nav-item"
 
 export type RouteExtension = {
@@ -37,7 +37,7 @@ export type DisplayExtension = {
 }
 
 export type FormFieldExtension = {
-  validation: ZodFirstPartySchemaTypes
+  validation: ZodType
   Component?: ComponentType<any>
   label?: string
   description?: string
@@ -52,7 +52,7 @@ export type FormExtension = {
 
 export type ConfigFieldExtension = {
   defaultValue: ((data: any) => any) | any
-  validation: ZodFirstPartySchemaTypes
+  validation: ZodType
 }
 
 export type ConfigExtension = {

--- a/admin-panel/src/hooks/api/customers.tsx
+++ b/admin-panel/src/hooks/api/customers.tsx
@@ -227,7 +227,8 @@ export const useDeleteCustomerAddress = (
 
 export const useListCustomerAddresses = (
   id: string,
-  query?: Record<string, any>,
+  // kept for call-site compatibility; the 2.14 SDK listAddresses no longer accepts a query
+  _query?: Record<string, any>,
   options?: UseQueryOptions<
     HttpTypes.AdminCustomerResponse,
     FetchError,
@@ -236,7 +237,8 @@ export const useListCustomerAddresses = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryFn: () => sdk.admin.customer.listAddresses(id, query),
+    // 2.14 SDK: listAddresses(id, headers?) no longer accepts a query arg.
+    queryFn: () => sdk.admin.customer.listAddresses(id) as any,
     queryKey: customerAddressesQueryKeys.list(id),
     ...options,
   })

--- a/admin-panel/src/hooks/api/price-preferences.tsx
+++ b/admin-panel/src/hooks/api/price-preferences.tsx
@@ -19,7 +19,7 @@ export const pricePreferencesQueryKeys = queryKeysFactory(
 
 export const usePricePreference = (
   id: string,
-  query?: HttpTypes.AdminPricePreferenceParams,
+  query?: HttpTypes.AdminGetPricePreferenceParams,
   options?: Omit<
     UseQueryOptions<
       HttpTypes.AdminPricePreferenceResponse,
@@ -62,7 +62,7 @@ export const usePricePreferences = (
 
 export const useUpsertPricePreference = (
   id?: string | undefined,
-  query?: HttpTypes.AdminPricePreferenceParams,
+  query?: HttpTypes.AdminGetPricePreferenceParams,
   options?: UseMutationOptions<
     HttpTypes.AdminPricePreferenceResponse,
     FetchError,

--- a/admin-panel/src/lib/validation.ts
+++ b/admin-panel/src/lib/validation.ts
@@ -88,7 +88,7 @@ return acc
   const validationResult = schema.safeParse(values)
 
   if (!validationResult.success) {
-    validationResult.error.errors.forEach(({ path, message, code }) => {
+    validationResult.error.issues.forEach(({ path, message, code }) => {
       form.setError(path.join(".") as any, {
         type: code,
         message,

--- a/admin-panel/src/routes/attributes/attribute-edit/schema.ts
+++ b/admin-panel/src/routes/attributes/attribute-edit/schema.ts
@@ -16,7 +16,7 @@ export const AdminUpdateAttributeValue = z.object({
   id: z.string().optional(),
   value: z.string().optional(),
   rank: z.number().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type AdminCreateAttributeValueType = z.infer<
@@ -25,7 +25,7 @@ export type AdminCreateAttributeValueType = z.infer<
 export const AdminCreateAttributeValue = z.object({
   value: z.string().min(1),
   rank: z.number(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type AdminUpdateAttributeType = z.infer<typeof AdminUpdateAttribute>;
@@ -36,7 +36,7 @@ export const AdminUpdateAttribute = z
     handle: z.string().optional(),
     is_filterable: z.boolean().optional(),
     is_required: z.boolean().optional(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
     ui_component: z.nativeEnum(AttributeUIComponent).optional(),
     product_category_ids: z.array(z.string()).optional(),
     possible_values: z.array(AdminUpdateAttributeValue).optional(),
@@ -53,7 +53,7 @@ export const CreateAttribute = z.object({
     .nativeEnum(AttributeUIComponent)
     .default(AttributeUIComponent.SELECT),
   handle: z.string().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   possible_values: z.array(AdminCreateAttributeValue).optional(),
   product_category_ids: z.array(z.string()).optional(),
 });

--- a/admin-panel/src/routes/categories/category-create/components/create-category-form/create-category-form.tsx
+++ b/admin-panel/src/routes/categories/category-create/components/create-category-form/create-category-form.tsx
@@ -62,7 +62,7 @@ export const CreateCategoryForm = ({
       })
 
       if (!result.success) {
-        result.error.errors.forEach((error) => {
+        result.error.issues.forEach((error) => {
           form.setError(error.path.join(".") as keyof CreateCategorySchema, {
             type: "manual",
             message: error.message,

--- a/admin-panel/src/routes/inventory/inventory-list/components/inventory-list-table.tsx
+++ b/admin-panel/src/routes/inventory/inventory-list/components/inventory-list-table.tsx
@@ -39,7 +39,7 @@ export const InventoryListTable = () => {
   const columns = useInventoryTableColumns()
 
   const { table } = useDataTable({
-    data: (inventory_items ?? []) as InventoryTypes.InventoryItemDTO[],
+    data: (inventory_items ?? []) as unknown as InventoryTypes.InventoryItemDTO[],
     columns,
     count,
     enablePagination: true,

--- a/admin-panel/src/routes/inventory/inventory-stock/components/inventory-stock-form/inventory-stock-form.tsx
+++ b/admin-panel/src/routes/inventory/inventory-stock/components/inventory-stock-form/inventory-stock-form.tsx
@@ -45,10 +45,10 @@ export const InventoryStockForm = ({
   const { mutateAsync, isPending } = useBatchInventoryItemsLocationLevels()
 
   const onSubmit = form.handleSubmit(async (data) => {
-    const payload: HttpTypes.AdminBatchInventoryItemsLocationLevels = {
-      create: [],
-      update: [],
-      delete: [],
+    const payload = {
+      create: [] as NonNullable<HttpTypes.AdminBatchInventoryItemsLocationLevels["create"]>,
+      update: [] as NonNullable<HttpTypes.AdminBatchInventoryItemsLocationLevels["update"]>,
+      delete: [] as NonNullable<HttpTypes.AdminBatchInventoryItemsLocationLevels["delete"]>,
       force: true,
     }
 

--- a/admin-panel/src/routes/inventory/inventory-stock/schema.ts
+++ b/admin-panel/src/routes/inventory/inventory-stock/schema.ts
@@ -7,14 +7,14 @@ const LocationQuantitySchema = z.object({
   disabledToggle: z.boolean(),
 })
 
-const InventoryLocationsSchema = z.record(LocationQuantitySchema)
+const InventoryLocationsSchema = z.record(z.string(),LocationQuantitySchema)
 
 const InventoryItemSchema = z.object({
   locations: InventoryLocationsSchema,
 })
 
 export const InventoryStockSchema = z.object({
-  inventory_items: z.record(InventoryItemSchema),
+  inventory_items: z.record(z.string(),InventoryItemSchema),
 })
 
 export type InventoryLocationsSchema = z.infer<typeof InventoryLocationsSchema>

--- a/admin-panel/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
+++ b/admin-panel/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
@@ -200,7 +200,7 @@ export function CreateShippingOptionsForm({
       })
 
       if (!result.success) {
-        const [firstError, ...rest] = result.error.errors
+        const [firstError, ...rest] = result.error.issues
 
         for (const error of rest) {
           const _path = error.path.join(".") as keyof CreateShippingOptionSchema

--- a/admin-panel/src/routes/price-lists/common/schemas.ts
+++ b/admin-panel/src/routes/price-lists/common/schemas.ts
@@ -30,15 +30,15 @@ export type PriceListCreateRegionPriceSchema = z.infer<
 >
 
 const PriceListCreateProductVariantSchema = z.object({
-  currency_prices: z.record(PriceListCreateCurrencyPriceSchema.optional()),
-  region_prices: z.record(PriceListCreateRegionPriceSchema.optional()),
+  currency_prices: z.record(z.string(),PriceListCreateCurrencyPriceSchema.optional()),
+  region_prices: z.record(z.string(),PriceListCreateRegionPriceSchema.optional()),
 })
 
 export type PriceListCreateProductVariantSchema = z.infer<
   typeof PriceListCreateProductVariantSchema
 >
 
-const PriceListCreateProductVariantsSchema = z.record(
+const PriceListCreateProductVariantsSchema = z.record(z.string(),
   PriceListCreateProductVariantSchema
 )
 
@@ -46,7 +46,7 @@ export type PriceListCreateProductVariantsSchema = z.infer<
   typeof PriceListCreateProductVariantsSchema
 >
 
-export const PriceListCreateProductsSchema = z.record(
+export const PriceListCreateProductsSchema = z.record(z.string(),
   z.object({
     variants: PriceListCreateProductVariantsSchema,
   })
@@ -74,10 +74,10 @@ export type PriceListUpdateRegionPrice = z.infer<
   typeof PriceListUpdateRegionPriceSchema
 >
 
-export const PriceListUpdateProductVariantsSchema = z.record(
+export const PriceListUpdateProductVariantsSchema = z.record(z.string(),
   z.object({
-    currency_prices: z.record(PriceListUpdateCurrencyPriceSchema.optional()),
-    region_prices: z.record(PriceListUpdateRegionPriceSchema.optional()),
+    currency_prices: z.record(z.string(),PriceListUpdateCurrencyPriceSchema.optional()),
+    region_prices: z.record(z.string(),PriceListUpdateRegionPriceSchema.optional()),
   })
 )
 
@@ -85,7 +85,7 @@ export type PriceListUpdateProductVariantsSchema = z.infer<
   typeof PriceListUpdateProductVariantsSchema
 >
 
-export const PriceListUpdateProductsSchema = z.record(
+export const PriceListUpdateProductsSchema = z.record(z.string(),
   z.object({
     variants: PriceListUpdateProductVariantsSchema,
   })

--- a/admin-panel/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-create-form.tsx
+++ b/admin-panel/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-create-form.tsx
@@ -136,7 +136,7 @@ return acc
     const validationResult = schema.safeParse(values)
 
     if (!validationResult.success) {
-      validationResult.error.errors.forEach(({ path, message, code }) => {
+      validationResult.error.issues.forEach(({ path, message, code }) => {
         form.setError(path.join(".") as keyof PricingCreateSchemaType, {
           type: code,
           message,

--- a/admin-panel/src/routes/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-form.tsx
+++ b/admin-panel/src/routes/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-form.tsx
@@ -105,7 +105,7 @@ return acc
     const validationResult = schema.safeParse(values)
 
     if (!validationResult.success) {
-      validationResult.error.errors.forEach(({ path, message, code }) => {
+      validationResult.error.issues.forEach(({ path, message, code }) => {
         form.setError(path.join(".") as keyof PriceListPricesAddSchema, {
           type: code,
           message,

--- a/admin-panel/src/routes/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
+++ b/admin-panel/src/routes/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
@@ -38,7 +38,7 @@ const ProductEditVariantSchema = z.object({
   mid_code: z.string().optional(),
   hs_code: z.string().optional(),
   origin_country: z.string().optional(),
-  options: z.record(z.string()),
+  options: z.record(z.string(), z.string()),
 })
 
 // TODO: Either pass option ID or make the backend handle options constraints differently to handle the lack of IDs

--- a/admin-panel/src/routes/products/product-create-variant/components/create-product-variant-form/constants.ts
+++ b/admin-panel/src/routes/products/product-create-variant/components/create-product-variant-form/constants.ts
@@ -8,7 +8,7 @@ export const CreateProductVariantSchema = z.object({
   manage_inventory: z.boolean().optional(),
   allow_backorder: z.boolean().optional(),
   inventory_kit: z.boolean().optional(),
-  options: z.record(z.string()),
+  options: z.record(z.string(), z.string()),
   prices: zod
     .record(zod.string(), zod.string().or(zod.number()).optional())
     .optional(),

--- a/admin-panel/src/routes/products/product-create/components/product-create-form/product-create-form.tsx
+++ b/admin-panel/src/routes/products/product-create/components/product-create-form/product-create-form.tsx
@@ -149,7 +149,7 @@ return acc
     await mutateAsync(
       normalizeProductFormValues({
         ...payload,
-        media: uploadedMedia,
+        media: uploadedMedia as any,
         status: (isDraftSubmission ? "draft" : "published") as any,
         regionsCurrencyMap,
       }),

--- a/admin-panel/src/routes/products/product-stock/components/product-stock-form/product-stock-form.tsx
+++ b/admin-panel/src/routes/products/product-stock/components/product-stock-form/product-stock-form.tsx
@@ -61,10 +61,10 @@ export const ProductStockForm = ({
   const { mutateAsync, isPending } = useBatchInventoryItemsLocationLevels()
 
   const onSubmit = form.handleSubmit(async (data) => {
-    const payload: HttpTypes.AdminBatchInventoryItemsLocationLevels = {
-      create: [],
-      update: [],
-      delete: [],
+    const payload = {
+      create: [] as NonNullable<HttpTypes.AdminBatchInventoryItemsLocationLevels["create"]>,
+      update: [] as NonNullable<HttpTypes.AdminBatchInventoryItemsLocationLevels["update"]>,
+      delete: [] as NonNullable<HttpTypes.AdminBatchInventoryItemsLocationLevels["delete"]>,
       force: true,
     }
 

--- a/admin-panel/src/routes/products/product-stock/schema.ts
+++ b/admin-panel/src/routes/products/product-stock/schema.ts
@@ -7,18 +7,18 @@ const LocationQuantitySchema = z.object({
   disabledToggle: z.boolean(),
 })
 
-const ProductStockLocationsSchema = z.record(LocationQuantitySchema)
+const ProductStockLocationsSchema = z.record(z.string(),LocationQuantitySchema)
 
 const ProductStockInventoryItemSchema = z.object({
   locations: ProductStockLocationsSchema,
 })
 
 const ProductStockVariantSchema = z.object({
-  inventory_items: z.record(ProductStockInventoryItemSchema),
+  inventory_items: z.record(z.string(),ProductStockInventoryItemSchema),
 })
 
 export const ProductStockSchema = z.object({
-  variants: z.record(ProductStockVariantSchema),
+  variants: z.record(z.string(),ProductStockVariantSchema),
 })
 
 export type ProductStockLocationSchema = z.infer<

--- a/admin-panel/src/routes/promotions/promotion-create/components/create-promotion-form/create-promotion-form.tsx
+++ b/admin-panel/src/routes/promotions/promotion-create/components/create-promotion-form/create-promotion-form.tsx
@@ -84,7 +84,7 @@ export const CreatePromotionForm = () => {
   const { handleSuccess } = useRouteModal()
   const direction = useDocumentDirection()
   const form = useForm<z.infer<typeof CreatePromotionSchema>>({
-    defaultValues,
+    defaultValues: defaultValues as unknown as z.infer<typeof CreatePromotionSchema>,
     resolver: zodResolver(CreatePromotionSchema),
   })
   const { setValue, reset, getValues } = form
@@ -263,7 +263,9 @@ export const CreatePromotionForm = () => {
       return
     }
 
-    reset({ ...defaultValues, template_id: watchTemplateId })
+    reset({ ...defaultValues, template_id: watchTemplateId } as unknown as z.infer<
+      typeof CreatePromotionSchema
+    >)
 
     for (const [key, value] of Object.entries(currentTemplate.defaults)) {
       if (typeof value === "object") {

--- a/admin-panel/src/routes/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/admin-panel/src/routes/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
@@ -46,7 +46,7 @@ export const EditPromotionDetailsForm = ({
       code: promotion.code,
       status: promotion.status,
       value: promotion.application_method!.value,
-      allocation: promotion.application_method!.allocation,
+      allocation: promotion.application_method!.allocation as any,
       value_type: promotion.application_method!.type,
       target_type: promotion.application_method!.target_type,
     },

--- a/admin-panel/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
+++ b/admin-panel/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
@@ -34,7 +34,7 @@ type AddCurrenciesFormProps = {
 
 const AddCurrenciesSchema = zod.object({
   currencies: zod.array(zod.string()).min(1),
-  pricePreferences: zod.record(zod.boolean()),
+  pricePreferences: zod.record(zod.string(), zod.boolean()),
 })
 
 const PAGE_SIZE = 50

--- a/admin-panel/src/types/algolia/algolia-product.ts
+++ b/admin-panel/src/types/algolia/algolia-product.ts
@@ -12,7 +12,7 @@ export const AlgoliaProductValidator = z.object({
   thumbnail: z.string().nullable(),
   average_rating: z.coerce.number().nullable().default(null),
   supported_countries: z.array(z.string()).nullable().default([]),
-  options: z.array(z.record(z.string())).nullable().default(null),
+  options: z.array(z.record(z.string(), z.string())).nullable().default(null),
   images: z
     .array(
       z.object({

--- a/backend/integration-tests/http/helpers/seller-auth.ts
+++ b/backend/integration-tests/http/helpers/seller-auth.ts
@@ -1,0 +1,192 @@
+import { Modules } from "@medusajs/framework/utils"
+import {
+  createSalesChannelsWorkflow,
+  createShippingProfilesWorkflow,
+} from "@medusajs/medusa/core-flows"
+import jwt from "jsonwebtoken"
+import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
+
+/**
+ * Test helper: bootstrap an authenticated, active seller for /vendor/* integration tests.
+ *
+ * The vendor auth stack (src/api/vendor/_middlewares.ts + src/shared/auth-helpers.ts and
+ * the @mercurjs/b2c-core store/seller guards) resolves a seller from the bearer token via
+ * `actor_id` (a mem_* member id, which maps to a sel_* seller) and/or the auth identity's
+ * app_metadata. This helper:
+ *   1. registers a seller auth identity (emailpass),
+ *   2. creates + activates a seller through the real mercurjs createSellerWorkflow
+ *      (the same workflow the approval service runs; store_status defaults to ACTIVE),
+ *   3. mints a JWT carrying the linked actor so both our custom routes and the mercurjs
+ *      dist routes authenticate.
+ *
+ * The token is minted directly with jsonwebtoken using the same JWT_SECRET the server
+ * verifies with (Medusa's auth middleware and our decodeAuthToken both jwt.verify against
+ * it), which makes the bootstrap deterministic regardless of /auth/token/refresh behaviour
+ * in a given Medusa build.
+ */
+
+// axios (the test runner's `api`) may or may not be configured to throw on non-2xx
+// depending on the @medusajs/test-utils version. This wrapper returns the response either
+// way so assertions can read `.status`/`.data` uniformly.
+export const safe = <T = any>(p: Promise<T>): Promise<T> =>
+  p.catch((e: any) => e?.response ?? Promise.reject(e))
+
+export const authHeader = (token: string) => ({
+  headers: { authorization: `Bearer ${token}` },
+})
+
+/**
+ * Idempotently ensure the store infrastructure that createProductsWorkflow needs
+ * (a default sales channel + a default shipping profile). A fresh test database has
+ * neither, which makes product creation fail with an opaque 500. Mirrors src/scripts/seed.ts.
+ */
+export interface StoreInfra {
+  salesChannelId: string
+  shippingProfileId: string
+}
+
+export async function ensureStoreInfra(container: any): Promise<StoreInfra> {
+  const salesChannelService = container.resolve(Modules.SALES_CHANNEL)
+  let [salesChannel] = await salesChannelService.listSalesChannels({
+    name: "Default Sales Channel",
+  })
+  if (!salesChannel) {
+    const { result } = await createSalesChannelsWorkflow(container).run({
+      input: { salesChannelsData: [{ name: "Default Sales Channel" }] },
+    })
+    salesChannel = result[0]
+  }
+
+  const fulfillmentService = container.resolve(Modules.FULFILLMENT)
+  let [shippingProfile] = await fulfillmentService.listShippingProfiles({
+    type: "default",
+  })
+  if (!shippingProfile) {
+    const { result } = await createShippingProfilesWorkflow(container).run({
+      input: { data: [{ name: "Default Shipping Profile", type: "default" }] },
+    })
+    shippingProfile = result[0]
+  }
+
+  return { salesChannelId: salesChannel.id, shippingProfileId: shippingProfile.id }
+}
+
+export interface AuthenticatedSeller {
+  token: string
+  authIdentityId: string
+  /** The actor id embedded in the token (a mem_* member id). */
+  actorId: string
+  /** The mercurjs seller (sel_*) created for this auth identity. */
+  seller: { id: string; name: string; handle?: string }
+  email: string
+  password: string
+}
+
+export interface CreateAuthenticatedSellerOptions {
+  api: any
+  getContainer: () => any
+  storeName?: string
+  memberName?: string
+}
+
+export async function createAuthenticatedSeller({
+  api,
+  getContainer,
+  storeName,
+  memberName = "Test Vendor",
+}: CreateAuthenticatedSellerOptions): Promise<AuthenticatedSeller> {
+  const container = getContainer()
+  const authModule = container.resolve(Modules.AUTH)
+
+  const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+  const email = `vendor+${unique}@example.com`
+  const password = "supersecret123"
+  const sellerName = storeName ?? `Test Store ${unique}`
+
+  // 1. Register an emailpass auth identity for the seller scope.
+  const reg = await safe(
+    api.post("/auth/seller/emailpass/register", { email, password })
+  )
+  const registrationToken: string | undefined = reg?.data?.token
+
+  // Resolve the auth identity created above (by provider entity_id == email).
+  const identities = await authModule.listAuthIdentities({
+    provider_identities: { entity_id: email },
+  })
+  const authIdentity = identities?.[0]
+  if (!authIdentity?.id) {
+    throw new Error(
+      `createAuthenticatedSeller: could not resolve auth identity for ${email}`
+    )
+  }
+  const authIdentityId: string = authIdentity.id
+
+  // 2. Create + activate the seller via the real mercurjs workflow.
+  const { result: seller } = await createSellerWorkflow.run({
+    container,
+    input: {
+      auth_identity_id: authIdentityId,
+      member: { name: memberName, email },
+      seller: { name: sellerName },
+    } as any,
+  })
+
+  // The workflow links the member id under app_metadata.seller_id on the auth identity
+  // (setAuthAppMetadataStep with actorType "seller"). That member id (mem_*) is the actor.
+  const [linked] = await authModule.listAuthIdentities({ id: [authIdentityId] })
+  const appMetadata = (linked?.app_metadata ?? {}) as Record<string, unknown>
+  const actorId =
+    typeof appMetadata.seller_id === "string" ? (appMetadata.seller_id as string) : ""
+  if (!actorId) {
+    throw new Error(
+      "createAuthenticatedSeller: seller workflow did not link an actor on the auth identity"
+    )
+  }
+
+  // 3. Obtain a Medusa-native seller token now that the actor is linked. Prefer the
+  //    canonical auth routes (login, then refresh) because the mercurjs dist routes
+  //    authenticate via Medusa's own auth middleware, which only trusts tokens it issued.
+  //    Fall back to a hand-minted token (accepted by our custom requireSellerId decode).
+  let token: string | undefined
+
+  // 3a. Login: re-authenticates with credentials and embeds the now-linked actor.
+  const login = await safe(
+    api.post("/auth/seller/emailpass", { email, password })
+  )
+  token = login?.data?.token
+
+  // 3b. Refresh: re-mints the registration token with the linked actor.
+  if (!token && registrationToken) {
+    const refreshed = await safe(
+      api.post("/auth/token/refresh", {}, authHeader(registrationToken))
+    )
+    token = refreshed?.data?.token
+  }
+
+  // 3c. Fallback: mint directly with the shared secret.
+  if (!token) {
+    const secret = process.env.JWT_SECRET
+    if (!secret) {
+      throw new Error("createAuthenticatedSeller: JWT_SECRET is not set in the test env")
+    }
+    token = jwt.sign(
+      {
+        actor_id: actorId,
+        actor_type: "seller",
+        auth_identity_id: authIdentityId,
+        app_metadata: { seller_id: actorId },
+      },
+      secret,
+      { expiresIn: "1h" }
+    )
+  }
+
+  return {
+    token,
+    authIdentityId,
+    actorId,
+    seller: seller as AuthenticatedSeller["seller"],
+    email,
+    password,
+  }
+}

--- a/backend/integration-tests/http/vendor-authenticated-flows.spec.ts
+++ b/backend/integration-tests/http/vendor-authenticated-flows.spec.ts
@@ -1,0 +1,105 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  createAuthenticatedSeller,
+  ensureStoreInfra,
+  authHeader,
+  safe,
+  AuthenticatedSeller,
+  StoreInfra,
+} from "./helpers/seller-auth"
+
+// Boot (~45-55s) + seller bootstrap (register + createSellerWorkflow) need extra headroom.
+jest.setTimeout(120 * 1000)
+
+/**
+ * Deep, authenticated smoke coverage for the @mercurjs/* vendor flows under
+ * Medusa 2.14.2 + zod 4. Exercises the real seller-auth path and the mercurjs
+ * route/middleware stack end-to-end so future Medusa/zod bumps have a regression net.
+ *
+ * All requests run inside a single test on purpose: the in-app test server closes idle
+ * keep-alive sockets between separate `it()` blocks, which surfaces as intermittent
+ * "Connection is closed" errors. Sequential requests in one test avoid that.
+ */
+medusaIntegrationTestRunner({
+  inApp: true,
+  env: {},
+  testSuite: ({ api, getContainer }) => {
+    describe("Vendor authenticated flows (mercurjs)", () => {
+      let ctx: AuthenticatedSeller
+      let infra: StoreInfra
+
+      beforeAll(async () => {
+        infra = await ensureStoreInfra(getContainer())
+        ctx = await createAuthenticatedSeller({ api, getContainer })
+      })
+
+      it("authenticates a seller across the mercurjs vendor read + product surface", async () => {
+        // onboarding — custom route, resolves seller from the bearer token.
+        const me = await safe(api.get("/vendor/sellers/me", authHeader(ctx.token)))
+        expect(me.status).toBe(200)
+        expect(me.data.seller?.id).toBe(ctx.seller.id)
+        expect(typeof me.data.seller?.store_status).toBe("string")
+
+        // orders — mercurjs dist route; exercises the seller-scoped filter middleware
+        // (patched for null-safety) without crashing under zod 4 / Medusa 2.14.
+        const orders = await safe(api.get("/vendor/orders", authHeader(ctx.token)))
+        expect(orders.status).toBe(200)
+        expect(Array.isArray(orders.data.orders)).toBe(true)
+
+        // statistics — commission proxy (no first-class vendor commission route ships in
+        // this mercurjs build). Assert only that auth succeeded and nothing crashed.
+        const stats = await safe(api.get("/vendor/statistics", authHeader(ctx.token)))
+        expect(stats.status).not.toBe(401)
+        expect(stats.status).toBeLessThan(500)
+
+        // reviews — @mercurjs/reviews is a meta-package; route may be absent (404).
+        const reviews = await safe(
+          api.get("/vendor/sellers/me/reviews", authHeader(ctx.token))
+        )
+        expect(reviews.status).not.toBe(401)
+        expect(reviews.status).toBeLessThan(500)
+
+        // product create — authenticated *mutation* path. This verifies the seller token
+        // passes the full POST stack (Medusa auth -> our ensureSellerContext -> mercurjs
+        // storeActiveGuard, which all reject non-active/unauthenticated sellers). We assert
+        // the request is authorized as a seller (not 401/403); the request body mirrors the
+        // seeded demo products (channel + default shipping profile + options/variant).
+        //
+        // NOTE: full product creation through createProductsWorkflow currently returns 500
+        // in a bare test DB even with store infra seeded (an opaque error originating in a
+        // mercurjs createProductsWorkflow hook). Asserting end-to-end creation is tracked as
+        // a follow-up that needs the mercurjs product-hook prerequisites reproduced; here we
+        // confirm the mutation auth path, and verify publish only if creation does succeed.
+        const create = await safe(
+          api.post(
+            "/vendor/products",
+            {
+              title: `Smoke Product ${Date.now()}`,
+              status: "draft",
+              shipping_profile_id: infra.shippingProfileId,
+              sales_channels: [{ id: infra.salesChannelId }],
+              options: [{ title: "Default", values: ["Default"] }],
+              variants: [{ title: "Default", options: { Default: "Default" } }],
+            },
+            authHeader(ctx.token)
+          )
+        )
+        expect(create.status).not.toBe(401)
+        expect(create.status).not.toBe(403)
+
+        const productId =
+          create.data?.product?.id ?? create.data?.products?.[0]?.id
+        if (productId) {
+          const publish = await safe(
+            api.post(
+              `/vendor/products/${productId}/status`,
+              { status: "published" },
+              authHeader(ctx.token)
+            )
+          )
+          expect(publish.status).toBe(200)
+        }
+      })
+    })
+  },
+})

--- a/backend/integration-tests/http/vendor-promotions-zod4-guard.spec.ts
+++ b/backend/integration-tests/http/vendor-promotions-zod4-guard.spec.ts
@@ -1,0 +1,60 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  createAuthenticatedSeller,
+  authHeader,
+  safe,
+  AuthenticatedSeller,
+} from "./helpers/seller-auth"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * Regression net for the zod 4 idiom bug in the mercurjs vendor-promotions path-param
+ * guards. The compiled guards read `result.error.errors`, which is `undefined` under
+ * zod 4 (renamed to `.issues`), so 400 responses for an invalid rule_type lost their
+ * `details` array. scripts/patch-mercurjs.js rewrites `.error.errors` -> `.error.issues`.
+ *
+ * This spec FAILS before that patch (details is undefined) and PASSES after it.
+ * The endpoints are GET, which storeActiveGuard allows regardless of store_status, so an
+ * authenticated seller reaches the guard.
+ */
+medusaIntegrationTestRunner({
+  inApp: true,
+  env: {},
+  testSuite: ({ api, getContainer }) => {
+    describe("Vendor promotions path-param guards (zod 4)", () => {
+      let ctx: AuthenticatedSeller
+
+      beforeAll(async () => {
+        ctx = await createAuthenticatedSeller({ api, getContainer })
+      })
+
+      // Both guard checks run in one test: the in-app server closes idle keep-alive
+      // sockets between separate it() blocks ("Connection is closed"); sequential
+      // requests in one test avoid that.
+      it("invalid rule_type returns 400 with a populated details array (zod 4 .issues)", async () => {
+        const attr = await safe(
+          api.get(
+            "/vendor/promotions/rule-attribute-options/not-a-real-rule",
+            authHeader(ctx.token)
+          )
+        )
+        expect(attr.status).toBe(400)
+        expect(attr.data.error).toBe("Invalid path parameters")
+        expect(Array.isArray(attr.data.details)).toBe(true)
+        expect(attr.data.details.length).toBeGreaterThan(0)
+
+        const value = await safe(
+          api.get(
+            "/vendor/promotions/rule-value-options/not-a-real-rule/attr_x",
+            authHeader(ctx.token)
+          )
+        )
+        expect(value.status).toBe(400)
+        expect(value.data.error).toBe("Invalid path parameters")
+        expect(Array.isArray(value.data.details)).toBe(true)
+        expect(value.data.details.length).toBeGreaterThan(0)
+      })
+    })
+  },
+})

--- a/backend/scripts/patch-mercurjs.js
+++ b/backend/scripts/patch-mercurjs.js
@@ -294,6 +294,32 @@ function patchCheckOwnershipForMissingSellerInventoryItem(filePath) {
   return true;
 }
 
+function patchPromotionGuardZod4(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  if (content.includes('// PATCHED: zod4 issues')) {
+    log(`  Already patched: ${filePath}`);
+    return false;
+  }
+
+  // Zod 4 renamed ZodError.errors -> ZodError.issues. MercurJS's compiled
+  // path-param guards still read `result.error.errors`, which is undefined
+  // under the zod 4 the backend now runs, so 400 responses lose their details.
+  const patched = content.replace(
+    /details: result\.error\.errors,/g,
+    'details: result.error.issues, // PATCHED: zod4 issues'
+  );
+
+  if (patched === content) {
+    log(`  Could not match pattern in: ${filePath}`);
+    return false;
+  }
+
+  fs.writeFileSync(filePath, patched);
+  log(`  Patched: ${filePath}`);
+  return true;
+}
+
 function main() {
   log('Applying MercurJS patches for store_status null-safety...');
 
@@ -338,6 +364,20 @@ function main() {
       if (patchCheckOwnershipForMissingSellerInventoryItem(checkOwnershipPath)) patchCount++;
     } else {
       log(`  Not found: check-ownership.js`);
+    }
+
+    // Patch vendor-promotions path-param guards for zod 4 (.error.errors -> .error.issues)
+    const middlewaresDir = path.join(dir, '.medusa', 'server', 'src', 'shared', 'infra', 'http', 'middlewares');
+    for (const guardFile of [
+      'vendor-promotions-rule-attribute-options-path-params-guard.js',
+      'vendor-promotions-rule-value-options-path-params-guard.js',
+    ]) {
+      const promoGuardPath = path.join(middlewaresDir, guardFile);
+      if (fs.existsSync(promoGuardPath)) {
+        if (patchPromotionGuardZod4(promoGuardPath)) patchCount++;
+      } else {
+        log(`  Not found: ${guardFile}`);
+      }
     }
   }
 

--- a/storefront/package.json
+++ b/storefront/package.json
@@ -37,16 +37,17 @@
       "preact": ">=10.27.3",
       "next": "15.5.18",
       "picomatch": ">=4.0.4",
-      "postcss": ">=8.5.10"
+      "postcss": ">=8.5.10",
+      "zod": "4.2.0"
     }
   },
   "dependencies": {
     "@headlessui/react": "^2.2.1",
     "@hookform/resolvers": "^3.10.0",
-    "@medusajs/icons": "^2.13.1",
-    "@medusajs/js-sdk": "2.12.5",
-    "@medusajs/types": "2.12.5",
-    "@medusajs/ui": "^4.0.28",
+    "@medusajs/icons": "^2.14.2",
+    "@medusajs/js-sdk": "2.14.2",
+    "@medusajs/types": "2.14.2",
+    "@medusajs/ui": "^4.1.9",
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.1.0",
     "@types/js-cookie": "^3.0.6",
@@ -75,7 +76,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "uuid": "^11.1.1",
-    "zod": "^3.24.1"
+    "zod": "^4.2.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.3",

--- a/storefront/pnpm-lock.yaml
+++ b/storefront/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   next: 15.5.18
   picomatch: '>=4.0.4'
   postcss: '>=8.5.10'
+  zod: 4.2.0
 
 importers:
 
@@ -25,17 +26,17 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.66.0(react@19.2.0))
       '@medusajs/icons':
-        specifier: ^2.13.1
-        version: 2.13.1(react@19.2.0)
+        specifier: ^2.14.2
+        version: 2.15.5(react@19.2.0)
       '@medusajs/js-sdk':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/types':
-        specifier: 2.12.5
-        version: 2.12.5(vite@7.3.2(@types/node@20.19.25)(jiti@1.21.7)(terser@5.44.1))
+        specifier: 2.14.2
+        version: 2.14.2(vite@7.3.2(@types/node@20.19.25)(jiti@1.21.7)(terser@5.44.1))
       '@medusajs/ui':
-        specifier: ^4.0.28
-        version: 4.1.0(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        specifier: ^4.1.9
+        version: 4.1.15(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@stripe/react-stripe-js':
         specifier: ^3.7.0
         version: 3.10.0(@stripe/stripe-js@7.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -121,8 +122,8 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: 4.2.0
+        version: 4.2.0
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^3.2.3
@@ -203,13 +204,13 @@ packages:
     resolution: {integrity: sha512-E6x4h5CPPPJ0za1r5HsLtHbeI+Tp3H+YFtcH8G3dSSPFE6w+PZINzB4NxLZmg1QqSeA5HTP3ZEzzsohp0o2GEw==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.2.0
 
   '@ai-sdk/provider-utils@3.0.17':
     resolution: {integrity: sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.2.0
 
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
@@ -1593,22 +1594,17 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@medusajs/icons@2.13.0':
-    resolution: {integrity: sha512-krc2HxIoeZY4XQ7z5qhhYGoooDwBJdO9MdP5zVrnVCzA2qbuPNWIjrNWN4EEky933X3oBVPIZU5JmQCRxA8YzA==}
+  '@medusajs/icons@2.15.5':
+    resolution: {integrity: sha512-cFPNZ26BeXt4joE3nQbMnlmszlWrJitNgOSwEZ7cK+1B483CjhcLtXYzo60OvtYsHB6flBQ9My7JkCtUAFYnEQ==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^18.3.1 || ^19.0.0
 
-  '@medusajs/icons@2.13.1':
-    resolution: {integrity: sha512-A0j+C4jURXSWARbxjEOXh3get9N7dY7n3TNTdmpOeY0XPZeDfKaL1yVBD2EC90jVTWY045whrMBCJUuV7kjYPg==}
-    peerDependencies:
-      react: ^18.3.1
-
-  '@medusajs/js-sdk@2.12.5':
-    resolution: {integrity: sha512-z7h1xxvx4lc1SMqOgihVAbqnZd0Yxq4u/s1JnI24e4kdr9A+lmbtajvpdD6/9gAf9HfL4qNDOJMb4rl8E+x8sQ==}
+  '@medusajs/js-sdk@2.14.2':
+    resolution: {integrity: sha512-nNpkzcQU8WhPEcXIoh7ET+1y8qSaRsAeoYtci+naCdT7U0/f4jT4vpBH1vI5E3P+sWvSO+fAVvkhVoHc0OY+bQ==}
     engines: {node: '>=20'}
 
-  '@medusajs/types@2.12.5':
-    resolution: {integrity: sha512-8VyCFX2JQIHQxbHZla+nr4kAXuJB4d0rhrcGHGvx4h0dYcZlcl4DJWfdtn6/2rvEWMQwb5NDCBzH1tfEvj1lyQ==}
+  '@medusajs/types@2.14.2':
+    resolution: {integrity: sha512-vWzzuG9hXrGMVhrwrUL+LiOi2cuvAoPRyDVdQeA7USdt7ooC+Tb6tWv6E9Sf1wFR3OoUa3S7Ft25qIXmVpV1AQ==}
     engines: {node: '>=20'}
     peerDependencies:
       ioredis: ^5.4.1
@@ -1619,8 +1615,8 @@ packages:
       vite:
         optional: true
 
-  '@medusajs/ui@4.1.0':
-    resolution: {integrity: sha512-VrvWksw+QdjM2Ez36akVN11LbLETWohN2WV7/Zz7wb02IzCBtIqq40Z1l8l5mSl8bO7tJHHqeRieYh5u0qND3w==}
+  '@medusajs/ui@4.1.15':
+    resolution: {integrity: sha512-8m+J54uMjA934BBWXqb7lKlg+Ja1cudcAbdXJp4GQgd0TSru+hEvkhAlH5baKeADB6tqo2H5BkBIwIFcJMxxnA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -3899,7 +3895,7 @@ packages:
     resolution: {integrity: sha512-9eGcu+1PJgPg4pRNV4L7tLjRR3wdJC9CXQoNMvtqvYNOLZHFCzjHtVIOr2SIkoJJeu2+sOy3hyiSuTmy2MA40g==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.2.0
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -5406,6 +5402,10 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6996,28 +6996,28 @@ packages:
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: 4.2.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.2.0:
+    resolution: {integrity: sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==}
 
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@2.0.9(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.9(zod@4.2.0)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.17(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.17(zod@4.2.0)
       '@vercel/oidc': 3.0.3
-      zod: 3.25.76
+      zod: 4.2.0
 
-  '@ai-sdk/provider-utils@3.0.17(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.17(zod@4.2.0)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.2.0
 
   '@ai-sdk/provider@2.0.0':
     dependencies:
@@ -8429,37 +8429,34 @@ snapshots:
       '@types/react': 19.2.5
       react: 19.2.0
 
-  '@medusajs/icons@2.13.0(react@19.2.0)':
+  '@medusajs/icons@2.15.5(react@19.2.0)':
     dependencies:
       react: 19.2.0
 
-  '@medusajs/icons@2.13.1(react@19.2.0)':
-    dependencies:
-      react: 19.2.0
-
-  '@medusajs/js-sdk@2.12.5':
+  '@medusajs/js-sdk@2.14.2':
     dependencies:
       fetch-event-stream: 0.1.6
       qs: 6.15.2
 
-  '@medusajs/types@2.12.5(vite@7.3.2(@types/node@20.19.25)(jiti@1.21.7)(terser@5.44.1))':
+  '@medusajs/types@2.14.2(vite@7.3.2(@types/node@20.19.25)(jiti@1.21.7)(terser@5.44.1))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       vite: 7.3.2(@types/node@20.19.25)(jiti@1.21.7)(terser@5.44.1)
 
-  '@medusajs/ui@4.1.0(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@medusajs/ui@4.1.15(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@dnd-kit/utilities': 3.2.2(react@19.2.0)
-      '@medusajs/icons': 2.13.0(react@19.2.0)
+      '@medusajs/icons': 2.15.5(react@19.2.0)
       '@radix-ui/react-dialog': 1.1.4(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tanstack/react-table': 8.20.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       clsx: 1.2.1
       copy-to-clipboard: 3.3.3
       cva: 1.0.0-beta.1(typescript@5.9.3)
+      lodash.isequal: 4.5.0
       prism-react-renderer: 2.4.1(react@19.2.0)
       prismjs: 1.30.0
       radix-ui: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -11283,13 +11280,13 @@ snapshots:
       loader-utils: 2.0.4
       regex-parser: 2.3.1
 
-  ai@5.0.93(zod@3.25.76):
+  ai@5.0.93(zod@4.2.0):
     dependencies:
-      '@ai-sdk/gateway': 2.0.9(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.9(zod@4.2.0)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.17(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.17(zod@4.2.0)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.2.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -12794,10 +12791,10 @@ snapshots:
   instantsearch-ui-components@0.14.0(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
-      ai: 5.0.93(zod@3.25.76)
+      ai: 5.0.93(zod@4.2.0)
       markdown-to-jsx: 7.7.17(react@19.2.0)
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod: 4.2.0
+      zod-to-json-schema: 3.24.6(zod@4.2.0)
     transitivePeerDependencies:
       - react
 
@@ -12808,7 +12805,7 @@ snapshots:
       '@types/google.maps': 3.58.1
       '@types/hogan.js': 3.0.5
       '@types/qs': 6.14.0
-      ai: 5.0.93(zod@3.25.76)
+      ai: 5.0.93(zod@4.2.0)
       algoliasearch: 5.44.0
       algoliasearch-helper: 3.26.1(algoliasearch@5.44.0)
       hogan.js: 3.0.2
@@ -12818,8 +12815,8 @@ snapshots:
       qs: 6.15.2
       react: 19.2.0
       search-insights: 2.17.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod: 4.2.0
+      zod-to-json-schema: 3.24.6(zod@4.2.0)
 
   internal-slot@1.1.0:
     dependencies:
@@ -13088,6 +13085,8 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.debounce@4.0.8: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -13849,14 +13848,14 @@ snapshots:
   react-instantsearch-core@7.19.0(algoliasearch@5.44.0)(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
-      ai: 5.0.93(zod@3.25.76)
+      ai: 5.0.93(zod@4.2.0)
       algoliasearch: 5.44.0
       algoliasearch-helper: 3.26.1(algoliasearch@5.44.0)
       instantsearch.js: 4.83.0(algoliasearch@5.44.0)
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod: 4.2.0
+      zod-to-json-schema: 3.24.6(zod@4.2.0)
 
   react-instantsearch-nextjs@0.4.9(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-instantsearch@7.19.0(algoliasearch@5.44.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
     dependencies:
@@ -14965,8 +14964,8 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.76):
+  zod-to-json-schema@3.24.6(zod@4.2.0):
     dependencies:
-      zod: 3.25.76
+      zod: 4.2.0
 
-  zod@3.25.76: {}
+  zod@4.2.0: {}

--- a/storefront/src/components/molecules/AddressForm/schema.ts
+++ b/storefront/src/components/molecules/AddressForm/schema.ts
@@ -15,7 +15,7 @@ export const addressSchema = z.object({
     .string()
     .nonempty("Phone number is required")
     .regex(/^\+?[0-9\s\-()]+$/, "Invalid phone number format"),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type AddressFormData = z.infer<typeof addressSchema>

--- a/vendor-panel/package.json
+++ b/vendor-panel/package.json
@@ -9,12 +9,13 @@
       "qs": ">=6.14.2",
       "@remix-run/router": "1.23.2",
       "react-router": "6.30.2",
-      "@medusajs/framework": "2.12.5",
+      "@medusajs/framework": "2.14.2",
       "lodash": ">=4.18.0",
       "nodemailer": ">=8.0.5",
       "@isaacs/brace-expansion": ">=5.0.1",
       "picomatch": ">=4.0.4",
-      "postcss": ">=8.5.10"
+      "postcss": ">=8.5.10",
+      "zod": "4.2.0"
     }
   },
   "scripts": {
@@ -67,11 +68,11 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "3.4.2",
-    "@medusajs/admin-sdk": "2.12.5",
-    "@medusajs/admin-shared": "2.12.5",
-    "@medusajs/icons": "2.12.5",
-    "@medusajs/js-sdk": "2.12.5",
-    "@medusajs/ui": "4.0.28",
+    "@medusajs/admin-sdk": "2.14.2",
+    "@medusajs/admin-shared": "2.14.2",
+    "@medusajs/icons": "2.14.2",
+    "@medusajs/js-sdk": "2.14.2",
+    "@medusajs/ui": "4.1.9",
     "@tanstack/react-query": "5.64.2",
     "@tanstack/react-table": "8.20.5",
     "@tanstack/react-virtual": "^3.8.3",
@@ -99,13 +100,13 @@
     "react-jwt": "^1.2.0",
     "react-router-dom": "^6.30.2",
     "recharts": "^2.15.1",
-    "zod": "3.22.4"
+    "zod": "^4.2.0"
   },
   "devDependencies": {
-    "@medusajs/admin-shared": "2.12.5",
-    "@medusajs/admin-vite-plugin": "2.12.5",
-    "@medusajs/types": "2.12.5",
-    "@medusajs/ui-preset": "2.12.5",
+    "@medusajs/admin-shared": "2.14.2",
+    "@medusajs/admin-vite-plugin": "2.14.2",
+    "@medusajs/types": "2.14.2",
+    "@medusajs/ui-preset": "2.14.2",
     "@types/lodash": "^4.17.20",
     "@types/node": "^20.11.15",
     "@types/react": "^18.2.79",

--- a/vendor-panel/pnpm-lock.yaml
+++ b/vendor-panel/pnpm-lock.yaml
@@ -10,12 +10,13 @@ overrides:
   qs: '>=6.14.2'
   '@remix-run/router': 1.23.2
   react-router: 6.30.2
-  '@medusajs/framework': 2.12.5
+  '@medusajs/framework': 2.14.2
   lodash: '>=4.18.0'
   nodemailer: '>=8.0.5'
   '@isaacs/brace-expansion': '>=5.0.1'
   picomatch: '>=4.0.4'
   postcss: '>=8.5.10'
+  zod: 4.2.0
 
 importers:
 
@@ -40,20 +41,20 @@ importers:
         specifier: 3.4.2
         version: 3.4.2(react-hook-form@7.49.1(react@18.3.1))
       '@medusajs/admin-sdk':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/admin-shared':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/icons':
-        specifier: 2.12.5
-        version: 2.12.5(react@18.3.1)
+        specifier: 2.14.2
+        version: 2.14.2(react@18.3.1)
       '@medusajs/js-sdk':
-        specifier: 2.12.5
-        version: 2.12.5
+        specifier: 2.14.2
+        version: 2.14.2
       '@medusajs/ui':
-        specifier: 4.0.28
-        version: 4.0.28(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+        specifier: 4.1.9
+        version: 4.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@tanstack/react-query':
         specifier: 5.64.2
         version: 5.64.2(react@18.3.1)
@@ -136,18 +137,18 @@ importers:
         specifier: ^2.15.1
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
-        specifier: 3.22.4
-        version: 3.22.4
+        specifier: 4.2.0
+        version: 4.2.0
     devDependencies:
       '@medusajs/admin-vite-plugin':
-        specifier: 2.12.5
-        version: 2.12.5(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
+        specifier: 2.14.2
+        version: 2.14.2(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
       '@medusajs/types':
-        specifier: 2.12.5
-        version: 2.12.5(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
+        specifier: 2.14.2
+        version: 2.14.2(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))
       '@medusajs/ui-preset':
-        specifier: 2.12.5
-        version: 2.12.5(tailwindcss@3.4.18)
+        specifier: 2.14.2
+        version: 2.14.2(tailwindcss@3.4.18)
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20
@@ -782,33 +783,28 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@medusajs/admin-sdk@2.12.5':
-    resolution: {integrity: sha512-KxNN/Iuu+o8TgWZHbR4RWxBNZF9bON5UWfBd2VDHvU5pdWewXuizroQSLL+QF+PCWmpxFijQy0v128XzgyHXZg==}
+  '@medusajs/admin-sdk@2.14.2':
+    resolution: {integrity: sha512-JYeV7BMGQ5VUnlJHFCjrHX7qO0skU9D0vGAbEwoJxyysqO1G6iDrAbB/KbQ+136qY71IVLvbQZ3UbtpDIMUflA==}
 
-  '@medusajs/admin-shared@2.12.5':
-    resolution: {integrity: sha512-LKO7QhMmCsvP0dGibBBjNxjwOhWnBTFYfb4y5zsejzzvrrcFhEn7dn9gg4L5XkqtgDRIuiDkEi45ng3xWPPIpQ==}
+  '@medusajs/admin-shared@2.14.2':
+    resolution: {integrity: sha512-NsYYI6aghCG6dY+jq0Qkhug7x0MVgGsZ38B+h+VO+C3jPIfwxwRafWd9ZSDioQDrRr3ua9MwQrRMjrWJLWfIgg==}
 
-  '@medusajs/admin-vite-plugin@2.12.5':
-    resolution: {integrity: sha512-gbt04lDMvclzBR52ugqid9BfI3okw2dg85Swj37EKvxhhV7788/no4MiQtBrsT1xcVms54V4HIwZ4L5jE9W5Yg==}
+  '@medusajs/admin-vite-plugin@2.14.2':
+    resolution: {integrity: sha512-NFlc8RrAI4rEnKxo0jr7/0nChGc9OqmQHcQ8IP07O6NCYVykjxUPpfIhcldmVab21HyE59yBJcuP8XBE9oV5bQ==}
     peerDependencies:
       vite: ^5.4.21
 
-  '@medusajs/icons@2.12.0':
-    resolution: {integrity: sha512-M+mKiTxSxtHOuy0VPgxIuB7y+V23ahXdhXcwpba5F+aG9N7rQ3Tty8KKuXv7M3MLbC7P9BH08E9Lm82j19yg/w==}
+  '@medusajs/icons@2.14.2':
+    resolution: {integrity: sha512-MdiX1Z3h9yMTqJ5Jmd4XC8goMzMttZJiDSPEBTzWAYpsfXn9G0Dp3bbFg2k7DiJPb4lOBzLPbw+LuwtnUCfpGA==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.2.5
 
-  '@medusajs/icons@2.12.5':
-    resolution: {integrity: sha512-aOhhT2xcIHVYBMGaNjHBCekP592xyM7N0BM9LVWohc9dk3Z5df6tHBn9D8dW7wqnvaDh0BIrAVanmaiOHJPqBg==}
-    peerDependencies:
-      react: ^18.3.1
-
-  '@medusajs/js-sdk@2.12.5':
-    resolution: {integrity: sha512-z7h1xxvx4lc1SMqOgihVAbqnZd0Yxq4u/s1JnI24e4kdr9A+lmbtajvpdD6/9gAf9HfL4qNDOJMb4rl8E+x8sQ==}
+  '@medusajs/js-sdk@2.14.2':
+    resolution: {integrity: sha512-nNpkzcQU8WhPEcXIoh7ET+1y8qSaRsAeoYtci+naCdT7U0/f4jT4vpBH1vI5E3P+sWvSO+fAVvkhVoHc0OY+bQ==}
     engines: {node: '>=20'}
 
-  '@medusajs/types@2.12.5':
-    resolution: {integrity: sha512-8VyCFX2JQIHQxbHZla+nr4kAXuJB4d0rhrcGHGvx4h0dYcZlcl4DJWfdtn6/2rvEWMQwb5NDCBzH1tfEvj1lyQ==}
+  '@medusajs/types@2.14.2':
+    resolution: {integrity: sha512-vWzzuG9hXrGMVhrwrUL+LiOi2cuvAoPRyDVdQeA7USdt7ooC+Tb6tWv6E9Sf1wFR3OoUa3S7Ft25qIXmVpV1AQ==}
     engines: {node: '>=20'}
     peerDependencies:
       ioredis: ^5.4.1
@@ -819,13 +815,13 @@ packages:
       vite:
         optional: true
 
-  '@medusajs/ui-preset@2.12.5':
-    resolution: {integrity: sha512-kcZCJijVoLWqpouEDdEvAmju+nQmal9ee5dbHEM8KeyA7SRnopwOwyjlzRDVhYhAHTFY6C1lGVWebMTwexsMAw==}
+  '@medusajs/ui-preset@2.14.2':
+    resolution: {integrity: sha512-1+0xDeV8zJkmTN+vyHQY7YFF3JW+nmRETT5pnrJQtQOALVofYO0tM3hM8W15ahg8HJV8c5hKRVpoffplB1mU3w==}
     peerDependencies:
       tailwindcss: ^3.4.3
 
-  '@medusajs/ui@4.0.28':
-    resolution: {integrity: sha512-8bmO2ajhHm69y0zbY5Flauz/4EsJlmNqILdKnHQXIFrezh3ckwYoaopUYG9xVdm/epTjGcV3IN/090LQBa9ZMw==}
+  '@medusajs/ui@4.1.9':
+    resolution: {integrity: sha512-yMG+LfPH5hgmz5b/xbVYu1e9VPjqPl8uHU9I0IuLSVDiy+fqBlYbMtc8Ojk/UNeSpD8WPrp9aoLrPD+weL6Uvw==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -3287,6 +3283,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -4219,13 +4219,10 @@ packages:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.2.0
 
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.2.0:
+    resolution: {integrity: sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==}
 
 snapshots:
 
@@ -4713,19 +4710,19 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@medusajs/admin-sdk@2.12.5':
+  '@medusajs/admin-sdk@2.14.2':
     dependencies:
-      '@medusajs/admin-shared': 2.12.5
-      zod: 3.25.76
+      '@medusajs/admin-shared': 2.14.2
+      zod: 4.2.0
 
-  '@medusajs/admin-shared@2.12.5': {}
+  '@medusajs/admin-shared@2.14.2': {}
 
-  '@medusajs/admin-vite-plugin@2.12.5(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
+  '@medusajs/admin-vite-plugin@2.14.2(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
-      '@medusajs/admin-shared': 2.12.5
+      '@medusajs/admin-shared': 2.14.2
       chokidar: 3.6.0
       fdir: 6.1.1(picomatch@4.0.4)
       magic-string: 0.30.5
@@ -4736,43 +4733,40 @@ snapshots:
       - picomatch
       - supports-color
 
-  '@medusajs/icons@2.12.0(react@18.3.1)':
+  '@medusajs/icons@2.14.2(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
-  '@medusajs/icons@2.12.5(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
-  '@medusajs/js-sdk@2.12.5':
+  '@medusajs/js-sdk@2.14.2':
     dependencies:
       fetch-event-stream: 0.1.6
       qs: 6.14.2
 
-  '@medusajs/types@2.12.5(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
+  '@medusajs/types@2.14.2(vite@5.4.21(@types/node@20.19.25)(lightningcss@1.32.0))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       vite: 5.4.21(@types/node@20.19.25)(lightningcss@1.32.0)
 
-  '@medusajs/ui-preset@2.12.5(tailwindcss@3.4.18)':
+  '@medusajs/ui-preset@2.14.2(tailwindcss@3.4.18)':
     dependencies:
       '@tailwindcss/forms': 0.5.10(tailwindcss@3.4.18)
       tailwindcss: 3.4.18
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.18)
 
-  '@medusajs/ui@4.0.28(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
+  '@medusajs/ui@4.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
-      '@medusajs/icons': 2.12.0(react@18.3.1)
+      '@medusajs/icons': 2.14.2(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table': 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 1.2.1
       copy-to-clipboard: 3.3.3
       cva: 1.0.0-beta.1(typescript@5.2.2)
+      lodash.isequal: 4.5.0
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
       radix-ui: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7328,8 +7322,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.2(jiti@1.21.7)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.2.0
+      zod-validation-error: 4.0.2(zod@4.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7733,6 +7727,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8744,10 +8740,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.2.0):
     dependencies:
-      zod: 3.25.76
+      zod: 4.2.0
 
-  zod@3.22.4: {}
-
-  zod@3.25.76: {}
+  zod@4.2.0: {}

--- a/vendor-panel/src/extensions/forms/form-extension-zone/utils.ts
+++ b/vendor-panel/src/extensions/forms/form-extension-zone/utils.ts
@@ -1,10 +1,10 @@
 import {
   ZodBoolean,
-  ZodEffects,
   ZodNull,
   ZodNullable,
   ZodNumber,
   ZodOptional,
+  ZodPipe,
   ZodString,
   ZodType,
   ZodUndefined,
@@ -47,10 +47,9 @@ export function getFieldType(type: ZodType): FormFieldType {
     return getFieldType(innerType)
   }
 
-  if (type instanceof ZodEffects) {
-    const innerType = type.innerType()
-
-    return getFieldType(innerType)
+  if (type instanceof ZodPipe) {
+    // Zod 4 represents transforms/preprocess as ZodPipe; recurse into the input schema.
+    return getFieldType(type.in as ZodType)
   }
 
   return "unsupported"

--- a/vendor-panel/src/extensions/forms/hooks.tsx
+++ b/vendor-panel/src/extensions/forms/hooks.tsx
@@ -1,11 +1,11 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { FieldValues, useForm, UseFormProps } from "react-hook-form"
-import { z, ZodEffects, ZodObject } from "zod"
+import { z } from "zod"
 
 import { ConfigField } from "../types"
 
 interface UseExtendableFormProps<
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
+  TSchema extends z.ZodType<any>,
   TContext = any,
   TData = any,
 > extends Omit<UseFormProps<z.infer<TSchema>, TContext>, "resolver"> {
@@ -20,30 +20,20 @@ function createAdditionalDataSchema(configs: ConfigField[]) {
       acc[config.name] = config.validation
       return acc
     },
-    {} as Record<string, z.ZodTypeAny>
+    {} as Record<string, z.ZodType>
   )
 }
 
 function createExtendedSchema<
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
->(baseSchema: TSchema, additionalDataSchema: Record<string, z.ZodTypeAny>) {
-  const extendedObjectSchema = z.object({
-    ...(baseSchema instanceof ZodEffects
-      ? baseSchema.innerType().shape
-      : baseSchema.shape),
-    additional_data: z.object(additionalDataSchema).optional(),
-  })
+  TSchema extends z.ZodType<any>,
+>(baseSchema: TSchema, additionalDataSchema: Record<string, z.ZodType>) {
+  const additionalData = z.object(additionalDataSchema).optional()
 
-  return baseSchema instanceof ZodEffects
-    ? baseSchema
-        .superRefine((data, ctx) => {
-          const result = extendedObjectSchema.safeParse(data)
-          if (!result.success) {
-            result.error.issues.forEach((issue) => ctx.addIssue(issue))
-          }
-        })
-        .and(extendedObjectSchema)
-    : extendedObjectSchema
+  // Zod 4 removed ZodEffects: refined/superRefined objects stay ZodObjects and
+  // transforms become ZodPipe. Intersecting the base schema with the additional_data
+  // object preserves all of the base schema's fields and refinements while adding the
+  // optional extension data, without needing to branch on the schema's internal type.
+  return z.intersection(baseSchema, z.object({ additional_data: additionalData }))
 }
 
 function createExtendedDefaultValues<TData>(
@@ -66,7 +56,7 @@ function createExtendedDefaultValues<TData>(
 }
 
 export const useExtendableForm = <
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
+  TSchema extends z.ZodType<any>,
   TContext = any,
   TTransformedValues extends FieldValues | undefined = undefined,
 >({

--- a/vendor-panel/src/extensions/types.ts
+++ b/vendor-panel/src/extensions/types.ts
@@ -8,7 +8,7 @@ import {
 } from "@medusajs/admin-shared"
 import { ComponentType } from "react"
 import { LoaderFunction } from "react-router-dom"
-import { ZodFirstPartySchemaTypes } from "zod"
+import { ZodType } from "zod"
 
 export type RouteExtension = {
   Component: ComponentType
@@ -36,7 +36,7 @@ export type DisplayExtension = {
 }
 
 export type FormFieldExtension = {
-  validation: ZodFirstPartySchemaTypes
+  validation: ZodType
   Component?: ComponentType<any>
   label?: string
   description?: string
@@ -51,7 +51,7 @@ export type FormExtension = {
 
 export type ConfigFieldExtension = {
   defaultValue: ((data: any) => any) | any
-  validation: ZodFirstPartySchemaTypes
+  validation: ZodType
 }
 
 export type ConfigExtension = {

--- a/vendor-panel/src/lib/validation.ts
+++ b/vendor-panel/src/lib/validation.ts
@@ -90,7 +90,7 @@ export function partialFormValidation<TForm extends FieldValues>(
   const validationResult = schema.safeParse(values)
 
   if (!validationResult.success) {
-    validationResult.error.errors.forEach(({ path, message, code }) => {
+    validationResult.error.issues.forEach(({ path, message, code }) => {
       form.setError(path.join(".") as any, {
         type: code,
         message,

--- a/vendor-panel/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
+++ b/vendor-panel/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
@@ -176,7 +176,7 @@ export function CreateShippingOptionsForm({
       })
 
       if (!result.success) {
-        const [firstError, ...rest] = result.error.errors
+        const [firstError, ...rest] = result.error.issues
 
         for (const error of rest) {
           const _path = error.path.join(".") as keyof CreateShippingOptionSchema

--- a/vendor-panel/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-create-form.tsx
+++ b/vendor-panel/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-create-form.tsx
@@ -131,7 +131,7 @@ export const PriceListCreateForm = ({
     const validationResult = schema.safeParse(values)
 
     if (!validationResult.success) {
-      validationResult.error.errors.forEach(({ path, message, code }) => {
+      validationResult.error.issues.forEach(({ path, message, code }) => {
         form.setError(path.join(".") as keyof PricingCreateSchemaType, {
           type: code,
           message,

--- a/vendor-panel/src/routes/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-form.tsx
+++ b/vendor-panel/src/routes/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-form.tsx
@@ -102,7 +102,7 @@ export const PriceListPricesAddForm = ({
     const validationResult = schema.safeParse(values)
 
     if (!validationResult.success) {
-      validationResult.error.errors.forEach(({ path, message, code }) => {
+      validationResult.error.issues.forEach(({ path, message, code }) => {
         form.setError(path.join(".") as keyof PriceListPricesAddSchema, {
           type: code,
           message,

--- a/vendor-panel/src/routes/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
+++ b/vendor-panel/src/routes/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
@@ -38,7 +38,7 @@ const ProductEditVariantSchema = z.object({
   mid_code: z.string().optional(),
   hs_code: z.string().optional(),
   origin_country: z.string().optional(),
-  options: z.record(z.string()),
+  options: z.record(z.string(), z.string()),
 })
 
 export const ProductEditVariantForm = ({

--- a/vendor-panel/src/routes/products/product-create-variant/components/create-product-variant-form/constants.ts
+++ b/vendor-panel/src/routes/products/product-create-variant/components/create-product-variant-form/constants.ts
@@ -8,7 +8,7 @@ export const CreateProductVariantSchema = z.object({
   manage_inventory: z.boolean().optional(),
   allow_backorder: z.boolean().optional(),
   inventory_kit: z.boolean().optional(),
-  options: z.record(z.string()),
+  options: z.record(z.string(), z.string()),
   prices: zod
     .record(zod.string(), zod.string().or(zod.number()).optional())
     .optional(),

--- a/vendor-panel/src/types/order.ts
+++ b/vendor-panel/src/types/order.ts
@@ -102,9 +102,9 @@ export interface ExtendedAdminOrderFulfillment
   }
 }
 
-export interface ExtendedAdminOrderChange extends HttpTypes.AdminOrderChange {
-  created_by?: string | null
-}
+// AdminOrderChange already provides `created_by` (required) as of Medusa 2.14, so the
+// previous optional override is no longer compatible; alias to the base type.
+export type ExtendedAdminOrderChange = HttpTypes.AdminOrderChange
 export interface OrderCommission {
   commission: {
     commission_value: {


### PR DESCRIPTION
Follow-up to the backend Medusa 2.12.5 → 2.14.2 + zod 4 upgrade, covering the two items
that were deferred from that change. **Stacked on `claude/v2-rollout-readiness-xZ5vB`**
(the backend-upgrade branch) — review/merge that first, or retarget to `main` once it lands.

## Part A — Panel version parity (admin-panel, vendor-panel, storefront)

Brings all three panel apps to parity with the upgraded backend: `@medusajs/* 2.14.2`,
`@medusajs/ui 4.1.9`, and `zod 4.2.0` (single version pinned via a per-app pnpm override,
since `@medusajs/admin-sdk@2.14` depends on zod 4.2.0).

- **zod 4 code migration** (same transforms as the backend): `z.record(value)` →
  `z.record(z.string(), value)`; `ZodError.errors` → `.issues`; form infrastructure updated
  for zod 4 removing `ZodEffects` / `ZodFirstPartySchemaTypes` / `ZodTypeAny` and modelling
  transforms as `ZodPipe` (cast `unwrap()` results to `ZodType`, recurse into `ZodPipe.in`).
- **Medusa 2.14 type adjustments** (admin-panel): `AdminPricePreferenceParams` →
  `AdminGetPricePreferenceParams`; `customer.listAddresses(id)` no longer takes a query arg;
  batch inventory payload `create/update/delete` are now optional (typed as `NonNullable`
  arrays so `push()` is valid); targeted casts for `AdminInventoryItem`/`InventoryItemDTO`,
  `AdminFile` media, and zod-4 enum inference in promotion default values.
- storefront is the lightest (one `z.record` + dep bumps).

**Verified per app:** `pnpm typecheck` (0/0/0), builds (admin ✓, vendor ✓, storefront
`next build` → ✓ Compiled successfully), and `pnpm lint` (0/0/0, vendor at strict
`--max-warnings 0`).

## Part B — Deep authenticated mercurjs vendor-flow tests + zod-4 guard patch (backend)

Confidence net for the `@mercurjs/*` runtime under Medusa 2.14 + zod 4.

- **`scripts/patch-mercurjs.js`**: extended the postinstall patcher to rewrite
  `result.error.errors` → `result.error.issues` in the two compiled `vendor-promotions`
  path-param guards (zod 4 renamed `ZodError.errors`), so invalid-`rule_type` 400 responses
  no longer drop their `details` array. Idempotent; applied to every b2c-core copy.
- **`integration-tests/http/helpers/seller-auth.ts`**: a real authenticated-seller harness —
  register (emailpass) → `createSellerWorkflow` (store_status defaults ACTIVE) → Medusa-issued
  login/refresh token (with a signed-token fallback) — plus `ensureStoreInfra()` to seed a
  default sales channel + shipping profile.
- **`vendor-authenticated-flows.spec.ts`**: authenticated smoke coverage for `sellers/me`,
  `orders` (seller-filter middleware), `statistics`, `reviews`, and the product mutation auth
  path. All requests run in one test to avoid the in-app server's idle keep-alive socket drops.
- **`vendor-promotions-zod4-guard.spec.ts`**: regression test proving the patched guards return
  a populated `details` array (fails pre-patch).

**Both suites pass** (`Test Suites: 2 passed`).

### Known follow-up
Full product *creation* via `createProductsWorkflow` returns an opaque 500 in a bare test DB
even with store infra seeded (a mercurjs product-hook prerequisite — not an auth or zod-4
regression). The spec verifies the mutation is seller-authorized and checks publish only if
creation succeeds; reproducing the full create path is left as a follow-up.

https://claude.ai/code/session_01FffhAruV557S9Yc8EsmZah

---
_Generated by [Claude Code](https://claude.ai/code/session_01FffhAruV557S9Yc8EsmZah)_