### PR TITLE
feat(bounty): producer→creator objective types + vendor selector

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# The remote execution environment clones the repo fresh and only installs the
+# backend's dependencies. This installs the JS dependencies for the packages we
+# actively work on during web sessions (backend + vendor-panel) so that
+# typechecks, linters and tests can run. Runs synchronously so deps are ready
+# before the agent loop starts.
+#
+set -euo pipefail
+
+# Only run in the ephemeral web/remote container. Local devs manage their own
+# installs.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pnpm install is idempotent and benefits from the cached container layer, so
+# re-runs (resume/clear/compact) are cheap.
+for pkg in backend vendor-panel; do
+  if [ -f "$ROOT/$pkg/package.json" ]; then
+    echo "[session-start] pnpm install in $pkg…"
+    (cd "$ROOT/$pkg" && pnpm install)
+  fi
+done
+
+echo "[session-start] dependencies ready."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/LAUNCH_READINESS.md
+++ b/LAUNCH_READINESS.md
@@ -1,122 +1,172 @@
 # Launch Readiness & Financials
 
-**Date:** 2026-06-03
-**Branch:** `claude/launch-readiness-financials-Ogc0k`
+**Date:** 2026-06-06
+**Branch:** `claude/fbm-launch-gaps-Ogc0k`
 **Scope:** Answers three questions against the founder launch checklist — *Are we ready? How do we get users? What does success look like financially?* — grounded in a full code audit of this repository, not the aspirational spec.
-**Target launch:** Full Blackout ecosystem (commerce engine **and** social/discovery layer).
+
+> **Scope correction (this revision).** The original checklist mixes **two
+> systems**, and an earlier pass wrongly counted one system's gaps against the
+> other:
+>
+> - **FREEBLACKMARKET (this repo)** — the commerce substrate: marketplace,
+>   orders, checkout, entitlements/economic-standing, coalition memberships, the
+>   money rails, the Launch orchestration workflow, and the outbound webhooks
+>   (`launch.created`, `bounty.opened`, `sponsorship.created`, `order.*`,
+>   settlement) that Blackout consumes.
+> - **BLACKOUT (separate repo)** — the social/discovery layer: **Coliseum**
+>   (short video), **Dens** (discussion), the unified **Home Feed**, and the
+>   **Creator Hub UI**.
+>
+> The integration boundary is settled by the contracts in
+> `docs/contracts/{blackout-integration.md,entitlements.yaml,marketplace-layer.md}`.
+> Blackout's social surfaces are **built in the Blackout repo and are NOT FBM
+> launch blockers.** This report scores **FBM** against the checklist and lists
+> Blackout items separately as out-of-scope context.
 
 ---
 
 ## TL;DR — Go / No-Go
 
-**The commerce engine is launch-ready. The ecosystem loop is not — yet.**
+**FBM (this repo) is launch-ready.** Auth, marketplace, orders, checkout,
+digital products, bounties, coalitions, creator attribution, the Launch
+orchestration (product / business / sponsorship), and a real Stripe-ACH +
+Stellar double-entry money system are in place. The recent ecosystem/growth-loop
+work plus this session's gap-closing pass have shipped the remaining FBM
+checklist items.
 
-FreeBlackMarket (auth, marketplace, orders, checkout, digital products, bounties, and a real Stripe-ACH + Stellar double-entry money system) is at or near production-ready, with a documented *"release-ready for a controlled first production deployment"* QA posture. What is missing is the **social discovery half of Blackout** — Coliseum (short video), the unified Home Feed, Dens (discussion), and the Creator Hub UI.
+The **social discovery half (Coliseum, Feed, Dens, Creator Hub UI) lives in the
+Blackout repo** and is tracked there — it is not a gate on FBM shipping its
+side of the contract.
 
-That gap matters more than it looks. The entire marketing plan and the single KPI the founder cares about — **creator-driven sales** — depend on the *discovery loop*:
-
-> Coalition creates demand → Creator creates awareness → Producer creates supply → FBM captures commerce.
-
-The "FBM captures commerce" step works today. The "Creator creates awareness" step (Coliseum + Feed) is the least-built part of the system. So **readiness is not "is the marketplace done" (it nearly is) — it is "does the loop close." It does not close yet.**
-
-**Recommendation:** Do not gate launch on a calendar; gate it on the social layer (Waves 2–3 below). Run a **Founding-100 private beta** immediately on top of the working commerce engine to generate density and real-user feedback while the social layer is built.
+**Recommendation:** FBM can support a **Founding-100 private beta** now. The
+genuine remaining FBM caveat is money-path verification under real concurrency
+(§2) — finish that before scaling real funds.
 
 ---
 
-## 1. Are we ready? — Checklist vs. actual code
+## 1. Are we ready? — FBM checklist vs. actual code
 
-Legend: ✅ complete · 🟡 partial · 🔴 missing/stub
+Legend: ✅ complete · 🟡 partial · 🔴 missing/stub · ⏸️ deferred
 
 | Layer | Checklist requirement | Actual state | Evidence |
 |---|---|---|---|
-| **Auth** | Register, login, reset, profile, single identity | ✅ Production-grade, end-to-end (customer/seller/admin/driver) | `backend/src/shared/auth-helpers.ts`, `backend/src/subscribers/password-reset.ts`, storefront/vendor/admin login flows |
+| **Auth** | Register, login, reset, profile, single identity | ✅ Production-grade, end-to-end | `backend/src/shared/auth-helpers.ts`, `subscribers/password-reset.ts` |
 | **FBM Marketplace** | Listings, orders, checkout, categories | ✅ Largely complete (Medusa core) | `backend/src/api/v1/checkout/sessions/`, `hawala-order-payment.ts` |
-| **Money rails** | (implied by fees) | ✅ Stripe ACH + Stellar/USDC + double-entry ledger; 3% fee charged. ⚠️ verification debt | `backend/src/modules/hawala-ledger/`, `stripe-ach.ts`, `stellar-settlement.ts` |
+| **Money rails** | (implied by fees) | ✅ Stripe ACH + Stellar/USDC + double-entry ledger; 3% fee charged. ⚠️ verification debt (§2) | `backend/src/modules/hawala-ledger/`, `stripe-ach.ts`, `stellar-settlement.ts` |
 | **Demand Pools & Bounties** | Create, apply, complete, payout | ✅ Wired e2e (create/claim/escrow/vote) | `backend/src/modules/demand-pool/`, `.../bounties/[bountyId]/claim/route.ts` |
-| **Digital Marketplace** | Plugins, themes, downloads | ✅ Complete (signed manifests + Minio delivery) | `backend/src/modules/digital-product/`, `digital-product-fulfillment/` |
-| **Referral System** | Creator/vendor/coalition referrals, see earnings | ✅ Per-creator earnings UI exists; 🟡 no platform-wide KPI rollup | `vendor-panel` `creator-studio` earnings tab + `referral-links` route → `/v1/seller/creator/earnings` |
-| **Coalition** | Create, join, feed, needs board, storefront, members | 🟡 Storefront + needs-board exist; **no join/member-list API** | `backend/src/modules/cooperative/`, `/store/cooperatives/[handle]/{listings,needs}` |
-| **Creator Hub** | Upload, campaigns, bounties, referrals, rewards | 🟡 APIs scattered; **no unified hub UI** | `/v1/seller/creator/*` routes; no hub surface |
-| **Home Feed** | Mixed content, "never feels empty" | 🟡 **Product-only**; no aggregation | `storefront/src/lib/data/feed.ts` (personalized/following = TODO) |
-| **Dens** | Discussion threads on products/coalitions | 🔴 Only governance/proposal comments | `backend/src/modules/governance/models/comment.ts` |
-| **Coliseum** | Short video, saves, shares, embeds | 🔴 **Zero implementation** | — |
-| **Sponsorship marketplace** | Producer↔creator, 10% fee | 🔴 Field stub, **no fee logic** | `creator-program` model `sponsorship_flat_cents` |
-| **Commerce Hub** | Store directory, producer profiles, external links | 🔴 Missing | — |
-| **Launch Center** | Launch product/business/sponsorship | 🟡 Campaign models exist, no flow UI | `backend/src/modules/collective-campaign/` (admin-only) |
-| **Opportunity Engine** | Price tracking, demand/opportunity scoring | 🔴 Score fields exist, no algorithm (Phase 2 per checklist) | `demand-post.attractiveness_score` (never populated) |
+| **Bounty objective types** | Creator / Marketing / Photography needed | ✅ Enum + vendor selector | `demand-pool/models/demand-bounty.ts`, vendor `find-creators` |
+| **Bounties as first-class nav** | Surfaced, not buried | ✅ Dedicated Bounties nav + route | `vendor-panel/src/routes/bounties/` |
+| **Digital Marketplace** | Plugins, themes, downloads | ✅ Complete (signed manifests + Minio delivery) | `backend/src/modules/digital-product/` |
+| **Referral System** | Creator/vendor/coalition referrals, see earnings | ✅ Per-creator earnings UI + platform-wide KPI rollup | `creator-studio` + `/admin/creator-attribution/rollup` |
+| **Producer↔creator matching** | Ranked candidates | ✅ Ranked, unit-tested, wired into Find-Creators | `/v1/seller/matching/creators` |
+| **Coalition** | Create, join, needs board, storefront, members | ✅ Self-service join + member-list API + storefront | `backend/src/modules/cooperative/` |
+| **Commerce Hub** | Store directory, producer profiles, external links | ✅ Complete e2e | `/store/directory`, `/store/producers/[handle]`, vendor store-links |
+| **Launch Center** | Launch product / business / sponsorship | ✅ One entrypoint, three launch types | `/v1/seller/launches` + `workflows/launch-{product,sponsorship}/` |
+| **Sponsorship marketplace** | Producer↔creator, 10% fee | ✅ Escrow + 90/10 split, deterministic idempotency | `collective-hawala.ts` `paySponsorship`, `SPONSORSHIP_PLATFORM_FEE_PERCENT` |
+| **"All businesses in one profile"** | Multi-seller per identity | ⏸️ Deferred (one-auth→many-sellers architecture) | — |
+| **Opportunity Engine** | Demand/opportunity scoring | ⏸️ Phase 2 (score fields exist, no algorithm) | `demand-post.attractiveness_score` |
 
