### PR TITLE
Launch-readiness: close the FBM money-path concurrency gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,77 @@ jobs:
           JWT_SECRET: ci-jwt-secret-at-least-32-characters-long-deterministic
           COOKIE_SECRET: ci-cookie-secret-at-least-32-characters-long-determinis
 
+  test-soak:
+    name: Money-Path Concurrency Soak
+    runs-on: ubuntu-latest
+    # Independent of the integration:http app-boot chain (TI-3): the module
+    # soak uses @medusajs/test-utils' moduleIntegrationTestRunner, which spins
+    # up its own isolated Postgres schema for the hawala-ledger module and
+    # never boots the full Medusa app. So it can run early and on its own.
+    services:
+      postgres:
+        image: postgres:15
+        # Test-fixture credentials only; bound to localhost on the runner and
+        # torn down at job end. The module runner needs CREATEDB (pg-god
+        # creates a per-worker schema); the default postgres superuser has it.
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ci_test_postgres_fixture_only_not_a_secret
+          POSTGRES_DB: medusa_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm via corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pnpm install --frozen-lockfile
+
+      # Closes the LAUNCH_READINESS §2 money-path gate: proves the
+      # atomic-by-default balance CAS + pool-total increments hold under real
+      # concurrency (no overdraw, value conservation, exact pool totals).
+      # Scoped to the soak spec so the signal stays clean.
+      #
+      # Authored in a DB-less web env, so this lands non-blocking
+      # (continue-on-error) following the repo's own live-Postgres rollout
+      # convention (see the test-integration TI-1/TI-3 history above). Flip to
+      # fail-fast — delete the `continue-on-error` line — once it's been
+      # observed green against live Postgres here.
+      - name: Run hawala money-path concurrency soak
+        working-directory: backend
+        run: pnpm test:integration:modules src/modules/hawala-ledger/__tests__/concurrency-soak.integration.spec.ts
+        continue-on-error: true
+        env:
+          NODE_ENV: test
+          # @medusajs/test-utils reads DB_HOST/DB_USERNAME/DB_PASSWORD/DB_PORT
+          # individually (not DATABASE_URL) to build the per-module test DB URL.
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_USERNAME: postgres
+          DB_PASSWORD: ci_test_postgres_fixture_only_not_a_secret
+          DATABASE_URL: postgres://postgres:ci_test_postgres_fixture_only_not_a_secret@localhost:5432/medusa_test
+          JWT_SECRET: ci-jwt-secret-at-least-32-characters-long-deterministic
+          COOKIE_SECRET: ci-cookie-secret-at-least-32-characters-long-determinis
+
   release-validation:
     name: Release Validation Gate
     runs-on: ubuntu-latest

--- a/LAUNCH_READINESS.md
+++ b/LAUNCH_READINESS.md
@@ -68,7 +68,7 @@ Legend: ✅ complete · 🟡 partial · 🔴 missing/stub · ⏸️ deferred
 
 ### FBM launch-critical path (remaining)
 
-1. **Money-path verification** under real concurrency (foundational — see §2). This is the one genuine FBM gate.
+1. **Money-path concurrency soak** against a real Postgres (foundational — see §2). The code-side hardening is **done** (atomic balance CAS + atomic pool totals are now the default); the residual gate is running the soak under parallel load in a DB-equipped env.
 2. *(Deferred)* Multi-seller "all businesses in one profile" — tracked, not a launch blocker per founder.
 
 ### Blackout (separate repo) — NOT FBM scope
@@ -102,13 +102,27 @@ The `ECONOMIC_REVIEW.md` remediation table marks the critical money bugs
 > An earlier automated read reported these as still broken. That read was
 > **stale** — the fixes are present. Do not act on the "money is broken" claim.
 
-**The genuine caveat:** the atomic balance path only runs **when a caller passes
-`pgConnection`**; otherwise it falls back to the legacy non-atomic path. Pool-total
-increments are still flagged non-atomic TODO. So "fixed" is *conditional on
-caller wiring* and currently unproven under real concurrency.
+**Status update (this session) — code-side gate closed.** The atomic path is
+now the **default**, not conditional on caller wiring:
 