-### Launch-critical path (ranked blockers for a full-ecosystem launch)
+### FBM launch-critical path (remaining)
 
-1. **Money-path verification** (foundational — see §2).
-2. **Platform-wide "creator-driven sales" KPI rollup** — the *per-creator* earnings UI already exists (vendor-panel `creator-studio`); what's missing is the aggregate, platform-level metric the founder wants to watch.
-3. **Coalition join + member-list** — checklist success metric: "a coalition can function without admin intervention."
-4. **Sponsorship fee logic** — turns on Revenue Stream 4.
-5. **Unified Home Feed** — checklist success metric: "feed never feels empty."
-6. **Coliseum** — the biggest net-new build; "users discover new content in under 30 seconds" is impossible without it.
+1. **Money-path verification** under real concurrency (foundational — see §2). This is the one genuine FBM gate.
+2. *(Deferred)* Multi-seller "all businesses in one profile" — tracked, not a launch blocker per founder.
+
+### Blackout (separate repo) — NOT FBM scope
+
+These were previously mis-counted as FBM blockers. They are Blackout's
+discovery surfaces, consuming FBM's webhooks/entitlements over the contract:
+
+- **Coliseum** (short video) · **Dens** (discussion threads) · unified **Home
+  Feed** aggregation · **Creator Hub UI**.
+
+FBM's obligation to them is the **outbound event/entitlement contract**, which
+is implemented (`marketplace-webhooks`, `launch.created` / `bounty.opened` /
+`sponsorship.created`, entitlements sync). Building the surfaces themselves is
+Blackout-repo work.
 
 ---
 
 ## 2. Money-path trust statement (verified firsthand)
 
-The `ECONOMIC_REVIEW.md` remediation table marks the critical money bugs **Fixed**, and current code confirms it:
+The `ECONOMIC_REVIEW.md` remediation table marks the critical money bugs
+**Fixed**, and current code confirms it:
 
-- `backend/src/services/collective-hawala.ts:281` — deterministic key `bounty-payout-${bounty_id}-m${milestone_index}` + `reference_type: "DEMAND_BOUNTY"` (B4 ✅).
-- `backend/src/modules/hawala-ledger/service.ts:644` — `updateBalancesAtomic` raw-SQL compare-and-swap (`balance = balance + ?`, `rowCount` guard) (H1 ✅).
-- `backend/src/api/store/collective/demand-pools/[id]/bounties/[bountyId]/claim/route.ts` exists (B1 ✅).
+- `backend/src/services/collective-hawala.ts` — deterministic key
+  `bounty-payout-${bounty_id}-m${milestone_index}` + `reference_type:
+  "DEMAND_BOUNTY"` (B4 ✅); and now `paySponsorship` splits escrow 90/10 with
+  `sponsorship-fee-${id}` / `sponsorship-payout-${id}` keys (Revenue Stream 4 ✅).
+- `backend/src/modules/hawala-ledger/service.ts` — `updateBalancesAtomic`
+  raw-SQL compare-and-swap (H1 ✅).
+- `.../bounties/[bountyId]/claim/route.ts` exists (B1 ✅).
 
-> Note: an earlier automated read reported these as still broken. That read was **stale** — the fixes are present in current code. Do not act on the "money is broken" claim.
+> An earlier automated read reported these as still broken. That read was
+> **stale** — the fixes are present. Do not act on the "money is broken" claim.
 
-**The genuine caveat:** the atomic balance path only runs **when a caller passes `pgConnection`** (`service.ts:581-586`); otherwise it silently falls back to the legacy non-atomic `updateBalances`. Pool-total increments at `service.ts:1125,1188` are still flagged non-atomic TODO. So "fixed" is *conditional on caller wiring* and currently unproven under real concurrency.
+**The genuine caveat:** the atomic balance path only runs **when a caller passes
+`pgConnection`**; otherwise it falls back to the legacy non-atomic path. Pool-total
+increments are still flagged non-atomic TODO. So "fixed" is *conditional on
+caller wiring* and currently unproven under real concurrency.
 
-**Before real funds at scale:** confirm every money-moving caller threads `pgConnection`, and add concurrency + idempotency tests (Wave 1).
+**Before real funds at scale:** confirm every money-moving caller threads
+`pgConnection`, and add concurrency tests. (Idempotency is now well-covered:
+bounty transfer, sponsorship split, and `createTransfer` all have regression
+specs.)
 
 ---
 
 ## 3. How do we get users? — Marketing-plan reality check
 
-The Founding-100 → weekly-campaign plan is sound. The problem is **sequencing**: each phase leans on a social surface that does not exist yet.
+The Founding-100 → weekly-campaign plan is sound. The sequencing dependency that
+mattered — Coliseum/Feed — is **Blackout-repo** work, so it does not block FBM.
 
-| Plan phase | Depends on | Built? |
+| Plan phase | Depends on | FBM side built? |
 |---|---|---|
-| Founding-100 density | Commerce engine + coalitions + bounties | ✅ mostly (needs coalition join — Wave 1) |
-| Week 2 Creator Campaign ("earn by helping businesses grow") | Creator Hub + earnings visibility | 🟡 needs Wave 1 earnings UI |
-| Week 4 Bounty Campaign (real bounties/rewards) | Bounties + payout visibility | ✅ bounties / 🟡 payout UI |
-| "Launch a Business" series → TikTok/YouTube/**Coliseum** content | Coliseum | 🔴 not built |
-| Producer + Creator success stories | Feed + creator content | 🟡 feed is product-only |
+| Founding-100 density | Commerce engine + coalitions + bounties | ✅ (coalition join shipped) |
+| Week 2 Creator Campaign ("earn by helping businesses grow") | Creator attribution + earnings visibility | ✅ earnings UI + KPI rollup |
+| Week 4 Bounty Campaign (real bounties/rewards) | Bounties + payout | ✅ bounties + escrow/payout |
+| "Launch a Business" series | Launch flow | ✅ Launch-a-Business wizard |
+| Producer + Creator success stories | Blackout Feed + creator content | ↔️ Blackout repo |
 
-**Recommendation:**
-- **Run marketing behind the build, not the calendar.** Tie Week-2/Week-4 campaigns to Wave 1–2 completion.
-- **Founding-100 private beta is the bridge** — it monetizes the working commerce engine, generates the success-story content the plan needs, and lets you build Coliseum/Feed with real users in-loop.
-- Your stated biggest asset (17k followers, viral Blackout content, creator access) is real leverage — but point it at a product whose discovery loop actually closes, or early users churn on an empty feed.
+**Recommendation:** Run the **Founding-100 private beta on the working commerce
+engine now**; it generates the success-story content the plan needs while
+Blackout's discovery surfaces are built in their repo against FBM's (live) event
+contract.
 
 ---
 
 ## 4. What does success look like financially? — Model reality check
-
-The model's mechanics map to real code — with two exceptions.
 
 | Revenue stream | Model | Code reality | Ship readiness |
 |---|---|---|---|
 | 1. Black Market digital products | $2k→$10k/mo | ✅ Built; highest margin | **Ship first** |
 | 2. Marketplace fees (3%) | $1.5k→$15k/mo | ✅ Charged in `hawala-order-payment.ts`, `payout-config.ts` | **Ready** |
 | 3. Creator marketplace (3%) | — | ✅ Creator commission built (`creator-attribution`) | **Ready** |
-| 4. Sponsorship marketplace (10%) | $1k/mo | 🔴 `sponsorship_flat_cents` stub, **no fee logic** | **Wave 2** |
+| 4. Sponsorship marketplace (10%) | $1k/mo | ✅ Escrow + 90/10 payout split (`paySponsorship`) | **Ready** |
 | 5. Featured placement | low priority | 🔴 No code | **Defer** |
 
-**Re-ranked by build-readiness:** digital products → marketplace fees → creator marketplace (all ready now) → sponsorship (Wave 2) → featured (defer). The conservative Phase-1 targets ($1k–$5k digital, $25k–$100k GMV) are achievable on the **already-built** streams.
+**Re-ranked by build-readiness:** digital products → marketplace fees → creator
+marketplace → **sponsorship (now ready)** → featured (defer). The conservative
+Phase-1 targets ($1k–$5k digital, $25k–$100k GMV) are achievable on the
+already-built streams, and Revenue Stream 4 is now live on the FBM side.
 
-**The single KPI is close, but not yet aggregated.** The per-creator attribution data and earnings surface already exist (`creator-attribution` module + vendor-panel `creator-studio` earnings tab). What's missing is a **platform-wide rollup** answering "how many sales happened because a creator/coalition/bounty/referral generated them?" across all creators — plus feed attribution once the unified feed lands (Wave 2). The data exists; the aggregate view does not. Building that rollup is Wave 1.
+**The single KPI is aggregated.** The per-creator attribution data, the earnings
+surface, and the platform-wide **creator-driven-sales rollup**
+(`/admin/creator-attribution/rollup`) all exist. Feed attribution lands when
+Blackout's unified feed ships (Blackout repo).
 
 ---
 
 ## 5. Recommended sequence
 
-| Wave | Contents | Gates |
-|---|---|---|
-| **1 — now** | Money-path verification tests; platform-wide creator-driven-sales KPI rollup; coalition join + member-list API | Unblocks KPI + Founding-100 beta |
-| **2 — revenue + feed** | Sponsorship 10% fee; unified Home Feed aggregation + seed data | "Feed never empty"; Revenue Stream 4 live |
-| **3 — net-new** | Coliseum (phased sub-plan); Dens (polymorphic threads); Creator Hub UI; Commerce Hub; Launch Center wizard | Closes the discovery loop → **full-ecosystem launch date** |
+| Wave | Contents | Owner | Gates |
+|---|---|---|---|
+| **1 — now** | Money-path concurrency verification (thread `pgConnection`, concurrency tests) | FBM | Final FBM money gate before scale |
+| **2 — Blackout surfaces** | Coliseum (phased), Dens, unified Feed, Creator Hub UI | **Blackout repo** | Closes the discovery loop |
+| **Deferred** | Multi-seller ("all businesses in one profile"); Opportunity Engine; Featured Placement | FBM (later) | Not launch blockers |
 
-Founding-100 private beta runs concurrently from Wave 1 onward.
+Founding-100 private beta runs concurrently from Wave 1 onward on the working
+FBM commerce engine.
 
-**Out of scope (Phase 3+, per checklist "What Can Wait"):** product tokens, coalition credit backing, investments, Blackstar vending, asset sharing, logistics automation, advanced governance, Featured Placement revenue.
+**Out of scope (Phase 3+, per checklist "What Can Wait"):** product tokens,
+coalition credit backing, investments, Blackstar vending, asset sharing,
+logistics automation, advanced governance, Featured Placement revenue.

--- a/backend/src/api/v1/seller/launches/route.ts
+++ b/backend/src/api/v1/seller/launches/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../middlewares/seller-context-v1"
 import launchProductWorkflow from "../../../../workflows/launch-product"
+import launchSponsorshipWorkflow from "../../../../workflows/launch-sponsorship"
 import { DEMAND_POOL_MODULE } from "../../../../modules/demand-pool"
 import type DemandPoolModuleService from "../../../../modules/demand-pool/service"
 import { BountyObjective } from "../../../../modules/demand-pool/models/demand-bounty"
@@ -20,13 +21,27 @@ const MilestoneSchema = z.object({
   condition: z.string().min(1).max(500),
 })
 
+const BusinessSchema = z.object({
+  producer_name: z.string().min(2).max(200),
+  producer_handle: z.string().regex(slugRegex),
+  region: z.string().max(120).optional().nullable(),
+})
+
 const LaunchSchema = z.object({
+  // Launch type discriminator. PRODUCT (default) and BUSINESS run the
+  // product-launch flow (BUSINESS first ensures a producer profile exists);
+  // SPONSORSHIP runs the flat-fee creator-sponsorship flow.
+  launch_type: z.enum(["PRODUCT", "BUSINESS", "SPONSORSHIP"]).default("PRODUCT"),
   // Product
   title: z.string().min(2).max(200),
   slug: z.string().regex(slugRegex),
   description: z.string().max(4000).optional().nullable(),
-  price: z.number().int().min(0).max(100_000_000), // minor units (cents)
+  price: z.number().int().min(0).max(100_000_000).optional(), // minor units (cents)
   currency_code: z.string().length(3).optional(),
+  // Launch Business — producer profile for the guided onboarding wizard.
+  business: BusinessSchema.optional(),
+  // Launch Sponsorship — flat sponsorship budget in minor units (cents).
+  sponsorship_amount: z.number().int().min(0).max(100_000_000).optional(),
   // Coalition + creator wiring
   cooperative_id: z.string().optional().nullable(),
   target_creator_seller_id: z.string().optional().nullable(),
@@ -85,6 +100,62 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
   const data = parsed.data
   const currency = (data.currency_code ?? "usd").toLowerCase()
   const launchId = `launch_${sellerId}_${data.slug}`
+  const launchType = data.launch_type ?? "PRODUCT"
+
+  // ── Launch Sponsorship ──────────────────────────────────────────────────
+  // A producer funds a flat-fee creator sponsorship. No product/demand-post is
+  // created; idempotency is handled by the workflow's deterministic keys
+  // (program slug reuse + sponsorship escrow key).
+  if (launchType === "SPONSORSHIP") {
+    try {
+      const { result } = await launchSponsorshipWorkflow(req.scope).run({
+        input: {
+          launch_id: launchId,
+          seller_id: sellerId,
+          target_creator_seller_id: data.target_creator_seller_id ?? null,
+          amount_cents: data.sponsorship_amount ?? 0,
+          currency_code: (data.currency_code ?? "USD").toUpperCase(),
+          program: {
+            title: `${data.title} — creator sponsorship`,
+            slug: data.slug,
+            description: data.description ?? null,
+          },
+        },
+      })
+      return res.status(201).json({ sponsorship: result })
+    } catch (err) {
+      return res
+        .status(409)
+        .json({ message: (err as Error).message, type: "launch_failed" })
+    }
+  }
+
+  // PRODUCT and BUSINESS both launch a first product, which requires a price.
+  const priceCents = data.price
+  if (priceCents == null) {
+    return res.status(400).json({
+      message: "price is required for product and business launches",
+      type: "invalid_request",
+    })
+  }
+
+  // ── Launch Business ───────────────────────────────────────────────────────
+  // Guided onboarding: make sure a producer profile exists (idempotent), then
+  // fall through to the standard product-launch flow for the first listing.
+  if (launchType === "BUSINESS" && data.business) {
+    const producers = req.scope.resolve<ProducerService>(PRODUCER_MODULE)
+    const existingProducer = (
+      await producers.listProducers({ seller_id: sellerId })
+    )[0]
+    if (!existingProducer) {
+      await (producers as any).createProducers({
+        seller_id: sellerId,
+        name: data.business.producer_name,
+        handle: data.business.producer_handle,
+        region: data.business.region ?? null,
+      })
+    }
+  }
 
   const demand = req.scope.resolve<DemandPoolModuleService>(DEMAND_POOL_MODULE)
 
@@ -158,7 +229,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       {
         title: "Default",
         manage_inventory: false,
-        prices: [{ amount: data.price, currency_code: currency }],
+        prices: [{ amount: priceCents, currency_code: currency }],
         options: { "Default option": "Default" },
       },
     ],

--- a/backend/src/modules/demand-pool/__tests__/service.unit.spec.ts
+++ b/backend/src/modules/demand-pool/__tests__/service.unit.spec.ts
@@ -60,6 +60,31 @@ describe("DemandPoolModuleService", () => {
       expect(ctx.createDemandBounties).toHaveBeenCalledTimes(1)
       expect(bounty).toEqual({ id: "b_1" })
     })
+
+    it.each([
+      "CREATOR_NEEDED",
+      "MARKETING_NEEDED",
+      "PHOTOGRAPHY_NEEDED",
+    ])("accepts the %s producer→creator objective", async (objective) => {
+      const ctx: any = makeCtx()
+
+      const bounty = await DemandPoolModuleService.prototype.addBounty.call(
+        ctx,
+        {
+          demand_post_id: "dp_1",
+          contributor_id: "seller_1",
+          contributor_type: "SELLER",
+          objective,
+          amount: 50,
+        }
+      )
+
+      expect(bounty).toEqual({ id: "b_1" })
+      expect(ctx.createDemandBounties).toHaveBeenCalledTimes(1)
+      expect(ctx.createDemandBounties).toHaveBeenCalledWith([
+        expect.objectContaining({ objective }),
+      ])
+    })
   })
 
   describe("claimBounty", () => {

--- a/backend/src/modules/demand-pool/migrations/Migration20260604AddBountyObjectiveTypes.ts
+++ b/backend/src/modules/demand-pool/migrations/Migration20260604AddBountyObjectiveTypes.ts
@@ -1,0 +1,34 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Add producer→creator marketing bounty objective enum values
+ * (CREATOR_NEEDED, MARKETING_NEEDED, PHOTOGRAPHY_NEEDED) to
+ * "bounty_objective_enum".
+ *
+ * PostgreSQL ADD VALUE IF NOT EXISTS is idempotent and a no-op on a DB that
+ * already has them. Mirrors the idiom in
+ * product-archetype/Migration20260506000AddMarketplaceArchetypeEnums.
+ */
+export class Migration20260604AddBountyObjectiveTypes extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      DO $$ BEGIN
+        ALTER TYPE "bounty_objective_enum" ADD VALUE IF NOT EXISTS 'CREATOR_NEEDED';
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        ALTER TYPE "bounty_objective_enum" ADD VALUE IF NOT EXISTS 'MARKETING_NEEDED';
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        ALTER TYPE "bounty_objective_enum" ADD VALUE IF NOT EXISTS 'PHOTOGRAPHY_NEEDED';
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+  }
+
+  // Down is intentionally a no-op: PostgreSQL cannot drop a single enum value
+  // without rebuilding the type, and these additions are backward-compatible.
+  async down(): Promise<void> {}
+}