-**Before real funds at scale:** confirm every money-moving caller threads
-`pgConnection`, and add concurrency tests. (Idempotency is now well-covered:
+- `createTransfer` self-resolves a pg connection from the module container
+  (`resolvePgConnection`, mirroring `creator-attribution`) and uses the atomic
+  balance CAS by default. None of the ~39 call sites have to thread
+  `pgConnection`; the legacy read-modify-write only runs when no connection is
+  reachable (DI-less unit tests).
+- The two flagged pool-total read-modify-writes (`createInvestment`
+  total_raised/total_investors; `distributeDividends` total_distributed) now use
+  a single atomic `col = col + ?` UPDATE (`atomicPoolIncrement`), with the same
+  graceful fallback.
+- New regression specs: `atomic-by-default.unit.spec.ts` (atomic-by-default,
+  explicit-over-resolved precedence, fallback, atomic pool increments). Full
+  hawala unit suite green (112 tests).
+
+**The one part that still cannot be closed from the web env:** a **concurrency
+soak test against a real Postgres** under parallel load. This container has no
+DB (`pg_isready` → no response), and integration tests (`TEST_TYPE=integration:*`)
+require one. This is the residual gate — run the soak in a DB-equipped
+environment before scaling real funds. (Idempotency is already well-covered:
 bounty transfer, sponsorship split, and `createTransfer` all have regression
 specs.)
 

--- a/LAUNCH_READINESS.md
+++ b/LAUNCH_READINESS.md
@@ -139,10 +139,20 @@ concurrent operations to assert three invariants: (1) no overdraw under
 concurrent debits, (2) total value conserved across interleaved bidirectional
 transfers, (3) exact pool totals under concurrent investments.
 
+**The soak is wired into CI.** A dedicated `test-soak` ("Money-Path
+Concurrency Soak") job in `.github/workflows/ci.yml` runs it on every push/PR
+against a Postgres service. It's independent of the `integration:http`
+app-boot debt (TI-3) because `moduleIntegrationTestRunner` stands up its own
+isolated module schema without booting the full app. Per the repo's own
+live-Postgres rollout convention (see the `test-integration` TI-1/TI-3
+history), it lands **non-blocking** (`continue-on-error: true`) because it was
+authored in a DB-less env; **flip it to fail-fast** (delete that one line)
+once it's been observed green against live Postgres.
+
 **The one part that still cannot be closed from the web env:** actually
-*running* that soak. This container has no DB (`pg_isready` → no response), and
-`TEST_TYPE=integration:modules` requires one. Run it in a DB-equipped
-environment before scaling real funds:
+*running* the soak — this container has no DB (`pg_isready` → no response).
+The CI job above is the automated path; to run it locally in a DB-equipped
+environment:
 
 ```
 cd backend && TEST_TYPE=integration:modules NODE_OPTIONS=--experimental-vm-modules \

--- a/LAUNCH_READINESS.md
+++ b/LAUNCH_READINESS.md
@@ -118,13 +118,40 @@ now the **default**, not conditional on caller wiring:
   explicit-over-resolved precedence, fallback, atomic pool increments). Full
   hawala unit suite green (112 tests).
 
-**The one part that still cannot be closed from the web env:** a **concurrency
-soak test against a real Postgres** under parallel load. This container has no
-DB (`pg_isready` → no response), and integration tests (`TEST_TYPE=integration:*`)
-require one. This is the residual gate — run the soak in a DB-equipped
-environment before scaling real funds. (Idempotency is already well-covered:
-bounty transfer, sponsorship split, and `createTransfer` all have regression
-specs.)
+**Latent table-name bug found and fixed while writing the soak.** Wiring the
+atomic path on by default exposed two raw-SQL statements that targeted
+**non-existent tables** (no compatibility view exists):
+
+- `updateBalancesAtomic` did `UPDATE ledger_account` — the real table is
+  `hawala_ledger_account`. As dormant code this never fired; as the new default
+  it would have thrown on **every** transfer. Fixed.
+- `reconciler.ts` summed `FROM ledger_entry` — real table `hawala_ledger_entry`
+  — so the balance-drift reconciler job was silently erroring on every run.
+  Fixed (both queries).
+
+This is exactly the class of bug the gate existed to catch.
+
+**The soak harness now exists** —
+`backend/src/modules/hawala-ledger/__tests__/concurrency-soak.integration.spec.ts`
+spins up a real Postgres via `moduleIntegrationTestRunner`, wires a live
+`PG_CONNECTION` (so the atomic-by-default paths are exercised), and fires
+concurrent operations to assert three invariants: (1) no overdraw under
+concurrent debits, (2) total value conserved across interleaved bidirectional
+transfers, (3) exact pool totals under concurrent investments.
+
+**The one part that still cannot be closed from the web env:** actually
+*running* that soak. This container has no DB (`pg_isready` → no response), and
+`TEST_TYPE=integration:modules` requires one. Run it in a DB-equipped
+environment before scaling real funds:
+
+```
+cd backend && TEST_TYPE=integration:modules NODE_OPTIONS=--experimental-vm-modules \
+  npx jest --runInBand --forceExit \
+  src/modules/hawala-ledger/__tests__/concurrency-soak.integration.spec.ts
+```
+
+(Idempotency is already well-covered: bounty transfer, sponsorship split, and
+`createTransfer` all have regression specs.)
 
 ---
 

--- a/backend/src/modules/hawala-ledger/__tests__/atomic-by-default.unit.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/atomic-by-default.unit.spec.ts
@@ -82,7 +82,7 @@ describe("createTransfer — atomic balance update by default", () => {
 
     // Two atomic balance UPDATEs ran; the legacy RMW path did not.
     expect(pg.raw).toHaveBeenCalledTimes(2)
-    expect(pg.calls[0].sql).toContain("UPDATE ledger_account")
+    expect(pg.calls[0].sql).toContain("UPDATE hawala_ledger_account")
     expect(pg.calls[0].sql).toContain("balance + ? >= 0")
     expect(pg.calls[0].bindings[0]).toBe(-100)
     expect(pg.calls[1].bindings[0]).toBe(100)

--- a/backend/src/modules/hawala-ledger/__tests__/atomic-by-default.unit.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/atomic-by-default.unit.spec.ts
@@ -1,0 +1,199 @@
+import HawalaLedgerModuleService from "../service"
+
+/**
+ * Unit tests for the "atomic by default" money path:
+ *
+ *  1. createTransfer self-resolves a pg connection from the module container
+ *     and uses the atomic balance CAS WITHOUT the caller threading one.
+ *  2. It still falls back to the legacy read-modify-write when no connection
+ *     is reachable (unit/DI-less contexts).
+ *  3. Investment-pool totals (total_raised/total_investors/total_distributed)
+ *     are bumped via a single atomic `col = col + ?` UPDATE when a connection
+ *     is reachable, and fall back to read-modify-write otherwise.
+ *
+ * The service is instantiated without the real constructor (which needs
+ * Medusa DI), then its auto-CRUD surface is stubbed — same approach as
+ * update-balances-atomic.unit.spec.ts and transfer-idempotency.unit.spec.ts.
+ */
+
+type RawCall = { sql: string; bindings: any[] }
+
+function makeAccount(id: string, balance = 1000) {
+  return {
+    id,
+    account_number: `ACC-${id}`,
+    currency_code: "USD",
+    balance,
+    available_balance: balance,
+    owner_id: "owner",
+    owner_type: "SELLER",
+  }
+}
+
+/**
+ * Build a service whose container_ resolves the given pgConnection (or, when
+ * `pg` is undefined, throws on resolve like awilix does for an unregistered
+ * key — exercising the guarded fallback).
+ */
+function buildTransferService(pg?: { raw: jest.Mock }) {
+  const svc: any = Object.create(HawalaLedgerModuleService.prototype)
+
+  const accountsById: Record<string, any> = {
+    "acc-debit": makeAccount("acc-debit"),
+    "acc-credit": makeAccount("acc-credit"),
+  }
+
+  svc.listLedgerEntries = jest.fn(async () => [])
+  svc.retrieveLedgerAccount = jest.fn(async (id: string) => accountsById[id])
+  svc.createLedgerEntries = jest.fn(async (data: any) => ({ id: "entry-1", ...data }))
+  svc.updateLedgerEntries = jest.fn(async (data: any) => data)
+  svc.updateBalances = jest.fn(async () => undefined)
+
+  svc.container_ = {
+    resolve: jest.fn(() => {
+      if (!pg) throw new Error("AwilixResolutionError: pgConnection not registered")
+      return pg
+    }),
+  }
+
+  return svc
+}
+
+function makePg(): { raw: jest.Mock; calls: RawCall[] } {
+  const calls: RawCall[] = []
+  const raw = jest.fn(async (sql: string, bindings: any[]) => {
+    calls.push({ sql, bindings })
+    return { rowCount: 1 }
+  })
+  return { raw, calls }
+}
+
+describe("createTransfer — atomic balance update by default", () => {
+  it("uses the atomic CAS via a self-resolved connection (no pgConnection arg)", async () => {
+    const pg = makePg()
+    const svc = buildTransferService(pg)
+
+    await svc.createTransfer({
+      debit_account_id: "acc-debit",
+      credit_account_id: "acc-credit",
+      amount: 100,
+      entry_type: "TRANSFER",
+    })
+
+    // Two atomic balance UPDATEs ran; the legacy RMW path did not.
+    expect(pg.raw).toHaveBeenCalledTimes(2)
+    expect(pg.calls[0].sql).toContain("UPDATE ledger_account")
+    expect(pg.calls[0].sql).toContain("balance + ? >= 0")
+    expect(pg.calls[0].bindings[0]).toBe(-100)
+    expect(pg.calls[1].bindings[0]).toBe(100)
+    expect(svc.updateBalances).not.toHaveBeenCalled()
+  })
+
+  it("falls back to legacy updateBalances when no connection is reachable", async () => {
+    const svc = buildTransferService(undefined)
+
+    await svc.createTransfer({
+      debit_account_id: "acc-debit",
+      credit_account_id: "acc-credit",
+      amount: 100,
+      entry_type: "TRANSFER",
+    })
+
+    // Debit + credit through the read-modify-write fallback.
+    expect(svc.updateBalances).toHaveBeenCalledTimes(2)
+  })
+
+  it("prefers an explicitly-passed connection over self-resolution", async () => {
+    const resolved = makePg()
+    const explicit = makePg()
+    const svc = buildTransferService(resolved)
+
+    await svc.createTransfer({
+      debit_account_id: "acc-debit",
+      credit_account_id: "acc-credit",
+      amount: 50,
+      entry_type: "TRANSFER",
+      pgConnection: explicit.raw ? { raw: explicit.raw } : undefined,
+    })
+
+    expect(explicit.raw).toHaveBeenCalledTimes(2)
+    expect(resolved.raw).not.toHaveBeenCalled()
+  })
+})
+
+describe("investment-pool totals — atomic increments", () => {
+  function buildPoolService(pg?: { raw: jest.Mock }) {
+    const svc: any = Object.create(HawalaLedgerModuleService.prototype)
+    const pool = {
+      id: "pool-1",
+      ledger_account_id: "acc-pool",
+      total_raised: 200,
+      total_investors: 4,
+      total_distributed: 30,
+    }
+    svc.retrieveInvestmentPool = jest.fn(async () => pool)
+    svc.listInvestments = jest.fn(async () => [])
+    svc.createInvestments = jest.fn(async (d: any) => ({ id: "inv-1", ...d }))
+    svc.updateInvestments = jest.fn(async (d: any) => d)
+    svc.updateInvestmentPools = jest.fn(async (d: any) => d)
+    // Isolate the pool-total path from the balance machinery.
+    svc.createTransfer = jest.fn(async () => ({ id: "entry-1" }))
+    svc.container_ = {
+      resolve: jest.fn(() => {
+        if (!pg) throw new Error("AwilixResolutionError")
+        return pg
+      }),
+    }
+    return { svc, pool }
+  }
+
+  it("createInvestment bumps total_raised/total_investors via one atomic UPDATE", async () => {
+    const pg = makePg()
+    const { svc } = buildPoolService(pg)
+
+    await svc.createInvestment({
+      pool_id: "pool-1",
+      investor_account_id: "acc-investor",
+      amount: 75,
+    })
+
+    expect(pg.raw).toHaveBeenCalledTimes(1)
+    const call = pg.calls[0]
+    expect(call.sql).toContain("UPDATE hawala_investment_pool")
+    expect(call.sql).toContain("total_raised = total_raised + ?")
+    expect(call.sql).toContain("total_investors = total_investors + ?")
+    expect(call.bindings).toEqual([75, 1, "pool-1"])
+    // No read-modify-write when the atomic path ran.
+    expect(svc.updateInvestmentPools).not.toHaveBeenCalled()
+  })
+
+  it("createInvestment falls back to read-modify-write without a connection", async () => {
+    const { svc } = buildPoolService(undefined)
+
+    await svc.createInvestment({
+      pool_id: "pool-1",
+      investor_account_id: "acc-investor",
+      amount: 75,
+    })
+
+    expect(svc.updateInvestmentPools).toHaveBeenCalledWith({
+      id: "pool-1",
+      total_raised: 275, // 200 + 75
+      total_investors: 5, // 4 + 1
+    })
+  })
+
+  it("distributeDividends bumps total_distributed via an atomic UPDATE", async () => {
+    const pg = makePg()
+    const { svc } = buildPoolService(pg)
+
+    await svc.distributeDividends({ pool_id: "pool-1", total_amount: 60 })
+
+    expect(pg.raw).toHaveBeenCalledTimes(1)
+    const call = pg.calls[0]
+    expect(call.sql).toContain("UPDATE hawala_investment_pool")
+    expect(call.sql).toContain("total_distributed = total_distributed + ?")
+    expect(call.bindings).toEqual([60, "pool-1"])
+    expect(svc.updateInvestmentPools).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/modules/hawala-ledger/__tests__/concurrency-soak.integration.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/concurrency-soak.integration.spec.ts
@@ -1,0 +1,201 @@
+import { moduleIntegrationTestRunner } from "@medusajs/test-utils"
+import { HAWALA_LEDGER_MODULE } from ".."
+import HawalaLedgerModuleService from "../service"
+import {
+  LedgerAccount,
+  LedgerEntry,
+  SettlementBatch,
+  InvestmentPool,
+  Investment,
+  BankAccount,
+  AchTransaction,
+  VendorAdvance,
+  AdvanceRepayment,
+  PayoutConfig,
+  PayoutSplitRule,
+  PayoutRequest,
+  ChargebackProtection,
+  ChargebackClaim,
+  VendorPayment,
+  VendorCreditLine,
+  CreditLineTransaction,
+  EscrowAgreement,
+  PatronageAllocation,
+  KarmaEvent,
+} from "../models"
+
+/**
+ * Money-path concurrency soak — the residual LAUNCH_READINESS §2 gate.
+ *
+ * This is the verification the unit tests structurally CANNOT provide: it
+ * spins up a real Postgres (via moduleIntegrationTestRunner), wires the
+ * module container with a real PG_CONNECTION so `createTransfer` and the
+ * pool-total updates take their atomic-by-default paths, and then fires
+ * genuinely concurrent operations at a single account/pool to prove the
+ * atomic CAS holds the financial invariants under contention.
+ *
+ * Requires a database — run with:
+ *   TEST_TYPE=integration:modules yarn test:integration:modules \
+ *     src/modules/hawala-ledger/__tests__/concurrency-soak.integration.spec.ts
+ *
+ * It is intentionally NOT a *.unit.spec.ts, so the unit suite (which has no
+ * DB) does not pick it up. If the legacy read-modify-write path were active,
+ * or the atomic UPDATE targeted the wrong table, these assertions would fail
+ * with overdrafts, lost updates, or conservation violations.
+ *
+ * The model list mirrors exactly what HawalaLedgerModuleService registers, so
+ * the generated schema matches the service's expectations.
+ */
+moduleIntegrationTestRunner<HawalaLedgerModuleService>({
+  moduleName: HAWALA_LEDGER_MODULE,
+  moduleModels: [
+    LedgerAccount,
+    LedgerEntry,
+    SettlementBatch,
+    InvestmentPool,
+    Investment,
+    BankAccount,
+    AchTransaction,
+    VendorAdvance,
+    AdvanceRepayment,
+    PayoutConfig,
+    PayoutSplitRule,
+    PayoutRequest,
+    ChargebackProtection,
+    ChargebackClaim,
+    VendorPayment,
+    VendorCreditLine,
+    CreditLineTransaction,
+    EscrowAgreement,
+    PatronageAllocation,
+    KarmaEvent,
+  ],
+  testSuite: ({ service }) => {
+    /**
+     * Create an account and seed its balance/available_balance directly
+     * (bypassing the transfer rails, which is fine for test setup).
+     */
+    async function seedAccount(accountType: string, balance: number) {
+      const account = await service.createAccount({
+        account_type: accountType,
+        owner_type: "SELLER",
+        owner_id: `owner-${Math.random().toString(36).slice(2)}`,
+      })
+      if (balance > 0) {
+        await (service as any).updateLedgerAccounts({
+          id: account.id,
+          balance,
+          available_balance: balance,
+        })
+      }
+      return account.id
+    }
+
+    async function balanceOf(accountId: string): Promise<number> {
+      const a = await service.retrieveLedgerAccount(accountId)
+      return Number(a.balance)
+    }
+
+    describe("hawala money-path concurrency soak (atomic by default)", () => {
+      it("never overdraws a single account under concurrent debits", async () => {
+        const FUNDING = 100
+        const ATTEMPTS = 150 // 50 more than can succeed
+        const source = await seedAccount("SELLER_EARNINGS", FUNDING)
+        const sink = await seedAccount("SELLER_EARNINGS", 0)
+
+        const results = await Promise.allSettled(
+          Array.from({ length: ATTEMPTS }, () =>
+            service.createTransfer({
+              debit_account_id: source,
+              credit_account_id: sink,
+              amount: 1,
+              entry_type: "TRANSFER",
+            })
+          )
+        )
+
+        const ok = results.filter((r) => r.status === "fulfilled").length
+        const failed = results.filter((r) => r.status === "rejected").length
+
+        // Exactly the funded amount of debits may succeed; the rest must be
+        // rejected by the atomic CAS — not silently allowed to overdraw.
+        expect(ok).toBe(FUNDING)
+        expect(failed).toBe(ATTEMPTS - FUNDING)
+
+        // The account is drained to exactly zero and never went negative.
+        expect(await balanceOf(source)).toBe(0)
+        // Every successful debit landed on the sink (no lost credits).
+        expect(await balanceOf(sink)).toBe(FUNDING)
+      })
+
+      it("conserves total value across concurrent bidirectional transfers", async () => {
+        const SEED = 1000
+        const N = 100
+        const a = await seedAccount("SELLER_EARNINGS", SEED)
+        const b = await seedAccount("SELLER_EARNINGS", SEED)
+
+        const transfers = [
+          ...Array.from({ length: N }, () =>
+            service.createTransfer({
+              debit_account_id: a,
+              credit_account_id: b,
+              amount: 1,
+              entry_type: "TRANSFER",
+            })
+          ),
+          ...Array.from({ length: N }, () =>
+            service.createTransfer({
+              debit_account_id: b,
+              credit_account_id: a,
+              amount: 1,
+              entry_type: "TRANSFER",
+            })
+          ),
+        ]
+
+        await Promise.allSettled(transfers)
+
+        const finalA = await balanceOf(a)
+        const finalB = await balanceOf(b)
+
+        // No money created or destroyed — the sum is conserved exactly even
+        // under interleaved read-modify-write pressure. A lost update would
+        // make this drift off 2*SEED.
+        expect(finalA + finalB).toBe(2 * SEED)
+        expect(finalA).toBeGreaterThanOrEqual(0)
+        expect(finalB).toBeGreaterThanOrEqual(0)
+      })
+
+      it("keeps investment-pool totals exact under concurrent investments", async () => {
+        const M = 50
+        const X = 2
+        const pool = await service.getOrCreateProducerPool(
+          `producer-${Math.random().toString(36).slice(2)}`
+        )
+        const investor = await seedAccount("USER_WALLET", M * X)
+
+        const results = await Promise.allSettled(
+          Array.from({ length: M }, () =>
+            service.createInvestment({
+              pool_id: pool!.id,
+              investor_account_id: investor,
+              amount: X,
+            })
+          )
+        )
+
+        const ok = results.filter((r) => r.status === "fulfilled").length
+        expect(ok).toBe(M)
+
+        const finalPool = await service.retrieveInvestmentPool(pool!.id)
+        // Atomic col = col + ? increments: no lost updates under concurrency.
+        expect(Number(finalPool.total_raised)).toBe(M * X)
+        expect(Number(finalPool.total_investors)).toBe(M)
+
+        // Funds fully moved investor -> pool ledger account.
+        expect(await balanceOf(investor)).toBe(0)
+        expect(await balanceOf(pool!.ledger_account_id)).toBe(M * X)
+      })
+    })
+  },
+})

--- a/backend/src/modules/hawala-ledger/__tests__/update-balances-atomic.unit.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/update-balances-atomic.unit.spec.ts
@@ -71,7 +71,7 @@ describe("updateBalancesAtomic (via createTransfer)", () => {
     expect(pgConnection.raw).toHaveBeenCalledTimes(2)
 
     const debitCall = rawCalls[0]
-    expect(debitCall.sql).toContain("UPDATE ledger_account")
+    expect(debitCall.sql).toContain("UPDATE hawala_ledger_account")
     expect(debitCall.sql).toContain("balance = balance + ?")
     expect(debitCall.sql).toContain("balance + ? >= 0")
     // delta is the first binding and is negative for the debit

--- a/backend/src/modules/hawala-ledger/reconciler.ts
+++ b/backend/src/modules/hawala-ledger/reconciler.ts
@@ -2,10 +2,10 @@
  * Ledger balance reconciler.
  *
  * Recomputes the "ledger truth" for every account from the immutable
- * `ledger_entry` rows (sum of credits minus sum of debits over terminal
- * COMPLETED/SETTLED entries) and compares it to the cached
- * `ledger_account.balance`. Any drift above a small epsilon is reported
- * and logged.
+ * `hawala_ledger_entry` rows (sum of credits minus sum of debits over
+ * terminal COMPLETED/SETTLED entries) and compares it to the cached
+ * `hawala_ledger_account.balance`. Any drift above a small epsilon is
+ * reported and logged.
  *
  * This is intentionally READ-ONLY: it never auto-corrects balances. A
  * detected drift is an operational signal that the cached balance and the
@@ -53,7 +53,7 @@ export async function reconcileLedgerBalances(
   // entries only. Two grouped scans, combined in memory.
   const creditResult = await pgConnection.raw(
     `SELECT credit_account_id AS account_id, COALESCE(SUM(amount), 0) AS total
-       FROM ledger_entry
+       FROM hawala_ledger_entry
       WHERE deleted_at IS NULL
         AND status IN ('COMPLETED', 'SETTLED')
         AND credit_account_id IS NOT NULL
@@ -62,7 +62,7 @@ export async function reconcileLedgerBalances(
   )
   const debitResult = await pgConnection.raw(
     `SELECT debit_account_id AS account_id, COALESCE(SUM(amount), 0) AS total
-       FROM ledger_entry
+       FROM hawala_ledger_entry
       WHERE deleted_at IS NULL
         AND status IN ('COMPLETED', 'SETTLED')
         AND debit_account_id IS NOT NULL

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -1,4 +1,4 @@
-import { MedusaService } from "@medusajs/framework/utils"
+import { MedusaService, ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { auditFinancialTransaction, logAuditEvent } from "./audit-logger"
 import { assertRailInvariants } from "./posture-a-guard"
 import {
@@ -576,11 +576,16 @@ class HawalaLedgerModuleService extends MedusaService({
       metadata: data.metadata,
     })
 
-    // Update account balances. Prefer the atomic CAS path when a pg
-    // connection is supplied; fall back to the legacy read-modify-write.
-    if (data.pgConnection) {
-      await this.updateBalancesAtomic(data.pgConnection, data.debit_account_id, -data.amount)
-      await this.updateBalancesAtomic(data.pgConnection, data.credit_account_id, data.amount)
+    // Update account balances. Prefer the atomic CAS path: use the caller's
+    // pg connection when supplied, otherwise self-resolve one from the module
+    // container so production money moves are atomic by default (the ~39
+    // createTransfer call sites don't have to thread a connection). Only when
+    // no connection is reachable at all (e.g. unit tests without DI) do we
+    // fall back to the legacy read-modify-write updateBalances.
+    const pgConnection = data.pgConnection ?? this.resolvePgConnection()
+    if (pgConnection) {
+      await this.updateBalancesAtomic(pgConnection, data.debit_account_id, -data.amount)
+      await this.updateBalancesAtomic(pgConnection, data.credit_account_id, data.amount)
     } else {
       await this.updateBalances(data.debit_account_id, -data.amount)
       await this.updateBalances(data.credit_account_id, data.amount)
@@ -630,6 +635,65 @@ class HawalaLedgerModuleService extends MedusaService({
    * 
    * For debits, validates sufficient balance before update.
    */
+  /**
+   * Resolve a raw pg connection from the module container, or undefined when
+   * one isn't reachable (e.g. unit tests instantiated without Medusa DI).
+   *
+   * This lets money-moving methods default to the atomic CAS / atomic-SQL
+   * paths in production WITHOUT every one of the ~39 createTransfer call
+   * sites having to thread a connection by hand. Mirrors the proven pattern
+   * in creator-attribution's `atomicIncrementAffiliateLink`. The awilix
+   * container throws on an unregistered key, so the resolve is guarded.
+   */
+  private resolvePgConnection():
+    | { raw: (sql: string, bindings?: any[]) => Promise<any> }
+    | undefined {
+    const container = (this as any).container_
+    try {
+      const pg = container?.resolve?.(ContainerRegistrationKeys.PG_CONNECTION)
+      return pg?.raw ? pg : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  /**
+   * Atomically apply integer/decimal deltas to investment-pool counter
+   * columns in a single `col = col + ?` UPDATE, so concurrent
+   * investments/distributions don't clobber each other (read-modify-write
+   * loses updates under concurrency). Returns true when the atomic UPDATE
+   * ran; false when no pg connection is reachable so the caller can fall
+   * back to the legacy read-modify-write.
+   *
+   * Column names come from a fixed allowlist and are interpolated into the
+   * SQL identifier position (bindings can't bind identifiers); deltas are
+   * always parameter-bound.
+   */
+  private async atomicPoolIncrement(
+    poolId: string,
+    increments: Partial<
+      Record<"total_raised" | "total_investors" | "total_distributed", number>
+    >
+  ): Promise<boolean> {
+    const pg = this.resolvePgConnection()
+    if (!pg) return false
+
+    const ALLOWED = ["total_raised", "total_investors", "total_distributed"] as const
+    const cols = Object.keys(increments).filter(
+      (c): c is (typeof ALLOWED)[number] =>
+        (ALLOWED as readonly string[]).includes(c)
+    )
+    if (cols.length === 0) return true
+
+    const setClause = cols.map((c) => `${c} = ${c} + ?`).join(", ")
+    const bindings = [...cols.map((c) => increments[c] as number), poolId]
+    await pg.raw(
+      `UPDATE hawala_investment_pool SET ${setClause}, updated_at = NOW() WHERE id = ? AND deleted_at IS NULL`,
+      bindings
+    )
+    return true
+  }
+
   /**
    * Atomically apply a balance delta using a single conditional UPDATE.
    *
@@ -1118,17 +1182,20 @@ class HawalaLedgerModuleService extends MedusaService({
       invested_at: new Date(),
     })
 
-    // Update pool totals
-    // FOLLOW-UP: these total_raised/total_investors increments are a
-    // read-modify-write and can lose updates under concurrent investments.
-    // Move to an atomic SQL UPDATE (... SET total_raised = total_raised + ?,
-    // total_investors = total_investors + 1 WHERE id = ?) once a pgConnection
-    // is threaded through this path.
-    await this.updateInvestmentPools({
-      id: data.pool_id,
-      total_raised: Number(pool.total_raised) + data.amount,
-      total_investors: pool.total_investors + 1,
+    // Update pool totals atomically (col = col + ?) so concurrent investments
+    // don't clobber each other. Falls back to read-modify-write only when no
+    // pg connection is reachable (e.g. unit tests without DI).
+    const atomicallyUpdated = await this.atomicPoolIncrement(data.pool_id, {
+      total_raised: data.amount,
+      total_investors: 1,
     })
+    if (!atomicallyUpdated) {
+      await this.updateInvestmentPools({
+        id: data.pool_id,
+        total_raised: Number(pool.total_raised) + data.amount,
+        total_investors: pool.total_investors + 1,
+      })
+    }
 
     return investment
   }
@@ -1183,13 +1250,18 @@ class HawalaLedgerModuleService extends MedusaService({
       }
     }
 
-    // Update pool totals
-    // FOLLOW-UP: read-modify-write; move total_distributed increment to an
-    // atomic SQL UPDATE once a pgConnection is threaded through this path.
-    await this.updateInvestmentPools({
-      id: data.pool_id,
-      total_distributed: Number(pool.total_distributed) + data.total_amount,
+    // Update pool totals atomically (col = col + ?) so concurrent
+    // distributions don't clobber each other. Falls back to read-modify-write
+    // only when no pg connection is reachable (e.g. unit tests without DI).
+    const distributedAtomically = await this.atomicPoolIncrement(data.pool_id, {
+      total_distributed: data.total_amount,
     })
+    if (!distributedAtomically) {
+      await this.updateInvestmentPools({
+        id: data.pool_id,
+        total_distributed: Number(pool.total_distributed) + data.total_amount,
+      })
+    }
 
     return distributions
   }

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -711,7 +711,7 @@ class HawalaLedgerModuleService extends MedusaService({
     delta: number
   ): Promise<void> {
     const result = await pgConnection.raw(
-      `UPDATE ledger_account
+      `UPDATE hawala_ledger_account
          SET balance = balance + ?,
              available_balance = available_balance + ?,
              updated_at = NOW()


### PR DESCRIPTION
## Summary

Closes the **code-side of the one remaining FBM launch gate** (`LAUNCH_READINESS.md` §2 — money-path concurrency), and wires the verifying soak into CI. Also carries the prior launch-gap work on this branch (bounties nav + objective types, Launch-a-Business wizard, Sponsor-a-creator / launch-sponsorship workflow, creator matching surfaces) and a web-session SessionStart hook.

The headline change: the atomic ledger path existed but was **dormant**, and turning it on surfaced two latent table-name bugs that would have broken production.

## The money-path gate

The atomic balance compare-and-swap (`updateBalancesAtomic`) and the pool-total fix existed in the code but were never exercised: the CAS only ran when a caller threaded `pgConnection`, and **none of the ~39 `createTransfer` call sites did** — so every production money move used the legacy non-atomic read-modify-write (TOCTOU window), and the pool totals were lossy read-modify-writes.

- **Atomic by default.** `createTransfer` now self-resolves a pg connection from the module container (`resolvePgConnection`, mirroring `creator-attribution`'s proven pattern) and uses the atomic CAS by default. No call site has to thread a connection; the legacy path only runs when no connection is reachable (DI-less unit tests). An explicitly-passed connection still wins.
- **Atomic pool totals.** `createInvestment` / `distributeDividends` now use a single atomic `col = col + ?` UPDATE (`atomicPoolIncrement`), closing the two flagged read-modify-write `FOLLOW-UP`s.

## Latent table-name bugs found & fixed

Wiring the atomic path on by default exposed two raw-SQL statements pointing at **non-existent tables** (no compatibility view exists):

- `updateBalancesAtomic` did `UPDATE ledger_account` — the real table is `hawala_ledger_account`. Dormant before; as the new default it would have thrown on **every transfer**.
- `reconciler.ts` summed `FROM ledger_entry` — real table `hawala_ledger_entry` — so the balance-drift reconciler job was silently erroring on every run.

Both fixed (plus the unit assertions that had pinned the old name). This is exactly the class of bug the gate existed to catch.

## Verification

- **New unit specs** — `atomic-by-default.unit.spec.ts`: atomic-by-default, explicit-over-resolved precedence, fallback when no DB, and atomic pool increments. Full backend unit suite green (**710 tests**).
- **Concurrency soak** — `concurrency-soak.integration.spec.ts` uses `moduleIntegrationTestRunner` to stand up a real Postgres, wires a live `PG_CONNECTION` (so the atomic-by-default paths run), and fires concurrent ops at one account/pool to assert three invariants: no overdraw under concurrent debits, value conservation across interleaved bidirectional transfers, and exact pool totals under concurrent investments.
- **CI wiring** — a dedicated `test-soak` job runs the soak on every push/PR against a Postgres service. It's independent of the `integration:http` app-boot debt (TI-3) because the module runner never boots the full app.

## ⚠️ One thing to flip after the first green run

The `test-soak` job lands **non-blocking** (`continue-on-error: true`) because it was authored in a DB-less environment and has never been executed — shipping it as a hard required check on code never run risks turning every PR red on an unforeseen env quirk. This follows the repo's own live-Postgres rollout convention (see the `test-integration` TI-1/TI-3 history). **Once this PR's `test-soak` run is observed green, delete that one `continue-on-error` line to make it gate for real.**

## Residual gate (not in this PR's control)

Running the soak requires a DB, which the authoring (web) environment lacks. The `test-soak` CI job is the automated path; this PR's run will be its first real execution against live Postgres.

https://claude.ai/code/session_01Wby3ku3BtG1rhDwPWhsoYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wby3ku3BtG1rhDwPWhsoYt)_