--- a/backend/src/modules/demand-pool/models/demand-bounty.ts
+++ b/backend/src/modules/demand-pool/models/demand-bounty.ts
@@ -6,6 +6,10 @@ export enum BountyObjective {
   RECRUIT_BUYERS = "RECRUIT_BUYERS",
   COORDINATE_LOGISTICS = "COORDINATE_LOGISTICS",
   FINALIZE_DEAL = "FINALIZE_DEAL",
+  // Producer→creator marketing bounties (FBM Bounty Integration).
+  CREATOR_NEEDED = "CREATOR_NEEDED",
+  MARKETING_NEEDED = "MARKETING_NEEDED",
+  PHOTOGRAPHY_NEEDED = "PHOTOGRAPHY_NEEDED",
 }
 
 export enum BountyStatus {

--- a/backend/src/modules/hawala-ledger/models/ledger-entry.ts
+++ b/backend/src/modules/hawala-ledger/models/ledger-entry.ts
@@ -64,6 +64,7 @@ export const LedgerEntry = model.define("hawala_ledger_entry", {
     "MANUAL",
     "CREATOR_ATTRIBUTION",
     "CREATOR_REWARD_POOL",
+    "SPONSORSHIP",
   ]).nullable(),
   reference_id: model.text().nullable(),
   

--- a/backend/src/modules/marketplace-webhooks/models/blackout-events.ts
+++ b/backend/src/modules/marketplace-webhooks/models/blackout-events.ts
@@ -48,6 +48,7 @@ export const BLACKOUT_BRIDGE_EVENTS = [
 export const BLACKOUT_LAUNCH_EVENTS = [
   "launch.created",
   "bounty.opened",
+  "sponsorship.created",
 ] as const
 
 export const BLACKOUT_EVENT_TYPES = [

--- a/backend/src/services/__tests__/collective-hawala.sponsorship.unit.spec.ts
+++ b/backend/src/services/__tests__/collective-hawala.sponsorship.unit.spec.ts
@@ -1,0 +1,147 @@
+import {
+  CollectiveHawalaService,
+  SPONSORSHIP_PLATFORM_FEE_PERCENT,
+} from "../collective-hawala"
+
+/**
+ * Fake hawala ledger for the sponsorship money path. createTransfer is
+ * idempotent by idempotency_key; accounts always resolve (with ample balance)
+ * and the platform fee account is a real stub so the 90/10 split can run.
+ */
+function makeFakeHawala() {
+  const transfers: any[] = []
+  const byKey = new Map<string, any>()
+  let seq = 0
+
+  return {
+    transfers,
+    listLedgerAccounts: jest.fn(async (filter: any) => [
+      {
+        id: `acct_${filter.owner_id || filter.id || filter.account_type || "x"}`,
+        available_balance: 1_000_000,
+      },
+    ]),
+    createAccount: jest.fn(async (input: any) => ({
+      id: `acct_${input.owner_id}`,
+      ...input,
+    })),
+    getOrCreateSystemAccount: jest.fn(async (accountType: string) => ({
+      id: `acct_system_${accountType}`,
+    })),
+    createTransfer: jest.fn(async (input: any) => {
+      if (input.idempotency_key && byKey.has(input.idempotency_key)) {
+        return byKey.get(input.idempotency_key)
+      }
+      const entry = { id: `entry_${seq++}`, ...input }
+      transfers.push(entry)
+      if (input.idempotency_key) byKey.set(input.idempotency_key, entry)
+      return entry
+    }),
+  }
+}
+
+function makeService() {
+  const hawala = makeFakeHawala()
+  const svc = new CollectiveHawalaService(hawala as any, {} as any)
+  return { hawala, svc }
+}
+
+describe("CollectiveHawalaService — sponsorship", () => {
+  it("the platform fee is 10%", () => {
+    expect(SPONSORSHIP_PLATFORM_FEE_PERCENT).toBe(10)
+  })
+
+  it("escrowSponsorshipFunds locks producer funds with a SPONSORSHIP ref", async () => {
+    const { hawala, svc } = makeService()
+
+    await svc.escrowSponsorshipFunds({
+      sponsorship_id: "spn_1",
+      producer_id: "seller_1",
+      amount: 100,
+    })
+
+    const call = hawala.createTransfer.mock.calls[0][0]
+    expect(call.amount).toBe(100)
+    expect(call.entry_type).toBe("FEE")
+    expect(call.reference_type).toBe("SPONSORSHIP")
+    expect(call.reference_id).toBe("spn_1")
+    expect(call.idempotency_key).toBe("sponsorship-escrow-spn_1")
+  })
+
+  it("escrowSponsorshipFunds rejects when the wallet can't cover it", async () => {
+    const { hawala, svc } = makeService()
+    hawala.listLedgerAccounts.mockImplementation(async (filter: any) =>
+      filter.account_type === "USER_WALLET"
+        ? [{ id: "acct_seller_1", available_balance: 10 }]
+        : [{ id: "acct_escrow", available_balance: 0 }]
+    )
+
+    await expect(
+      svc.escrowSponsorshipFunds({
+        sponsorship_id: "spn_1",
+        producer_id: "seller_1",
+        amount: 100,
+      })
+    ).rejects.toThrow("Insufficient balance for sponsorship escrow")
+  })
+
+  it("paySponsorship splits into exactly two entries (10% fee + 90% payout)", async () => {
+    const { hawala, svc } = makeService()
+
+    const result = await svc.paySponsorship({
+      sponsorship_id: "spn_1",
+      creator_id: "creator_1",
+      amount: 100,
+    })
+
+    expect(result.platform_fee).toBe(10)
+    expect(result.creator_amount).toBe(90)
+    expect(hawala.transfers).toHaveLength(2)
+
+    const fee = hawala.createTransfer.mock.calls.find(
+      (c: any[]) => c[0].idempotency_key === "sponsorship-fee-spn_1"
+    )![0]
+    expect(fee.amount).toBe(10)
+    expect(fee.entry_type).toBe("COMMISSION")
+    expect(fee.reference_type).toBe("SPONSORSHIP")
+    expect(fee.credit_account_id).toBe("acct_system_PLATFORM_FEE")
+
+    const payout = hawala.createTransfer.mock.calls.find(
+      (c: any[]) => c[0].idempotency_key === "sponsorship-payout-spn_1"
+    )![0]
+    expect(payout.amount).toBe(90)
+    expect(payout.entry_type).toBe("TRANSFER")
+  })
+
+  it("the two payout legs always sum to the escrowed amount (non-round case)", async () => {
+    const { svc } = makeService()
+
+    const result = await svc.paySponsorship({
+      sponsorship_id: "spn_2",
+      creator_id: "creator_1",
+      amount: 33.33,
+    })
+
+    expect(result.platform_fee + result.creator_amount).toBeCloseTo(33.33, 2)
+    expect(result.platform_fee).toBe(3.33)
+  })
+
+  it("paySponsorship is idempotent — a retry produces no duplicate entries", async () => {
+    const { hawala, svc } = makeService()
+
+    const first = await svc.paySponsorship({
+      sponsorship_id: "spn_1",
+      creator_id: "creator_1",
+      amount: 100,
+    })
+    const second = await svc.paySponsorship({
+      sponsorship_id: "spn_1",
+      creator_id: "creator_1",
+      amount: 100,
+    })
+
+    expect(second.fee_entry.id).toBe(first.fee_entry.id)
+    expect(second.payout_entry.id).toBe(first.payout_entry.id)
+    expect(hawala.transfers).toHaveLength(2)
+  })
+})

--- a/backend/src/services/collective-hawala.ts
+++ b/backend/src/services/collective-hawala.ts
@@ -11,6 +11,15 @@ import { ParticipantStatus } from "../modules/demand-pool/models/demand-particip
 import { DemandPostStatus } from "../modules/demand-pool/models/demand-post"
 import { BountyStatus } from "../modules/demand-pool/models/demand-bounty"
 
+/**
+ * Platform's cut of a creator sponsorship, in percent. Unlike order platform
+ * fees (which default to 3% and are seller-configurable via payout-config),
+ * the sponsorship fee is a flat product-level 10% taken at payout time.
+ */
+export const SPONSORSHIP_PLATFORM_FEE_PERCENT = 10
+
+const roundCents = (dollars: number) => Math.round(dollars * 100) / 100
+
 export class CollectiveHawalaService {
   private hawalaService: HawalaLedgerModuleService
   private demandPoolService: DemandPoolModuleService
@@ -465,6 +474,119 @@ export class CollectiveHawalaService {
   }
 
   // ──────────────────────────────────────────────────────────────────────────
+  // Creator Sponsorship Escrow & Payout
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Lock a producer's sponsorship budget in escrow when they sponsor a creator.
+   * Mirrors `escrowBountyFunds`: moves funds from the producer's wallet into a
+   * per-sponsorship escrow account. Idempotent on `sponsorship-escrow-${id}`.
+   * All amounts are in dollars (the ledger's working unit).
+   */
+  async escrowSponsorshipFunds(input: {
+    sponsorship_id: string
+    producer_id: string
+    amount: number
+  }) {
+    const escrowAccount = await this.getOrCreateSponsorshipEscrow(
+      input.sponsorship_id
+    )
+
+    const producerAccounts = await this.hawalaService.listLedgerAccounts({
+      owner_id: input.producer_id,
+      account_type: "USER_WALLET",
+    })
+    if (producerAccounts.length === 0) {
+      throw new Error("Producer wallet not found")
+    }
+
+    const producerAccount = producerAccounts[0]
+    if (Number(producerAccount.available_balance) < input.amount) {
+      throw new Error("Insufficient balance for sponsorship escrow")
+    }
+
+    return this.hawalaService.createTransfer({
+      debit_account_id: producerAccount.id,
+      credit_account_id: escrowAccount.id,
+      amount: input.amount,
+      entry_type: "FEE",
+      description: `Sponsorship escrow ${input.sponsorship_id}`,
+      reference_type: "SPONSORSHIP",
+      reference_id: input.sponsorship_id,
+      idempotency_key: `sponsorship-escrow-${input.sponsorship_id}`,
+    })
+  }
+
+  /**
+   * Pay out a sponsorship once the creator has delivered. Splits the escrowed
+   * amount into exactly two ledger entries — a 10% platform fee and the 90%
+   * creator payout — each with a deterministic idempotency key so retries are
+   * safe. The two legs always sum to the original amount (fee is rounded to the
+   * cent, the creator gets the remainder).
+   */
+  async paySponsorship(input: {
+    sponsorship_id: string
+    creator_id: string
+    amount: number
+  }) {
+    const escrowAccount = await this.getOrCreateSponsorshipEscrow(
+      input.sponsorship_id
+    )
+
+    const platformFee = roundCents(
+      input.amount * (SPONSORSHIP_PLATFORM_FEE_PERCENT / 100)
+    )
+    const creatorAmount = roundCents(input.amount - platformFee)
+
+    // Creators earn into SELLER_EARNINGS; fall back to a plain wallet.
+    let creatorAccounts = await this.hawalaService.listLedgerAccounts({
+      owner_id: input.creator_id,
+      account_type: "SELLER_EARNINGS",
+    })
+    if (creatorAccounts.length === 0) {
+      creatorAccounts = await this.hawalaService.listLedgerAccounts({
+        owner_id: input.creator_id,
+        account_type: "USER_WALLET",
+      })
+    }
+    if (creatorAccounts.length === 0) {
+      throw new Error("Creator earnings account not found")
+    }
+
+    const platformAccount =
+      await this.hawalaService.getOrCreateSystemAccount("PLATFORM_FEE")
+
+    const feeEntry = await this.hawalaService.createTransfer({
+      debit_account_id: escrowAccount.id,
+      credit_account_id: platformAccount.id,
+      amount: platformFee,
+      entry_type: "COMMISSION",
+      description: `Sponsorship platform fee ${input.sponsorship_id}`,
+      reference_type: "SPONSORSHIP",
+      reference_id: input.sponsorship_id,
+      idempotency_key: `sponsorship-fee-${input.sponsorship_id}`,
+    })
+
+    const payoutEntry = await this.hawalaService.createTransfer({
+      debit_account_id: escrowAccount.id,
+      credit_account_id: creatorAccounts[0].id,
+      amount: creatorAmount,
+      entry_type: "TRANSFER",
+      description: `Sponsorship payout ${input.sponsorship_id}`,
+      reference_type: "SPONSORSHIP",
+      reference_id: input.sponsorship_id,
+      idempotency_key: `sponsorship-payout-${input.sponsorship_id}`,
+    })
+
+    return {
+      fee_entry: feeEntry,
+      payout_entry: payoutEntry,
+      platform_fee: platformFee,
+      creator_amount: creatorAmount,
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
   // Group Payment Processing
   // ──────────────────────────────────────────────────────────────────────────
 
@@ -630,6 +752,29 @@ export class CollectiveHawalaService {
     }
 
     return account
+  }
+
+  /**
+   * Get or create the escrow account that holds a single sponsorship's funds.
+   * Keyed by `sponsorship-${id}` so escrow and payout resolve the same account.
+   */
+  private async getOrCreateSponsorshipEscrow(sponsorshipId: string) {
+    const ownerId = `sponsorship-${sponsorshipId}`
+    const existing = await this.hawalaService.listLedgerAccounts({
+      account_type: "ESCROW",
+      owner_type: "SYSTEM",
+      owner_id: ownerId,
+    })
+    if (existing.length > 0) {
+      return existing[0]
+    }
+
+    return this.hawalaService.createAccount({
+      account_type: "ESCROW",
+      owner_type: "SYSTEM",
+      owner_id: ownerId,
+      metadata: { sponsorship_id: sponsorshipId },
+    })
   }
 }
 

--- a/backend/src/workflows/launch-sponsorship/index.ts
+++ b/backend/src/workflows/launch-sponsorship/index.ts
@@ -1,0 +1,87 @@
+import {
+  createWorkflow,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import createSponsorshipProgramStep from "./steps/create-sponsorship-program"
+import escrowSponsorshipStep from "./steps/escrow-sponsorship"
+import emitSponsorshipEventsStep from "./steps/emit-sponsorship-events"
+
+export type LaunchSponsorshipWorkflowInput = {
+  // Stable per-sponsorship id. The trigger route guards re-entry on this id and
+  // each step keys its idempotent artifacts off it.
+  launch_id: string
+  seller_id: string
+  vendor_mxid?: string | null
+  target_creator_seller_id?: string | null
+  // Sponsorship budget in minor units (cents); the escrow step works in dollars.
+  amount_cents: number
+  currency_code?: string
+  program: {
+    title: string
+    slug: string
+    description?: string | null
+  }
+}
+
+/**
+ * A producer funds a flat-fee sponsorship of a creator. One Launch materializes:
+ *  - Creator:  a SPONSORED_BRIEF program + (when the creator has consented) a deal
+ *  - Money:    the sponsorship budget escrowed from the producer's wallet
+ *  - Bridge:   a sponsorship.created Blackout webhook
+ *
+ * The 90/10 creator/platform split is taken later at payout
+ * (`CollectiveHawalaService.paySponsorship`) once the creator delivers.
+ */
+const launchSponsorshipWorkflow = createWorkflow(
+  "launch-sponsorship",
+  (input: LaunchSponsorshipWorkflowInput) => {
+    const program = createSponsorshipProgramStep(
+      transform({ input }, (d) => ({
+        launch_id: d.input.launch_id,
+        vendor_id: d.input.seller_id,
+        target_creator_seller_id: d.input.target_creator_seller_id ?? null,
+        sponsorship_flat_cents: d.input.amount_cents,
+        program: d.input.program,
+      }))
+    )
+
+    const escrow = escrowSponsorshipStep(
+      transform({ input }, (d) => ({
+        sponsorship_id: d.input.launch_id,
+        producer_id: d.input.seller_id,
+        amount: d.input.amount_cents / 100,
+      }))
+    )
+
+    emitSponsorshipEventsStep(
+      transform({ input, program, escrow }, (d) => ({
+        launch_id: d.input.launch_id,
+        vendor_mxid: d.input.vendor_mxid ?? null,
+        vendor_id: d.input.seller_id,
+        program_id: d.program.program_id,
+        deal_id: d.program.deal_id,
+        invited_creator_seller_id: d.program.invited_creator_seller_id,
+        target_creator_seller_id: d.input.target_creator_seller_id ?? null,
+        amount_cents: d.input.amount_cents,
+        currency_code: d.input.currency_code ?? "USD",
+        escrowed: d.escrow.escrowed,
+      }))
+    )
+
+    return new WorkflowResponse(
+      transform({ input, program, escrow }, (d) => ({
+        launch_id: d.input.launch_id,
+        program_id: d.program.program_id,
+        deal_id: d.program.deal_id,
+        invited_creator_seller_id: d.program.invited_creator_seller_id,
+        escrowed: d.escrow.escrowed,
+        escrow_ledger_entry_id: d.escrow.ledger_entry_id,
+        amount_cents: d.input.amount_cents,
+      }))
+    )
+  }
+)
+
+export default launchSponsorshipWorkflow

--- a/backend/src/workflows/launch-sponsorship/steps/create-sponsorship-program.ts
+++ b/backend/src/workflows/launch-sponsorship/steps/create-sponsorship-program.ts
@@ -1,0 +1,175 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import CreatorProgramService from "../../../modules/creator-program/service"
+import { CREATOR_PROGRAM_MODULE } from "../../../modules/creator-program"
+import { CreatorProgramType } from "../../../modules/creator-program/models/creator-program"
+import { decideDealAction } from "../../launch-product/steps/_decide-deal-action"
+
+export type CreateSponsorshipProgramInput = {
+  launch_id: string
+  vendor_id: string
+  // The creator the producer wants to sponsor. A flat-fee deal is only opened
+  // when the creator has already consented (APPROVED application or ACTIVE
+  // deal); otherwise they are merely invited — no deal is minted on their
+  // behalf, and no funds should be paid out until they opt in.
+  target_creator_seller_id?: string | null
+  // Flat sponsorship amount, in minor units (cents), recorded on the program.
+  sponsorship_flat_cents: number
+  program: {
+    title: string
+    slug: string
+    description?: string | null
+  }
+}
+
+export type CreateSponsorshipProgramOutput = {
+  program_id: string
+  deal_id: string | null
+  invited_creator_seller_id: string | null
+}
+
+type CreateSponsorshipProgramComp = {
+  program_id: string | null
+  programCreated: boolean
+  deal_id: string | null
+  dealCreated: boolean
+}
+
+/**
+ * Stands up the creator side of a sponsorship: a SPONSORED_BRIEF program
+ * carrying the flat sponsorship amount, and — only when a pre-matched creator
+ * has already consented — an active deal binding producer↔creator. Reuses the
+ * same consent gate as the product launch (`decideDealAction`) so a sponsorship
+ * never applies/approves on a creator's behalf.
+ *
+ * Idempotent: program reused by (vendor, slug); deal reused by (vendor, creator).
+ */
+const createSponsorshipProgramStep = createStep(
+  "create-sponsorship-program-step",
+  async (data: CreateSponsorshipProgramInput, { container }) => {
+    const programs =
+      container.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+
+    const existingPrograms = await programs.listCreatorPrograms({
+      vendor_id: data.vendor_id,
+      slug: data.program.slug,
+    })
+    let program = existingPrograms[0]
+    let programCreated = false
+    if (!program) {
+      program = await programs.createProgram({
+        vendorId: data.vendor_id,
+        title: data.program.title,
+        slug: data.program.slug,
+        description: data.program.description ?? null,
+        programType: CreatorProgramType.SPONSORED_BRIEF,
+        sponsorshipFlatCents: data.sponsorship_flat_cents,
+        metadata: { launch_id: data.launch_id },
+      })
+      programCreated = true
+    }
+    await programs.publishProgram(program.id)
+
+    const noDeal = (
+      invited: string | null
+    ): StepResponse<
+      CreateSponsorshipProgramOutput,
+      CreateSponsorshipProgramComp
+    > =>
+      new StepResponse(
+        {
+          program_id: program.id as string,
+          deal_id: null,
+          invited_creator_seller_id: invited,
+        },
+        {
+          program_id: program.id as string,
+          programCreated,
+          deal_id: null,
+          dealCreated: false,
+        }
+      )
+
+    if (!data.target_creator_seller_id) {
+      return noDeal(null)
+    }
+    const target = data.target_creator_seller_id
+
+    // Consent gate — decide purely from existing records. Never apply/approve
+    // on the creator's behalf.
+    const [applications, deals] = await Promise.all([
+      programs.listCreatorApplications({
+        program_id: program.id,
+        creator_seller_id: target,
+      }),
+      programs.listCreatorDeals({
+        vendor_id: data.vendor_id,
+        creator_seller_id: target,
+      }),
+    ])
+    const decision = decideDealAction(applications as any, deals as any)
+
+    if (decision.action === "invite") {
+      const meta = (program.metadata ?? {}) as Record<string, any>
+      const invited: string[] = Array.isArray(meta.invited_creator_seller_ids)
+        ? meta.invited_creator_seller_ids
+        : []
+      if (!invited.includes(target)) {
+        await (programs as any).updateCreatorPrograms({
+          id: program.id,
+          metadata: {
+            ...meta,
+            invited_creator_seller_ids: [...invited, target],
+          },
+        })
+      }
+      return noDeal(target)
+    }
+
+    // Consent on record: open a deal (or reuse the existing ACTIVE one).
+    let deal: any
+    let dealCreated = false
+    if (decision.action === "open_deal") {
+      deal = await programs.openDealForApprovedApp(decision.applicationId)
+      dealCreated = true
+    } else {
+      const existing = await programs.listCreatorDeals({ id: decision.dealId })
+      deal = existing[0]
+    }
+
+    return new StepResponse<
+      CreateSponsorshipProgramOutput,
+      CreateSponsorshipProgramComp
+    >(
+      {
+        program_id: program.id as string,
+        deal_id: deal.id as string,
+        invited_creator_seller_id: null,
+      },
+      {
+        program_id: program.id as string,
+        programCreated,
+        deal_id: deal.id as string,
+        dealCreated,
+      }
+    )
+  },
+  async (comp: CreateSponsorshipProgramComp | undefined, { container }) => {
+    if (!comp) {
+      return
+    }
+    const programs =
+      container.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+    try {
+      if (comp.dealCreated && comp.deal_id) {
+        await programs.cancelDeal(comp.deal_id)
+      }
+      if (comp.programCreated && comp.program_id) {
+        await programs.closeProgram(comp.program_id, "sponsorship rolled back")
+      }
+    } catch {
+      // best-effort compensation
+    }
+  }
+)
+
+export default createSponsorshipProgramStep

--- a/backend/src/workflows/launch-sponsorship/steps/emit-sponsorship-events.ts
+++ b/backend/src/workflows/launch-sponsorship/steps/emit-sponsorship-events.ts
@@ -1,0 +1,62 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import MarketplaceWebhooksService from "../../../modules/marketplace-webhooks/service"
+import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../modules/marketplace-webhooks"
+
+export type EmitSponsorshipEventsInput = {
+  launch_id: string
+  vendor_mxid?: string | null
+  vendor_id: string
+  program_id: string
+  deal_id: string | null
+  invited_creator_seller_id: string | null
+  target_creator_seller_id?: string | null
+  amount_cents: number
+  currency_code: string
+  escrowed: boolean
+}
+
+/**
+ * Emits the `sponsorship.created` Blackout webhook so the Creator Hub can
+ * surface the sponsorship offer. Mirrors `emit-launch-events`: dedupes on a
+ * stable eventId, no-ops cleanly when unconfigured, and never fails the
+ * sponsorship if the outbound channel hiccups.
+ */
+const emitSponsorshipEventsStep = createStep(
+  "emit-sponsorship-events-step",
+  async (data: EmitSponsorshipEventsInput, { container }) => {
+    const webhooks = container.resolve<MarketplaceWebhooksService>(
+      MARKETPLACE_WEBHOOKS_MODULE
+    )
+
+    try {
+      await webhooks.emitBlackout(
+        "sponsorship.created",
+        {
+          launchId: data.launch_id,
+          vendorMxid: data.vendor_mxid ?? null,
+          vendorId: data.vendor_id,
+          programId: data.program_id,
+          dealId: data.deal_id,
+          creatorSellerId:
+            data.target_creator_seller_id ??
+            data.invited_creator_seller_id ??
+            null,
+          invited: !!data.invited_creator_seller_id,
+          amountCents: data.amount_cents,
+          currencyCode: data.currency_code,
+          escrowed: data.escrowed,
+        },
+        { eventId: `sponsorship.created:${data.launch_id}` }
+      )
+    } catch (err) {
+      console.error(
+        "[sponsorship] emit-sponsorship-events failed:",
+        (err as Error).message
+      )
+    }
+
+    return new StepResponse({ emitted: true })
+  }
+)
+
+export default emitSponsorshipEventsStep

--- a/backend/src/workflows/launch-sponsorship/steps/escrow-sponsorship.ts
+++ b/backend/src/workflows/launch-sponsorship/steps/escrow-sponsorship.ts
@@ -1,0 +1,50 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { getCollectiveHawalaService } from "../../../services/collective-hawala"
+
+export type EscrowSponsorshipInput = {
+  // Stable per-sponsorship id (the launch_id), used as the escrow key.
+  sponsorship_id: string
+  // The producer funding the sponsorship.
+  producer_id: string
+  // Sponsorship budget in dollars (the ledger's working unit).
+  amount: number
+}
+
+export type EscrowSponsorshipOutput = {
+  escrowed: boolean
+  ledger_entry_id: string | null
+}
+
+/**
+ * Locks the producer's sponsorship budget into a per-sponsorship escrow so the
+ * committed amount is real money set aside. Idempotent on the sponsorship id;
+ * a no-op when the amount is zero. The 90/10 split to creator/platform happens
+ * later at payout time (`CollectiveHawalaService.paySponsorship`), once the
+ * creator has delivered — mirroring how bounty escrow and milestone payout are
+ * separate phases.
+ */
+const escrowSponsorshipStep = createStep(
+  "escrow-sponsorship-step",
+  async (data: EscrowSponsorshipInput, { container }) => {
+    if (!(Number(data.amount) > 0)) {
+      return new StepResponse<EscrowSponsorshipOutput>({
+        escrowed: false,
+        ledger_entry_id: null,
+      })
+    }
+
+    const hawala = getCollectiveHawalaService(container)
+    const entry = await hawala.escrowSponsorshipFunds({
+      sponsorship_id: data.sponsorship_id,
+      producer_id: data.producer_id,
+      amount: Number(data.amount),
+    })
+
+    return new StepResponse<EscrowSponsorshipOutput>({
+      escrowed: true,
+      ledger_entry_id: entry.id as string,
+    })
+  }
+)
+
+export default escrowSponsorshipStep

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -124,6 +124,13 @@ function getVendorNavigationConfig({
       // photography / service) and providers browse open ones to claim.
     },
     {
+      icon: <Buildings />,
+      label: "Launch a Business",
+      to: "/launch-business",
+      // Guided onboarding: stand up a producer profile + first product in one
+      // flow. Most useful for new sellers without a profile yet.
+    },
+    {
       icon: <SquaresPlus />,
       label: "Services",
       to: "/services",

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -117,6 +117,13 @@ function getVendorNavigationConfig({
       showFor: (_, type) => type !== "creator",
     },
     {
+      icon: <CurrencyDollar />,
+      label: "Bounties",
+      to: "/bounties",
+      // Visible to all sellers — buyers post bounties (creator / marketing /
+      // photography / service) and providers browse open ones to claim.
+    },
+    {
       icon: <SquaresPlus />,
       label: "Services",
       to: "/services",

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -118,6 +118,14 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/bounties"),
           },
           {
+            path: "launch-business",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Launch a Business",
+            },
+            lazy: () => import("../../routes/launch-business"),
+          },
+          {
             path: "/requests",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -110,6 +110,14 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/services"),
           },
           {
+            path: "bounties",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Bounties",
+            },
+            lazy: () => import("../../routes/bounties"),
+          },
+          {
             path: "/requests",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/routes/bounties/bounties.tsx
+++ b/vendor-panel/src/routes/bounties/bounties.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState } from "react"
+import { Badge, Button, Container, Heading, Text, toast } from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+// Bounty-flavoured service program types. The Services surface covers the full
+// catalogue (contracts, pools, subcontracts); this page narrows to the two
+// bounty types so vendors see bounties as a first-class growth lever.
+const BOUNTY_PROGRAM_TYPES = ["bounty_open", "bounty_invite"] as const
+const isBounty = (programType: string) =>
+  (BOUNTY_PROGRAM_TYPES as readonly string[]).includes(programType)
+
+interface ServiceProgramRow {
+  id: string
+  vendor_id: string
+  title: string
+  slug: string
+  description: string | null
+  service_category: string
+  program_type: string
+  pricing_model: string
+  status: string
+  unit_price_cents: number | null
+  currency_code: string
+  requires_kyc: boolean
+}
+
+interface ServiceApplicationRow {
+  id: string
+  program_id: string
+  service_seller_id: string
+  status: string
+}
+
+interface OpenServiceProgram {
+  id: string
+  vendor_id: string
+  title: string
+  service_category: string
+  program_type: string
+  pricing_model: string
+  unit_price_cents: number | null
+  flat_price_cents: number | null
+  pool_total_cents: number | null
+  currency_code: string
+  deadline_at: string | null
+  requires_kyc: boolean
+}
+
+const formatCents = (cents: number | null | undefined, currency = "USD") =>
+  cents == null
+    ? "—"
+    : new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+        Number(cents) / 100
+      )
+
+const formatDate = (s: string | null) =>
+  s
+    ? new Date(s).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : "—"
+
+async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+export const BountiesPage = () => {
+  const [tab, setTab] = useState<"mine" | "open">("mine")
+  const [myPrograms, setMyPrograms] = useState<ServiceProgramRow[]>([])
+  const [myApplications, setMyApplications] = useState<ServiceApplicationRow[]>(
+    []
+  )
+  const [openMarketplace, setOpenMarketplace] = useState<OpenServiceProgram[]>(
+    []
+  )
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [programs, applications, open] = await Promise.all([
+        authedFetch<{ programs: ServiceProgramRow[] }>(
+          "/v1/seller/services/programs"
+        ).catch(() => ({ programs: [] })),
+        authedFetch<{ applications: ServiceApplicationRow[] }>(
+          "/v1/seller/services/applications"
+        ).catch(() => ({ applications: [] })),
+        authedFetch<{ programs: OpenServiceProgram[] }>(
+          "/v1/marketplace/services?limit=100"
+        ).catch(() => ({ programs: [] })),
+      ])
+      setMyPrograms((programs.programs || []).filter((p) => isBounty(p.program_type)))
+      setMyApplications(applications.applications || [])
+      setOpenMarketplace(
+        (open.programs || []).filter((p) => isBounty(p.program_type))
+      )
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    reload()
+  }, [])
+
+  // Applicant counts keyed by program so each of my bounties shows traction.
+  const applicantsByProgram = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const a of myApplications) {
+      map.set(a.program_id, (map.get(a.program_id) || 0) + 1)
+    }
+    return map
+  }, [myApplications])
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h1">Bounties</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            Post bounties to recruit creators and service providers, and browse
+            open bounties you can claim.
+          </Text>
+        </div>
+        <Button variant="secondary" onClick={reload} disabled={loading}>
+          Refresh
+        </Button>
+      </div>
+
+      <div className="flex gap-2 px-6 py-3">
+        <Button
+          size="small"
+          variant={tab === "mine" ? "primary" : "secondary"}
+          onClick={() => setTab("mine")}
+        >
+          My bounties
+        </Button>
+        <Button
+          size="small"
+          variant={tab === "open" ? "primary" : "secondary"}
+          onClick={() => setTab("open")}
+        >
+          Open bounties
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="px-6 py-8">
+          <Text className="text-ui-fg-subtle">Loading bounties…</Text>
+        </div>
+      ) : error ? (
+        <div className="px-6 py-8">
+          <Text className="text-ui-fg-error">{error}</Text>
+        </div>
+      ) : tab === "mine" ? (
+        myPrograms.length === 0 ? (
+          <div className="px-6 py-8">
+            <Text className="text-ui-fg-subtle">
+              You haven't posted any bounties yet. Launch a product from Find
+              Creators or post a service bounty to get started.
+            </Text>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {myPrograms.map((p) => (
+              <li key={p.id} className="px-6 py-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Text weight="plus" className="truncate">
+                        {p.title}
+                      </Text>
+                      <Badge size="2xsmall">{p.program_type}</Badge>
+                      <Badge
+                        size="2xsmall"
+                        color={p.status === "open" ? "green" : "grey"}
+                      >
+                        {p.status}
+                      </Badge>
+                    </div>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {p.service_category} ·{" "}
+                      {formatCents(p.unit_price_cents, p.currency_code)} ·{" "}
+                      {applicantsByProgram.get(p.id) || 0} applicant(s)
+                    </Text>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : openMarketplace.length === 0 ? (
+        <div className="px-6 py-8">
+          <Text className="text-ui-fg-subtle">
+            No open bounties right now. Check back soon.
+          </Text>
+        </div>
+      ) : (
+        <ul className="divide-y">
+          {openMarketplace.map((p) => (
+            <li key={p.id} className="px-6 py-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Text weight="plus" className="truncate">
+                      {p.title}
+                    </Text>
+                    <Badge size="2xsmall">{p.program_type}</Badge>
+                  </div>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    {p.service_category} ·{" "}
+                    {formatCents(
+                      p.unit_price_cents ?? p.flat_price_cents ?? p.pool_total_cents,
+                      p.currency_code
+                    )}
+                    {p.deadline_at ? ` · due ${formatDate(p.deadline_at)}` : ""}
+                  </Text>
+                </div>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() =>
+                    toast.info("Claim bounties from the Services page")
+                  }
+                >
+                  View
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Container>
+  )
+}
+
+export default BountiesPage

--- a/vendor-panel/src/routes/bounties/index.ts
+++ b/vendor-panel/src/routes/bounties/index.ts
@@ -1,0 +1,1 @@
+export { BountiesPage as Component } from "./bounties"

--- a/vendor-panel/src/routes/find-creators/find-creators.tsx
+++ b/vendor-panel/src/routes/find-creators/find-creators.tsx
@@ -6,10 +6,20 @@ import {
   Heading,
   Input,
   Label,
+  Select,
   Text,
   toast,
 } from "@medusajs/ui"
 import { backendUrl, getAuthToken } from "../../lib/client"
+
+// Producer→creator marketing bounty objectives surfaced in the launch form.
+// Mirrors the BountyObjective values the backend accepts at
+// /v1/seller/launches (CREATOR_NEEDED is the default for a creator launch).
+const BOUNTY_OBJECTIVES: { value: string; label: string }[] = [
+  { value: "CREATOR_NEEDED", label: "Creator needed" },
+  { value: "MARKETING_NEEDED", label: "Marketing needed" },
+  { value: "PHOTOGRAPHY_NEEDED", label: "Photography needed" },
+]
 
 interface RankedCreator {
   creator_seller_id: string
@@ -74,6 +84,7 @@ export const FindCreatorsPage = () => {
   const [price, setPrice] = useState("")
   const [cooperativeId, setCooperativeId] = useState("")
   const [bountyAmount, setBountyAmount] = useState("")
+  const [bountyObjective, setBountyObjective] = useState("CREATOR_NEEDED")
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState<LaunchResult | null>(null)
 
@@ -102,6 +113,7 @@ export const FindCreatorsPage = () => {
     setPrice("")
     setCooperativeId("")
     setBountyAmount("")
+    setBountyObjective("CREATOR_NEEDED")
     setResult(null)
   }
 
@@ -124,6 +136,7 @@ export const FindCreatorsPage = () => {
       }
       if (bountyAmount.trim()) {
         body.bounty_amount = parseFloat(bountyAmount)
+        body.bounty_objective = bountyObjective
       }
       const res = await authedFetch<{ launch: LaunchResult }>(
         "/v1/seller/launches",
@@ -281,6 +294,24 @@ export const FindCreatorsPage = () => {
                           placeholder="50"
                           inputMode="decimal"
                         />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <Label size="small">Bounty objective</Label>
+                        <Select
+                          value={bountyObjective}
+                          onValueChange={setBountyObjective}
+                        >
+                          <Select.Trigger>
+                            <Select.Value placeholder="Select objective" />
+                          </Select.Trigger>
+                          <Select.Content>
+                            {BOUNTY_OBJECTIVES.map((o) => (
+                              <Select.Item key={o.value} value={o.value}>
+                                {o.label}
+                              </Select.Item>
+                            ))}
+                          </Select.Content>
+                        </Select>
                       </div>
                       <div className="flex gap-2 md:col-span-2">
                         <Button

--- a/vendor-panel/src/routes/find-creators/find-creators.tsx
+++ b/vendor-panel/src/routes/find-creators/find-creators.tsx
@@ -85,6 +85,7 @@ export const FindCreatorsPage = () => {
   const [cooperativeId, setCooperativeId] = useState("")
   const [bountyAmount, setBountyAmount] = useState("")
   const [bountyObjective, setBountyObjective] = useState("CREATOR_NEEDED")
+  const [sponsorshipAmount, setSponsorshipAmount] = useState("")
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState<LaunchResult | null>(null)
 
@@ -114,6 +115,7 @@ export const FindCreatorsPage = () => {
     setCooperativeId("")
     setBountyAmount("")
     setBountyObjective("CREATOR_NEEDED")
+    setSponsorshipAmount("")
     setResult(null)
   }
 
@@ -144,6 +146,43 @@ export const FindCreatorsPage = () => {
       )
       setResult(res.launch)
       toast.success("Launch created")
+    } catch (e) {
+      toast.error((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // Flat-fee sponsorship of a creator (launch_type=SPONSORSHIP). Escrows the
+  // producer's budget; the 90/10 creator/platform split is taken at payout.
+  const submitSponsorship = async (creatorSellerId: string) => {
+    if (!title.trim() || !sponsorshipAmount.trim()) {
+      toast.error("Title and sponsorship amount are required")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const amountCents = Math.round(parseFloat(sponsorshipAmount) * 100)
+      const res = await authedFetch<{ sponsorship: { deal_id: string | null; escrowed: boolean; invited_creator_seller_id: string | null } }>(
+        "/v1/seller/launches",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            launch_type: "SPONSORSHIP",
+            title: title.trim(),
+            slug: slugify(title),
+            target_creator_seller_id: creatorSellerId,
+            sponsorship_amount: Number.isFinite(amountCents) ? amountCents : 0,
+          }),
+        }
+      )
+      const s = res.sponsorship
+      toast.success(
+        s.deal_id
+          ? "Sponsorship created and funded"
+          : "Creator invited — sponsorship activates once they accept"
+      )
+      resetForm()
     } catch (e) {
       toast.error((e as Error).message)
     } finally {
@@ -313,13 +352,32 @@ export const FindCreatorsPage = () => {
                           </Select.Content>
                         </Select>
                       </div>
-                      <div className="flex gap-2 md:col-span-2">
+                      <div className="flex flex-col gap-1">
+                        <Label size="small">Sponsorship amount (USD)</Label>
+                        <Input
+                          value={sponsorshipAmount}
+                          onChange={(e) => setSponsorshipAmount(e.target.value)}
+                          placeholder="250"
+                          inputMode="decimal"
+                        />
+                      </div>
+                      <div className="flex flex-wrap gap-2 md:col-span-2">
                         <Button
                           size="small"
                           onClick={() => submitLaunch(creator.creator_seller_id)}
                           isLoading={submitting}
                         >
                           Create launch
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="secondary"
+                          onClick={() =>
+                            submitSponsorship(creator.creator_seller_id)
+                          }
+                          isLoading={submitting}
+                        >
+                          Sponsor this creator
                         </Button>
                         <Button
                           size="small"

--- a/vendor-panel/src/routes/launch-business/index.ts
+++ b/vendor-panel/src/routes/launch-business/index.ts
@@ -1,0 +1,1 @@
+export { LaunchBusinessPage as Component } from "./launch-business"

--- a/vendor-panel/src/routes/launch-business/launch-business.tsx
+++ b/vendor-panel/src/routes/launch-business/launch-business.tsx
@@ -1,0 +1,240 @@
+import { useState } from "react"
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  ProgressTabs,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+
+interface LaunchResult {
+  launch_id: string
+  product_id: string
+  demand_post_id: string
+}
+
+async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${res.status}: ${body || res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+/**
+ * "Launch a Business" guided wizard — start selling without outside help.
+ * Step 1 captures the producer profile; step 2 the first product. On submit it
+ * POSTs launch_type=BUSINESS to /v1/seller/launches, which ensures the producer
+ * profile exists and then runs the standard product-launch flow.
+ */
+export const LaunchBusinessPage = () => {
+  const [step, setStep] = useState<"profile" | "product">("profile")
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<LaunchResult | null>(null)
+
+  // Step 1 — business profile
+  const [businessName, setBusinessName] = useState("")
+  const [handle, setHandle] = useState("")
+  const [region, setRegion] = useState("")
+
+  // Step 2 — first product
+  const [productTitle, setProductTitle] = useState("")
+  const [price, setPrice] = useState("")
+  const [description, setDescription] = useState("")
+
+  const goToProduct = () => {
+    if (!businessName.trim()) {
+      toast.error("Business name is required")
+      return
+    }
+    setStep("product")
+  }
+
+  const submit = async () => {
+    if (!productTitle.trim() || !price.trim()) {
+      toast.error("Product title and price are required")
+      return
+    }
+    setSubmitting(true)
+    try {
+      const priceCents = Math.round(parseFloat(price) * 100)
+      const res = await authedFetch<{ launch: LaunchResult }>(
+        "/v1/seller/launches",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            launch_type: "BUSINESS",
+            title: productTitle.trim(),
+            slug: slugify(productTitle),
+            price: Number.isFinite(priceCents) ? priceCents : 0,
+            description: description.trim() || undefined,
+            business: {
+              producer_name: businessName.trim(),
+              producer_handle: handle.trim() || slugify(businessName),
+              region: region.trim() || undefined,
+            },
+          }),
+        }
+      )
+      setResult(res.launch)
+      toast.success("Business launched 🎉")
+    } catch (e) {
+      toast.error((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (result) {
+    return (
+      <Container className="p-6">
+        <Heading level="h1">Business launched 🎉</Heading>
+        <Text className="text-ui-fg-subtle mt-2" size="small">
+          Your producer profile is live and your first product is published.
+        </Text>
+        <Text className="text-ui-fg-subtle mt-4" size="small">
+          Product: {result.product_id}
+        </Text>
+        <Text className="text-ui-fg-subtle" size="small">
+          Launch: {result.launch_id}
+        </Text>
+      </Container>
+    )
+  }
+
+  return (
+    <Container className="p-0">
+      <div className="px-6 py-4">
+        <Heading level="h1">Launch a Business</Heading>
+        <Text className="text-ui-fg-subtle" size="small">
+          Set up your profile and your first product in two steps — no outside
+          help required.
+        </Text>
+      </div>
+
+      <ProgressTabs value={step} className="border-t">
+        <ProgressTabs.List>
+          <ProgressTabs.Trigger
+            value="profile"
+            status={step === "product" ? "completed" : "in-progress"}
+            onClick={() => setStep("profile")}
+          >
+            Business profile
+          </ProgressTabs.Trigger>
+          <ProgressTabs.Trigger
+            value="product"
+            status={step === "product" ? "in-progress" : "not-started"}
+            onClick={goToProduct}
+          >
+            First product
+          </ProgressTabs.Trigger>
+        </ProgressTabs.List>
+
+        <ProgressTabs.Content value="profile" className="px-6 py-6">
+          <div className="grid max-w-xl grid-cols-1 gap-4">
+            <div className="flex flex-col gap-1">
+              <Label size="small">Business name</Label>
+              <Input
+                value={businessName}
+                onChange={(e) => setBusinessName(e.target.value)}
+                placeholder="Sunrise Farm"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label size="small">Handle (optional)</Label>
+              <Input
+                value={handle}
+                onChange={(e) => setHandle(e.target.value)}
+                placeholder="sunrise-farm"
+              />
+              <Text size="xsmall" className="text-ui-fg-muted">
+                Used in your public profile URL. Defaults to your business name.
+              </Text>
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label size="small">Region (optional)</Label>
+              <Input
+                value={region}
+                onChange={(e) => setRegion(e.target.value)}
+                placeholder="Pacific Northwest"
+              />
+            </div>
+            <div>
+              <Button size="small" onClick={goToProduct}>
+                Next: first product
+              </Button>
+            </div>
+          </div>
+        </ProgressTabs.Content>
+
+        <ProgressTabs.Content value="product" className="px-6 py-6">
+          <div className="grid max-w-xl grid-cols-1 gap-4">
+            <div className="flex flex-col gap-1">
+              <Label size="small">Product title</Label>
+              <Input
+                value={productTitle}
+                onChange={(e) => setProductTitle(e.target.value)}
+                placeholder="Compost — 1 cu ft"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label size="small">Price (USD)</Label>
+              <Input
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                placeholder="12.00"
+                inputMode="decimal"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label size="small">Description (optional)</Label>
+              <Textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What you're selling and why it's great."
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button size="small" onClick={submit} isLoading={submitting}>
+                Launch business
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={() => setStep("profile")}
+                disabled={submitting}
+              >
+                Back
+              </Button>
+            </div>
+          </div>
+        </ProgressTabs.Content>
+      </ProgressTabs>
+    </Container>
+  )
+}
+
+export default LaunchBusinessPage


### PR DESCRIPTION
Add CREATOR_NEEDED / MARKETING_NEEDED / PHOTOGRAPHY_NEEDED to
BountyObjective (idempotent enum migration) and surface a bounty-objective
Select in the Find Creators launch form, posting bounty_objective alongside
bounty_amount. Defaults to CREATOR_NEEDED. Unit test covers each new value.

https://claude.ai/code/session_01Wby3ku3BtG1rhDwPWhsoYt