### PR TITLE
feat(opportunity-engine): §5 Opportunity Engine + §15 Economic Intelligence + §12 startup guides

### DIFF
--- a/LAUNCH_READINESS.md
+++ b/LAUNCH_READINESS.md
@@ -64,7 +64,10 @@ Legend: ✅ complete · 🟡 partial · 🔴 missing/stub · ⏸️ deferred
 | **Launch Center** | Launch product / business / sponsorship | ✅ One entrypoint, three launch types | `/v1/seller/launches` + `workflows/launch-{product,sponsorship}/` |
 | **Sponsorship marketplace** | Producer↔creator, 10% fee | ✅ Escrow + 90/10 split, deterministic idempotency | `collective-hawala.ts` `paySponsorship`, `SPONSORSHIP_PLATFORM_FEE_PERCENT` |
 | **"All businesses in one profile"** | Multi-seller per identity | ⏸️ Deferred (one-auth→many-sellers architecture) | — |
-| **Opportunity Engine** | Demand/opportunity scoring | ⏸️ Phase 2 (score fields exist, no algorithm) | `demand-post.attractiveness_score` |
+| **Opportunity Engine** | Demand/opportunity scoring | ✅ Implemented (deterministic 0–10 score + price tracker) | `modules/opportunity-engine/`, `api/store/opportunities`, `/store/price-tracker` — see `PHASE_2_CHECKLIST.md` |
+| **Knowledge Base / DIY** | DIY library + guides (§14) | ✅ Implemented | `modules/knowledge-base/`, `api/store/knowledge-base` |
+| **Economic Intelligence** | Market/price trends (§15) | ✅ Implemented | `api/v1/seller/economic-intelligence/trends` |
+| **Plugin ecosystem** | Browse/install plugins (§16) | ✅ Implemented | `modules/plugin-registry/`, `api/store/plugins` |
 
 ### FBM launch-critical path (remaining)
 
@@ -213,7 +216,7 @@ Blackout's unified feed ships (Blackout repo).
 |---|---|---|---|
 | **1 — now** | Money-path concurrency verification (thread `pgConnection`, concurrency tests) | FBM | Final FBM money gate before scale |
 | **2 — Blackout surfaces** | Coliseum (phased), Dens, unified Feed, Creator Hub UI | **Blackout repo** | Closes the discovery loop |
-| **Deferred** | Multi-seller ("all businesses in one profile"); Opportunity Engine; Featured Placement | FBM (later) | Not launch blockers |
+| **Deferred** | Multi-seller ("all businesses in one profile"); Featured Placement | FBM (later) | Not launch blockers |
 
 Founding-100 private beta runs concurrently from Wave 1 onward on the working
 FBM commerce engine.

--- a/PHASE_2_CHECKLIST.md
+++ b/PHASE_2_CHECKLIST.md
@@ -1,0 +1,78 @@
+# FreeBlackMarket — Phase 2 Checklist Status
+
+_Last updated: 2026-06-08_
+
+This maps the Phase 2 "Functioning Features" spec to the code in **this repo
+(FBM)**. The spec spans two systems; the social/discovery half (**Dens**,
+**Coliseum**, the unified **Feed**, the **Creator Hub UI**) is built in the
+separate **Blackout** repo and reached over the webhook/entitlements contract in
+`docs/contracts/blackout-integration.md`. Those are marked _Blackout_ below and
+are not FBM gaps.
+
+Legend: ✅ implemented · 🟡 partial · 🔵 Blackout repo
+
+| # | Feature | Status | Primary evidence (FBM) |
+|---|---|---|---|
+| 1 | User Accounts & Identity | ✅ | `lib/blackout-identity.ts`, `api/v1/integrations/blackout/oauth`, `seller-extension` (`blackout_user_id`, `mxid`) |
+| 2 | Marketplace | ✅ | `product-archetype`, `listing-type`, checkout/cart, Stripe, `delivery` + order tracking |
+| 3 | Vendor Profiles | ✅ | `producer`, `cooperative` memberships, `creator-attribution` partnerships, producer story |
+| 4 | Commerce Hub | ✅ | `api/store/directory`, `shared/external-stores.ts`, `woocommerce-import`, storefront links |
+| 5 | **Opportunity Engine** | ✅ | **`modules/opportunity-engine`** (scoring + price tracker), `api/store/opportunities[/:subject]`, `/store/price-tracker`, recompute job |
+| 6 | Launch Center | ✅ | `api/v1/seller/launches`, `workflows/launch-{product,sponsorship}` |
+| 7 | Producer–Creator Matching | ✅ | `api/v1/seller/matching/{creators,opportunities}`, `_ranking.ts` |
+| 8 | Bounty Marketplace | ✅ | `demand-pool`, bounty claim/milestone routes, escrow payout |
+| 9 | Sponsorship Marketplace | ✅ | `workflows/launch-sponsorship`, `collective-hawala.paySponsorship` (90/10) |
+| 10 | Referral System | ✅ | `creator-attribution`, affiliate links, earnings + KPI rollup |
+| 11 | Vendor Growth Dashboard | ✅ | metrics dashboard + **`api/v1/seller/growth/suggestions`** (creators / coalitions / high-demand) |
+| 12 | Business Launch System | ✅ | **`opportunity-engine/startup-guides`** catalog, `api/store/startup-guides[/:slug]` |
+| 13 | Community Product Pages | ✅ / 🔵 | **`api/store/products/:handle/community`** (coalitions + creator content); Dens threads = Blackout |
+| 14 | **Product Knowledge Base / DIY Library** | ✅ | **`modules/knowledge-base`**, `api/store/knowledge-base[/:slug]`, community contributions + moderation |
+| 15 | **Economic Intelligence** | ✅ | **`api/v1/seller/economic-intelligence/trends`**, price-trend analysis in `opportunity-engine/_scoring.ts` |
+| 16 | Black Market Product Integration | ✅ | **`modules/plugin-registry`** (`/store/plugins`, install), `/store/black-market/templates`, `digital-product` |
+
+## What this phase added (the former red/yellow gaps)
+
+The commerce substrate (1–4, 6–10) was already done. This phase closed the
+"discover → learn → opportunity" half of the funnel:
+
+- **§5 Opportunity Engine + §15 Economic Intelligence** — new `opportunity-engine`
+  module: a deterministic 0–10 opportunity score (high demand + low competition
+  + low startup cost) over live `demand-pool` / `wishlist` / `cooperative` /
+  catalog signals, a price tracker with trend analysis, materialized scores
+  (recompute job), and store/seller APIs. Pure scoring is unit-tested.
+- **§12 Business Launch System** — in-code startup-guide catalog (seedling,
+  compost, soap, gardening) supplying the startup-cost signal and a
+  "start a business" directory that feeds the Launch Center.
+- **§14 Product Knowledge Base** — new `knowledge-base` module: DIY library,
+  container-gardening guides (by climate/space/difficulty), substitution guides,
+  and a community-contribution moderation queue.
+- **§11 Growth Suggestions** — `/v1/seller/growth/suggestions` reusing the
+  matching ranking + opportunity scores + coalitions.
+- **§13 Community Product Pages** — `/store/products/:handle/community`
+  aggregation (Dens threads stay Blackout-hosted).
+- **§16 Plugin Ecosystem** — new `plugin-registry` module (browse + install) and
+  a curated business-templates directory.
+
+## Still deferred (Phase 3, per the spec's "What Can Wait")
+
+- Multi-seller "all businesses in one profile" (one auth → many sellers).
+- Featured Placement revenue.
+- Product tokens, coalition credit backing, investments, Blackstar vending,
+  advanced logistics/governance automation.
+
+## Seeds & jobs
+
+- `pnpm medusa exec ./src/scripts/seed-opportunity-engine.ts` (startup guides +
+  baseline prices), `./src/scripts/seed-knowledge-base.ts`,
+  `./src/scripts/seed-plugins.ts`.
+- Job `recompute-opportunity-scores` (every 6h) materializes opportunity scores.
+
+## Verification
+
+- Unit (DB-less): `cd backend && TEST_TYPE=unit … jest` — opportunity scoring,
+  KB catalog/filter, plugin catalog (24 new tests).
+- Typecheck: `cd backend && node node_modules/typescript/bin/tsc --noEmit` (0 errors).
+- DB-dependent (CI / DB env): module-integration specs + seed scripts; API smoke
+  on `/store/opportunities`, `/store/price-tracker`, `/store/knowledge-base`,
+  `/store/startup-guides`, `/store/plugins`, and authed
+  `/v1/seller/growth/suggestions`, `/v1/seller/economic-intelligence/trends`.

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -226,6 +226,15 @@ const collectiveModules = [
   { resolve: './src/modules/collective-campaign' },
 ]
 
+// Phase 2 discovery layer: Opportunity Engine (§5) + Economic Intelligence
+// (§15) + startup guides (§12); Product Knowledge Base / DIY library (§14);
+// plugin ecosystem (§16). See PHASE_2_CHECKLIST.md.
+const discoveryModules = [
+  { resolve: './src/modules/opportunity-engine' },
+  { resolve: './src/modules/knowledge-base' },
+  { resolve: './src/modules/plugin-registry' },
+]
+
 // Content/utility modules
 const utilityModules = [
   { resolve: './src/modules/cms-blueprint' },
@@ -538,6 +547,7 @@ module.exports = defineConfig({
     ...marketplaceModules,
     ...communityModules,
     ...collectiveModules,
+    ...discoveryModules,
     ...utilityModules,
     ...optionalModules,
 

--- a/backend/src/api/admin/knowledge-base/contributions/[id]/decide/route.ts
+++ b/backend/src/api/admin/knowledge-base/contributions/[id]/decide/route.ts
@@ -1,0 +1,52 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { KNOWLEDGE_BASE_MODULE } from "../../../../../../modules/knowledge-base"
+import type KnowledgeBaseService from "../../../../../../modules/knowledge-base/service"
+
+const decideSchema = z.object({
+  decision: z.enum(["APPROVE", "REJECT"]),
+  note: z.string().optional(),
+  slug: z.string().optional(),
+  category: z.string().optional(),
+  difficulty: z.string().optional(),
+})
+
+/**
+ * POST /admin/knowledge-base/contributions/:id/decide
+ * Moderate a community contribution (§14): approve (→ published article) or
+ * reject. Admin-authed.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const reviewerId = (req as any).auth_context?.actor_id || "admin"
+  const id = String(req.params.id)
+
+  const parsed = decideSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ message: "Invalid decision", issues: parsed.error.issues })
+  }
+
+  const kb = req.scope.resolve<KnowledgeBaseService>(KNOWLEDGE_BASE_MODULE)
+
+  try {
+    if (parsed.data.decision === "APPROVE") {
+      const article = await kb.approveContribution(id, reviewerId, {
+        slug: parsed.data.slug,
+        category: parsed.data.category,
+        difficulty: parsed.data.difficulty,
+      })
+      return res
+        .status(200)
+        .json({ status: "APPROVED", article: { id: article.id, slug: article.slug } })
+    }
+    const contribution = await kb.rejectContribution(
+      id,
+      reviewerId,
+      parsed.data.note
+    )
+    return res.status(200).json({ status: "REJECTED", contribution })
+  } catch (e) {
+    return res.status(404).json({ message: (e as Error).message, type: "not_found" })
+  }
+}

--- a/backend/src/api/store/black-market/templates/route.ts
+++ b/backend/src/api/store/black-market/templates/route.ts
@@ -1,0 +1,47 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+/**
+ * GET /store/black-market/templates
+ * Business templates surface (§16): curated vendor kits, launch kits, and
+ * marketing packs. These are delivered as digital products via the existing
+ * signed digital-product pipeline; this route is the curated directory.
+ * Filter by ?kind=VENDOR_KIT|LAUNCH_KIT|MARKETING_PACK.
+ */
+const TEMPLATES = [
+  {
+    slug: "starter-vendor-kit",
+    kind: "VENDOR_KIT",
+    name: "Starter Vendor Kit",
+    description:
+      "Profile, policy, and shipping templates to stand up a new shop fast.",
+  },
+  {
+    slug: "product-launch-kit",
+    kind: "LAUNCH_KIT",
+    name: "Product Launch Kit",
+    description:
+      "Launch checklist, bounty brief, and creator outreach templates.",
+  },
+  {
+    slug: "seasonal-marketing-pack",
+    kind: "MARKETING_PACK",
+    name: "Seasonal Marketing Pack",
+    description:
+      "Social copy, banners, and email templates for a seasonal campaign.",
+  },
+  {
+    slug: "coalition-onboarding-kit",
+    kind: "VENDOR_KIT",
+    name: "Coalition Onboarding Kit",
+    description:
+      "Member agreement, revenue-share, and needs-board templates for coalitions.",
+  },
+]
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const { kind } = req.query as Record<string, string>
+  const templates = kind
+    ? TEMPLATES.filter((t) => t.kind === kind.toUpperCase())
+    : TEMPLATES
+  return res.status(200).json({ count: templates.length, templates })
+}

--- a/backend/src/api/store/knowledge-base/[slug]/route.ts
+++ b/backend/src/api/store/knowledge-base/[slug]/route.ts
@@ -1,0 +1,21 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { KNOWLEDGE_BASE_MODULE } from "../../../../modules/knowledge-base"
+import type KnowledgeBaseService from "../../../../modules/knowledge-base/service"
+
+/**
+ * GET /store/knowledge-base/:slug
+ * Full article (§14) with materials, steps, and related products.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const slug = String(req.params.slug)
+  const kb = req.scope.resolve<KnowledgeBaseService>(KNOWLEDGE_BASE_MODULE)
+
+  const [article] = await kb.listKbArticles({ slug })
+  if (!article) {
+    return res
+      .status(404)
+      .json({ message: `Article "${slug}" not found`, type: "not_found" })
+  }
+
+  return res.status(200).json({ article })
+}

--- a/backend/src/api/store/knowledge-base/contributions/route.ts
+++ b/backend/src/api/store/knowledge-base/contributions/route.ts
@@ -1,0 +1,54 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { KNOWLEDGE_BASE_MODULE } from "../../../../modules/knowledge-base"
+import type KnowledgeBaseService from "../../../../modules/knowledge-base/service"
+
+const contributionSchema = z.object({
+  title: z.string().min(3),
+  type: z.enum(["DIY", "CONTAINER_GARDENING", "SUBSTITUTION"]).default("DIY"),
+  summary: z.string().min(1),
+  body: z.string().min(1),
+  category: z.string().optional(),
+  difficulty: z.string().optional(),
+  climate_zone: z.string().optional(),
+  space: z.string().optional(),
+  materials: z.array(z.string()).optional(),
+  steps: z.array(z.string()).optional(),
+})
+
+/**
+ * POST /store/knowledge-base/contributions
+ * Community Contributions (§14): an authenticated customer submits a
+ * tutorial/guide/method for moderation.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const parsed = contributionSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ message: "Invalid contribution", issues: parsed.error.issues })
+  }
+  const { title, type, ...payload } = parsed.data
+
+  const kb = req.scope.resolve<KnowledgeBaseService>(KNOWLEDGE_BASE_MODULE)
+  const contribution = await kb.submitContribution({
+    submitter_id: customerId,
+    submitter_type: "CUSTOMER",
+    title,
+    type,
+    payload,
+  })
+
+  return res.status(201).json({
+    contribution: {
+      id: contribution.id,
+      status: contribution.status,
+      title: contribution.title,
+    },
+  })
+}

--- a/backend/src/api/store/knowledge-base/route.ts
+++ b/backend/src/api/store/knowledge-base/route.ts
@@ -1,0 +1,59 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { KNOWLEDGE_BASE_MODULE } from "../../../modules/knowledge-base"
+import type KnowledgeBaseService from "../../../modules/knowledge-base/service"
+import { filterArticles } from "../../../modules/knowledge-base/catalog"
+import { KbArticleStatus } from "../../../modules/knowledge-base/models/kb-article"
+
+/**
+ * GET /store/knowledge-base
+ * DIY Library (§14): list published articles, filterable by type, category,
+ * difficulty, climate_zone, space, and free-text q.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const kb = req.scope.resolve<KnowledgeBaseService>(KNOWLEDGE_BASE_MODULE)
+  const {
+    type,
+    category,
+    difficulty,
+    climate_zone,
+    space,
+    q,
+    limit = "50",
+    offset = "0",
+  } = req.query as Record<string, string>
+
+  const all = await kb.listKbArticles(
+    { status: KbArticleStatus.PUBLISHED },
+    { take: 1000, order: { title: "ASC" } }
+  )
+
+  // Reuse the same pure filter the catalog defines (works on DB rows).
+  const filtered = filterArticles(all as any[], {
+    type,
+    category,
+    difficulty,
+    climate_zone,
+    space,
+    q,
+  })
+
+  const start = parseInt(offset, 10) || 0
+  const take = Math.min(parseInt(limit, 10) || 50, 100)
+  const page = filtered.slice(start, start + take)
+
+  return res.status(200).json({
+    count: filtered.length,
+    articles: page.map((a: any) => ({
+      slug: a.slug,
+      title: a.title,
+      type: a.type,
+      summary: a.summary,
+      category: a.category,
+      difficulty: a.difficulty,
+      climate_zone: a.climate_zone,
+      space: a.space,
+      contributed_by_community: a.contributed_by_community,
+      upvotes: a.upvotes,
+    })),
+  })
+}

--- a/backend/src/api/store/opportunities/[subject]/route.ts
+++ b/backend/src/api/store/opportunities/[subject]/route.ts
@@ -1,0 +1,95 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { OPPORTUNITY_ENGINE_MODULE } from "../../../../modules/opportunity-engine"
+import type OpportunityEngineService from "../../../../modules/opportunity-engine/service"
+import { gatherCategorySignals } from "../../../../modules/opportunity-engine/_signals"
+import { listStartupGuides } from "../../../../modules/opportunity-engine/startup-guides"
+import { COOPERATIVE_MODULE } from "../../../../modules/cooperative"
+
+/**
+ * GET /store/opportunities/:subject
+ * Opportunity page (§5) for a category subject: live market demand,
+ * price trend (§15), startup requirements (§12 guide), and related products /
+ * coalitions. `:subject` is the category key (e.g. "compost", "agriculture").
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const subject = String(req.params.subject)
+  const region = String((req.query as Record<string, string>).region || "US")
+
+  const engine = req.scope.resolve<OpportunityEngineService>(
+    OPPORTUNITY_ENGINE_MODULE
+  )
+
+  // Live signal snapshot (also reflects what the recompute job stores).
+  const snapshot = await gatherCategorySignals(req.scope, {
+    category: subject,
+    region,
+  })
+  const trend = await engine.getPriceTrend({ category: subject, region })
+
+  // Startup requirements: the guides whose opportunity key matches.
+  const guides = listStartupGuides().filter(
+    (g) =>
+      g.related_opportunity_key.toLowerCase() === subject.toLowerCase() ||
+      g.category.toLowerCase() === subject.toLowerCase()
+  )
+
+  // Related products in the category (best-effort).
+  let relatedProducts: Array<{ id: string; title: string; handle: string }> = []
+  try {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "product",
+      fields: ["id", "title", "handle", "categories.name"],
+      filters: { status: "published" },
+      pagination: { take: 200 },
+    })
+    relatedProducts = (data || [])
+      .filter((p: any) =>
+        (p?.categories ?? []).some(
+          (c: any) =>
+            typeof c?.name === "string" &&
+            c.name.toLowerCase() === subject.toLowerCase()
+        )
+      )
+      .slice(0, 12)
+      .map((p: any) => ({ id: p.id, title: p.title, handle: p.handle }))
+  } catch {
+    relatedProducts = []
+  }
+
+  // Related coalitions (cooperatives) — best-effort by region.
+  let relatedCoalitions: Array<{ id: string; name: string }> = []
+  try {
+    const coop: any = req.scope.resolve(COOPERATIVE_MODULE)
+    const coops = await coop.listCooperatives(
+      { public_storefront_enabled: true },
+      { take: 50 }
+    )
+    relatedCoalitions = (coops as any[])
+      .slice(0, 8)
+      .map((c) => ({ id: c.id, name: c.name }))
+  } catch {
+    relatedCoalitions = []
+  }
+
+  return res.status(200).json({
+    subject_key: subject,
+    region,
+    opportunity_score: snapshot.score.composite,
+    bands: snapshot.score.bands,
+    market_demand: snapshot.demand_raw,
+    competition: snapshot.competition_raw,
+    startup_cost_dollars: snapshot.startup_cost_dollars,
+    price_trend: trend,
+    startup_requirements: guides.map((g) => ({
+      slug: g.slug,
+      title: g.title,
+      estimated_startup_cost_cents: g.estimated_startup_cost_cents,
+      required_equipment: g.required_equipment,
+      production_suggestions: g.production_suggestions,
+    })),
+    related_products: relatedProducts,
+    related_coalitions: relatedCoalitions,
+  })
+}

--- a/backend/src/api/store/opportunities/route.ts
+++ b/backend/src/api/store/opportunities/route.ts
@@ -1,0 +1,41 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { OPPORTUNITY_ENGINE_MODULE } from "../../../modules/opportunity-engine"
+import type OpportunityEngineService from "../../../modules/opportunity-engine/service"
+
+/**
+ * GET /store/opportunities
+ * Ranked local-production opportunities (§5). Reads the materialized
+ * `opportunity_score` table (recomputed by the recompute-opportunity-scores
+ * job). Filter by region; sorted by composite score descending.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const engine = req.scope.resolve<OpportunityEngineService>(
+    OPPORTUNITY_ENGINE_MODULE
+  )
+
+  const { region = "US", limit = "20", offset = "0" } = req.query as Record<
+    string,
+    string
+  >
+
+  const rows = await engine.listTopOpportunities({
+    region,
+    limit: Math.min(parseInt(limit, 10) || 20, 100),
+    offset: parseInt(offset, 10) || 0,
+  })
+
+  const opportunities = (rows as any[]).map((r) => ({
+    id: r.id,
+    subject_key: r.subject_key,
+    subject_label: r.subject_label,
+    region: r.region,
+    opportunity_score: Number(r.composite),
+    demand: Number(r.demand_score),
+    competition: Number(r.competition_score),
+    startup_cost: Number(r.startup_cost_score),
+    bands: (r.signals as any)?.score?.bands ?? null,
+    computed_at: r.computed_at,
+  }))
+
+  return res.status(200).json({ region, count: opportunities.length, opportunities })
+}

--- a/backend/src/api/store/plugins/route.ts
+++ b/backend/src/api/store/plugins/route.ts
@@ -1,0 +1,32 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { PLUGIN_REGISTRY_MODULE } from "../../../modules/plugin-registry"
+import type PluginRegistryService from "../../../modules/plugin-registry/service"
+
+/**
+ * GET /store/plugins
+ * Browse the Black Market plugin ecosystem (§16): marketplace extensions,
+ * analytics, and automation tools. Filter by ?category=.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const registry = req.scope.resolve<PluginRegistryService>(
+    PLUGIN_REGISTRY_MODULE
+  )
+  const { category, limit = "100" } = req.query as Record<string, string>
+
+  const plugins = await registry.listPublished({
+    category,
+    limit: Math.min(parseInt(limit, 10) || 100, 200),
+  })
+
+  return res.status(200).json({
+    count: plugins.length,
+    plugins: (plugins as any[]).map((p) => ({
+      slug: p.slug,
+      name: p.name,
+      category: p.category,
+      description: p.description,
+      version: p.version,
+      install_count: p.install_count,
+    })),
+  })
+}

--- a/backend/src/api/store/price-tracker/route.ts
+++ b/backend/src/api/store/price-tracker/route.ts
@@ -1,0 +1,43 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { OPPORTUNITY_ENGINE_MODULE } from "../../../modules/opportunity-engine"
+import type OpportunityEngineService from "../../../modules/opportunity-engine/service"
+
+const FOCUS_CATEGORIES = ["food", "gardening", "agriculture", "home-goods"]
+
+/**
+ * GET /store/price-tracker
+ * Price Tracker (§5): price series + trend for a category in a region (US /
+ * state / named region). Focus categories: Food, Gardening, Agriculture,
+ * Household. Pass ?category=&region= for one, or omit category for the focus set.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const engine = req.scope.resolve<OpportunityEngineService>(
+    OPPORTUNITY_ENGINE_MODULE
+  )
+  const { category, region = "US" } = req.query as Record<string, string>
+
+  const categories = category ? [category] : FOCUS_CATEGORIES
+
+  const tracks = await Promise.all(
+    categories.map(async (cat) => {
+      const series = await engine.getPriceSeries({
+        category: cat,
+        region,
+        limit: 365,
+      })
+      const trend = await engine.getPriceTrend({ category: cat, region })
+      return {
+        category: cat,
+        region,
+        trend,
+        series: (series as any[]).map((s) => ({
+          price_cents: Number(s.price_cents),
+          unit: s.unit,
+          observed_at: s.observed_at,
+        })),
+      }
+    })
+  )
+
+  return res.status(200).json({ region, tracks })
+}

--- a/backend/src/api/store/products/[handle]/community/route.ts
+++ b/backend/src/api/store/products/[handle]/community/route.ts
@@ -1,0 +1,87 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { KNOWLEDGE_BASE_MODULE } from "../../../../../modules/knowledge-base"
+import type KnowledgeBaseService from "../../../../../modules/knowledge-base/service"
+import { filterArticles } from "../../../../../modules/knowledge-base/catalog"
+import { KbArticleStatus } from "../../../../../modules/knowledge-base/models/kb-article"
+import { COOPERATIVE_MODULE } from "../../../../../modules/cooperative"
+
+/**
+ * GET /store/products/:handle/community
+ * Community Product Page panel (§13): related coalitions, creator content
+ * (knowledge-base tutorials), and a discussion link. Note: the discussion
+ * threads themselves ("Dens") live in the Blackout repo and are surfaced via
+ * the existing webhook contract — this returns the deep-link/placeholder, not
+ * an FBM-hosted thread.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const handle = String(req.params.handle)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Resolve the product + its category.
+  let productId: string | null = null
+  let categories: string[] = []
+  try {
+    const { data } = await query.graph({
+      entity: "product",
+      fields: ["id", "handle", "categories.name"],
+      filters: { handle },
+      pagination: { take: 1 },
+    })
+    const product = (data || [])[0]
+    productId = product?.id ?? null
+    categories = (product?.categories ?? [])
+      .map((c: any) => c?.name)
+      .filter((n: unknown): n is string => typeof n === "string")
+  } catch {
+    productId = null
+  }
+
+  const primaryCategory = categories[0]
+
+  // Related knowledge-base / creator content in the product's category.
+  let creatorContent: Array<{ slug: string; title: string; type: string }> = []
+  try {
+    const kb = req.scope.resolve<KnowledgeBaseService>(KNOWLEDGE_BASE_MODULE)
+    const published = await kb.listKbArticles(
+      { status: KbArticleStatus.PUBLISHED },
+      { take: 500 }
+    )
+    const matched = primaryCategory
+      ? filterArticles(published as any[], { category: primaryCategory })
+      : (published as any[]).slice(0, 6)
+    creatorContent = matched.slice(0, 6).map((a: any) => ({
+      slug: a.slug,
+      title: a.title,
+      type: a.type,
+    }))
+  } catch {
+    creatorContent = []
+  }
+
+  // Related coalitions (best-effort, public storefronts).
+  let coalitions: Array<{ id: string; name: string }> = []
+  try {
+    const coop: any = req.scope.resolve(COOPERATIVE_MODULE)
+    const coops = await coop.listCooperatives(
+      { public_storefront_enabled: true },
+      { take: 6 }
+    )
+    coalitions = (coops as any[]).map((c) => ({ id: c.id, name: c.name }))
+  } catch {
+    coalitions = []
+  }
+
+  return res.status(200).json({
+    product_handle: handle,
+    product_id: productId,
+    coalition_recommendations: coalitions,
+    creator_content: creatorContent,
+    // Dens discussion lives in Blackout; deep-link by product when available.
+    discussion: {
+      provider: "blackout-dens",
+      // The Blackout app resolves this into the product's Den thread.
+      deep_link: productId ? `blackout://dens/product/${productId}` : null,
+    },
+  })
+}

--- a/backend/src/api/store/startup-guides/[slug]/route.ts
+++ b/backend/src/api/store/startup-guides/[slug]/route.ts
@@ -1,0 +1,80 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { getStartupGuide } from "../../../../modules/opportunity-engine/startup-guides"
+import { COOPERATIVE_MODULE } from "../../../../modules/cooperative"
+
+/**
+ * GET /store/startup-guides/:slug
+ * A single startup guide (§12) with its startup resources and the related
+ * products / coalitions / opportunity it links to — the "idea → production"
+ * bridge into the Launch Center.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const slug = String(req.params.slug)
+  const guide = getStartupGuide(slug)
+  if (!guide) {
+    return res
+      .status(404)
+      .json({ message: `Startup guide "${slug}" not found`, type: "not_found" })
+  }
+
+  // Related products in the guide's category (best-effort).
+  let relatedProducts: Array<{ id: string; title: string; handle: string }> = []
+  try {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "product",
+      fields: ["id", "title", "handle", "categories.name"],
+      filters: { status: "published" },
+      pagination: { take: 200 },
+    })
+    relatedProducts = (data || [])
+      .filter((p: any) =>
+        (p?.categories ?? []).some(
+          (c: any) =>
+            typeof c?.name === "string" &&
+            c.name.toLowerCase() === guide.category.toLowerCase()
+        )
+      )
+      .slice(0, 12)
+      .map((p: any) => ({ id: p.id, title: p.title, handle: p.handle }))
+  } catch {
+    relatedProducts = []
+  }
+
+  let relatedCoalitions: Array<{ id: string; name: string }> = []
+  try {
+    const coop: any = req.scope.resolve(COOPERATIVE_MODULE)
+    const coops = await coop.listCooperatives(
+      { public_storefront_enabled: true },
+      { take: 8 }
+    )
+    relatedCoalitions = (coops as any[]).map((c) => ({ id: c.id, name: c.name }))
+  } catch {
+    relatedCoalitions = []
+  }
+
+  return res.status(200).json({
+    guide: {
+      slug: guide.slug,
+      title: guide.title,
+      category: guide.category,
+      summary: guide.summary,
+      estimated_startup_cost_cents: guide.estimated_startup_cost_cents,
+      difficulty: guide.difficulty,
+      required_equipment: guide.required_equipment,
+      production_suggestions: guide.production_suggestions,
+      related_archetypes: guide.related_archetypes,
+      related_opportunity_key: guide.related_opportunity_key,
+    },
+    related_products: relatedProducts,
+    related_coalitions: relatedCoalitions,
+    // The "Launch this business" CTA posts to /v1/seller/launches with
+    // launch_type=BUSINESS, prefilled from this guide.
+    launch_hint: {
+      launch_type: "BUSINESS",
+      category: guide.category,
+      title: guide.title,
+    },
+  })
+}

--- a/backend/src/api/store/startup-guides/route.ts
+++ b/backend/src/api/store/startup-guides/route.ts
@@ -1,0 +1,21 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { listStartupGuides } from "../../../modules/opportunity-engine/startup-guides"
+
+/**
+ * GET /store/startup-guides
+ * Business Launch System catalog (§12). Code-sourced; lists the startup guides
+ * (seedling, compost, soap, gardening …) with cost/difficulty for the
+ * "Start a Business" directory.
+ */
+export async function GET(_req: MedusaRequest, res: MedusaResponse) {
+  const guides = listStartupGuides().map((g) => ({
+    slug: g.slug,
+    title: g.title,
+    category: g.category,
+    summary: g.summary,
+    estimated_startup_cost_cents: g.estimated_startup_cost_cents,
+    difficulty: g.difficulty,
+    related_opportunity_key: g.related_opportunity_key,
+  }))
+  return res.status(200).json({ count: guides.length, guides })
+}

--- a/backend/src/api/v1/seller/economic-intelligence/trends/route.ts
+++ b/backend/src/api/v1/seller/economic-intelligence/trends/route.ts
@@ -1,0 +1,70 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { OPPORTUNITY_ENGINE_MODULE } from "../../../../../modules/opportunity-engine"
+import type OpportunityEngineService from "../../../../../modules/opportunity-engine/service"
+
+const FOCUS_CATEGORIES = ["food", "gardening", "agriculture", "home-goods"]
+
+/**
+ * GET /v1/seller/economic-intelligence/trends
+ * Economic Intelligence (§15): market trends for the vendor — rising/falling
+ * demand (from opportunity scores) and price changes (from the price tracker).
+ * Read-only; backed by the materialized opportunity_score + price_observation
+ * data the recompute job maintains.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res
+      .status(401)
+      .json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const region = String((req.query as Record<string, string>).region || "US")
+  const engine = req.scope.resolve<OpportunityEngineService>(
+    OPPORTUNITY_ENGINE_MODULE
+  )
+
+  const scores = await engine.listTopOpportunities({ region, limit: 100 })
+  const byKey = new Map<string, any>()
+  for (const s of scores as any[]) {
+    byKey.set(String(s.subject_key), s)
+  }
+
+  const trends = await Promise.all(
+    FOCUS_CATEGORIES.map(async (category) => {
+      const trend = await engine.getPriceTrend({ category, region })
+      const score = byKey.get(category)
+      const composite = score ? Number(score.composite) : null
+      const demandScore = score ? Number(score.demand_score) : null
+      return {
+        category,
+        opportunity_score: composite,
+        demand_direction:
+          demandScore === null
+            ? "unknown"
+            : demandScore >= 0.66
+            ? "rising"
+            : demandScore <= 0.33
+            ? "falling"
+            : "steady",
+        price_trend: trend,
+      }
+    })
+  )
+
+  // Rising opportunities the vendor could move into now.
+  const rising = (scores as any[])
+    .filter((s) => Number(s.composite) >= 7)
+    .slice(0, 10)
+    .map((s) => ({
+      subject_key: s.subject_key,
+      opportunity_score: Number(s.composite),
+    }))
+
+  return res.status(200).json({
+    region,
+    trends,
+    rising_opportunities: rising,
+  })
+}

--- a/backend/src/api/v1/seller/growth/suggestions/route.ts
+++ b/backend/src/api/v1/seller/growth/suggestions/route.ts
@@ -1,0 +1,175 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { PRODUCER_MODULE } from "../../../../../modules/producer"
+import type ProducerService from "../../../../../modules/producer/service"
+import { CREATOR_PROGRAM_MODULE } from "../../../../../modules/creator-program"
+import type CreatorProgramService from "../../../../../modules/creator-program/service"
+import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../modules/creator-attribution"
+import type CreatorAttributionService from "../../../../../modules/creator-attribution/service"
+import { COOPERATIVE_MODULE } from "../../../../../modules/cooperative"
+import { OPPORTUNITY_ENGINE_MODULE } from "../../../../../modules/opportunity-engine"
+import type OpportunityEngineService from "../../../../../modules/opportunity-engine/service"
+import { rankCreators, type CreatorSignal } from "../../matching/_ranking"
+
+function sumSnapshot(snapshot: unknown): number {
+  if (!snapshot || typeof snapshot !== "object") {
+    return 0
+  }
+  return Object.values(snapshot as Record<string, unknown>).reduce<number>(
+    (sum, v) => sum + (typeof v === "number" && Number.isFinite(v) ? v : 0),
+    0
+  )
+}
+
+/**
+ * GET /v1/seller/growth/suggestions
+ * Vendor Growth Dashboard suggestions (§11): recommended creators (matching
+ * ranking), recommended coalitions, and high-demand products to launch
+ * (opportunity scores). Read-only; reuses existing modules.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const producerService = req.scope.resolve<ProducerService>(PRODUCER_MODULE)
+  const programs =
+    req.scope.resolve<CreatorProgramService>(CREATOR_PROGRAM_MODULE)
+  const attribution = req.scope.resolve<CreatorAttributionService>(
+    CREATOR_ATTRIBUTION_MODULE
+  )
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Seller signal: region + product categories.
+  const producerRows = await producerService.listProducers({
+    seller_id: sellerId,
+  })
+  const region = (producerRows[0]?.region ?? null) as string | null
+
+  let categories: string[] = []
+  try {
+    const { data: sellerProducts } = await query.graph({
+      entity: "seller_product",
+      fields: ["product.categories.name"],
+      filters: { seller_id: sellerId },
+    })
+    categories = [
+      ...new Set(
+        (sellerProducts || [])
+          .flatMap((sp: any) => sp?.product?.categories ?? [])
+          .map((c: any) => c?.name)
+          .filter((n: unknown): n is string => typeof n === "string")
+      ),
+    ]
+  } catch {
+    categories = []
+  }
+
+  // ── Recommended creators (reuse the matching ranking) ──
+  let recommendedCreators: Array<{
+    creator_seller_id: string
+    score: number
+    reasons: string[]
+  }> = []
+  try {
+    const applications = await programs.listCreatorApplications({}, { take: 1000 })
+    const deals = await programs.listCreatorDeals({}, { take: 2000 })
+    const links = await attribution.listAffiliateLinks({}, { take: 5000 })
+
+    const byCreator = new Map<string, CreatorSignal>()
+    const ensure = (id: string): CreatorSignal => {
+      let sig = byCreator.get(id)
+      if (!sig) {
+        sig = {
+          creator_seller_id: id,
+          niches: [],
+          regions: [],
+          follower_total: 0,
+          attributed_cents: 0,
+          clicks: 0,
+        }
+        byCreator.set(id, sig)
+      }
+      return sig
+    }
+    for (const app of applications as any[]) {
+      if (!app?.creator_seller_id) continue
+      const sig = ensure(app.creator_seller_id)
+      const platforms = Array.isArray(app.proposed_platforms)
+        ? (app.proposed_platforms as string[])
+        : []
+      sig.niches = [...new Set([...sig.niches, ...platforms])]
+      sig.follower_total = Math.max(
+        sig.follower_total,
+        sumSnapshot(app.follower_snapshot)
+      )
+    }
+    for (const deal of deals as any[]) {
+      if (!deal?.creator_seller_id) continue
+      ensure(deal.creator_seller_id).attributed_cents +=
+        Number(deal.total_attributed_cents) || 0
+    }
+    for (const link of links as any[]) {
+      if (!link?.creator_seller_id) continue
+      ensure(link.creator_seller_id).clicks += Number(link.click_count) || 0
+    }
+    recommendedCreators = rankCreators(
+      { categories, region },
+      [...byCreator.values()],
+      { limit: 5 }
+    )
+  } catch {
+    recommendedCreators = []
+  }
+
+  // ── Recommended coalitions (public, best-effort) ──
+  let recommendedCoalitions: Array<{ id: string; name: string }> = []
+  try {
+    const coop: any = req.scope.resolve(COOPERATIVE_MODULE)
+    const filters: Record<string, unknown> = {
+      public_storefront_enabled: true,
+    }
+    if (region) {
+      filters.region = region
+    }
+    const coops = await coop.listCooperatives(filters, { take: 5 })
+    recommendedCoalitions = (coops as any[]).map((c) => ({
+      id: c.id,
+      name: c.name,
+    }))
+  } catch {
+    recommendedCoalitions = []
+  }
+
+  // ── High-demand products to launch (opportunity scores) ──
+  let highDemand: Array<{ subject_key: string; opportunity_score: number }> = []
+  try {
+    const engine = req.scope.resolve<OpportunityEngineService>(
+      OPPORTUNITY_ENGINE_MODULE
+    )
+    const scores = await engine.listTopOpportunities({ limit: 100 })
+    const preferred = (scores as any[]).filter(
+      (s) =>
+        categories.length === 0 ||
+        categories.some(
+          (c) => c.toLowerCase() === String(s.subject_key).toLowerCase()
+        )
+    )
+    const pool = preferred.length > 0 ? preferred : (scores as any[])
+    highDemand = pool.slice(0, 5).map((s) => ({
+      subject_key: s.subject_key,
+      opportunity_score: Number(s.composite),
+    }))
+  } catch {
+    highDemand = []
+  }
+
+  return res.status(200).json({
+    seller_id: sellerId,
+    recommended_creators: recommendedCreators,
+    recommended_coalitions: recommendedCoalitions,
+    high_demand_products: highDemand,
+  })
+}

--- a/backend/src/api/v1/seller/plugins/[slug]/install/route.ts
+++ b/backend/src/api/v1/seller/plugins/[slug]/install/route.ts
@@ -1,0 +1,58 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
+import { SELLER_EXTENSION_MODULE } from "../../../../../../modules/seller-extension"
+import type SellerExtensionService from "../../../../../../modules/seller-extension/service"
+import { PLUGIN_REGISTRY_MODULE } from "../../../../../../modules/plugin-registry"
+import type PluginRegistryService from "../../../../../../modules/plugin-registry/service"
+
+/**
+ * POST /v1/seller/plugins/:slug/install
+ * Install a plugin (§16) for the authenticated vendor: add it to
+ * seller_metadata.enabled_extensions and bump the registry install count.
+ * Idempotent — installing an already-installed plugin is a no-op success.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+  const slug = String(req.params.slug)
+
+  const registry = req.scope.resolve<PluginRegistryService>(
+    PLUGIN_REGISTRY_MODULE
+  )
+  const plugin = await registry.getBySlug(slug)
+  if (!plugin) {
+    return res
+      .status(404)
+      .json({ message: `Plugin "${slug}" not found`, type: "not_found" })
+  }
+
+  const sellerExt = req.scope.resolve<SellerExtensionService>(
+    SELLER_EXTENSION_MODULE
+  )
+  const [meta] = await sellerExt.listSellerMetadatas({ seller_id: sellerId })
+  const current = Array.isArray(meta?.enabled_extensions)
+    ? (meta!.enabled_extensions as string[])
+    : []
+
+  if (current.includes(slug)) {
+    return res.status(200).json({ installed: current, already: true })
+  }
+
+  const next = [...current, slug]
+  if (meta) {
+    await sellerExt.updateSellerMetadatas({
+      id: meta.id,
+      enabled_extensions: next,
+    } as any)
+  } else {
+    await sellerExt.createSellerMetadatas({
+      seller_id: sellerId,
+      enabled_extensions: next,
+    } as any)
+  }
+  await registry.incrementInstallCount(slug)
+
+  return res.status(200).json({ installed: next, already: false })
+}

--- a/backend/src/api/v1/seller/plugins/installed/route.ts
+++ b/backend/src/api/v1/seller/plugins/installed/route.ts
@@ -2,11 +2,13 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
 import { SELLER_EXTENSION_MODULE } from "../../../../../modules/seller-extension"
 import type SellerExtensionService from "../../../../../modules/seller-extension/service"
+import { PLUGIN_REGISTRY_MODULE } from "../../../../../modules/plugin-registry"
+import type PluginRegistryService from "../../../../../modules/plugin-registry/service"
 
 /**
  * GET /v1/seller/plugins/installed
- * The authenticated vendor's installed plugin slugs (§16), read from
- * seller_metadata.enabled_extensions.
+ * The authenticated vendor's installed plugin slugs (§16) plus the available
+ * catalog, so the vendor Plugins page needs only seller auth.
  */
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const sellerId = (req as SellerAuthRequest).seller_id
@@ -22,5 +24,19 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     ? (meta!.enabled_extensions as string[])
     : []
 
-  return res.status(200).json({ installed })
+  const registry = req.scope.resolve<PluginRegistryService>(
+    PLUGIN_REGISTRY_MODULE
+  )
+  const available = await registry.listPublished({ limit: 200 })
+
+  return res.status(200).json({
+    installed,
+    available: (available as any[]).map((p) => ({
+      slug: p.slug,
+      name: p.name,
+      category: p.category,
+      description: p.description,
+      install_count: p.install_count,
+    })),
+  })
 }

--- a/backend/src/api/v1/seller/plugins/installed/route.ts
+++ b/backend/src/api/v1/seller/plugins/installed/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
+import { SELLER_EXTENSION_MODULE } from "../../../../../modules/seller-extension"
+import type SellerExtensionService from "../../../../../modules/seller-extension/service"
+
+/**
+ * GET /v1/seller/plugins/installed
+ * The authenticated vendor's installed plugin slugs (§16), read from
+ * seller_metadata.enabled_extensions.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as SellerAuthRequest).seller_id
+  if (!sellerId) {
+    return res.status(401).json({ message: "Unauthorized", type: "unauthorized" })
+  }
+
+  const sellerExt = req.scope.resolve<SellerExtensionService>(
+    SELLER_EXTENSION_MODULE
+  )
+  const [meta] = await sellerExt.listSellerMetadatas({ seller_id: sellerId })
+  const installed = Array.isArray(meta?.enabled_extensions)
+    ? (meta!.enabled_extensions as string[])
+    : []
+
+  return res.status(200).json({ installed })
+}

--- a/backend/src/jobs/recompute-opportunity-scores.ts
+++ b/backend/src/jobs/recompute-opportunity-scores.ts
@@ -1,0 +1,93 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { OPPORTUNITY_ENGINE_MODULE } from "../modules/opportunity-engine"
+import type OpportunityEngineService from "../modules/opportunity-engine/service"
+import { gatherCategorySignals } from "../modules/opportunity-engine/_signals"
+import { OpportunitySubjectType } from "../modules/opportunity-engine/models/opportunity-score"
+
+/**
+ * Scheduled job: recompute materialized opportunity scores (§5/§15).
+ *
+ * For each tracked category subject it gathers live demand/competition/
+ * startup-cost signals (`gatherCategorySignals`) and upserts the 0..10
+ * composite. The category set is the union of the startup-guide focus areas
+ * and any categories that currently have open demand posts, so new demand
+ * surfaces automatically.
+ */
+const SEED_CATEGORIES = [
+  "agriculture",
+  "gardening",
+  "food",
+  "home-goods",
+  "manufacturing",
+  "technology",
+  "services",
+  "preparedness",
+]
+
+export default async function recomputeOpportunityScoresJob(
+  container: MedusaContainer
+) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const engine = container.resolve<OpportunityEngineService>(
+    OPPORTUNITY_ENGINE_MODULE
+  )
+
+  logger.info("[opportunity-engine] recompute starting")
+
+  const categories = new Set<string>(SEED_CATEGORIES)
+
+  // Pull any additional categories that have live demand.
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "demand_post",
+      fields: ["category"],
+      filters: { status: ["OPEN", "THRESHOLD_MET"] },
+      pagination: { take: 1000 },
+    })
+    for (const d of data || []) {
+      if (d?.category) {
+        categories.add(String(d.category))
+      }
+    }
+  } catch {
+    // fall back to the seed set
+  }
+
+  let upserts = 0
+  for (const category of categories) {
+    try {
+      const snapshot = await gatherCategorySignals(container, {
+        category,
+        region: "US",
+      })
+      await engine.upsertOpportunityScore({
+        subject_type: OpportunitySubjectType.CATEGORY,
+        subject_key: category,
+        subject_label: category,
+        region: "US",
+        demand_score: snapshot.normalized.demand,
+        competition_score: snapshot.normalized.competition,
+        startup_cost_score: snapshot.normalized.startupCost,
+        composite: snapshot.score.composite,
+        signals: snapshot as unknown as Record<string, unknown>,
+      })
+      upserts++
+    } catch (e) {
+      logger.warn(
+        `[opportunity-engine] failed to score "${category}": ${
+          (e as Error).message
+        }`
+      )
+    }
+  }
+
+  logger.info(`[opportunity-engine] recompute done — ${upserts} scores upserted`)
+}
+
+export const config = {
+  name: "recompute-opportunity-scores",
+  // Every 6 hours.
+  schedule: "0 */6 * * *",
+}

--- a/backend/src/modules/knowledge-base/__tests__/catalog.unit.spec.ts
+++ b/backend/src/modules/knowledge-base/__tests__/catalog.unit.spec.ts
@@ -1,0 +1,61 @@
+import { KB_SEED_ARTICLES, filterArticles } from "../catalog"
+
+describe("knowledge-base/catalog (§14)", () => {
+  it("seeds the DIY library, container gardening, and substitution guides", () => {
+    const slugs = KB_SEED_ARTICLES.map((a) => a.slug)
+    // The four named DIY library entries from the spec.
+    expect(slugs).toEqual(
+      expect.arrayContaining([
+        "diy-laundry-detergent",
+        "diy-compost-at-home",
+        "diy-seed-starting",
+        "diy-food-preservation",
+      ])
+    )
+    const types = new Set(KB_SEED_ARTICLES.map((a) => a.type))
+    expect(types).toEqual(
+      new Set(["DIY", "CONTAINER_GARDENING", "SUBSTITUTION"])
+    )
+  })
+
+  it("every article has materials and steps", () => {
+    for (const a of KB_SEED_ARTICLES) {
+      expect(a.materials.length).toBeGreaterThan(0)
+      expect(a.steps.length).toBeGreaterThan(0)
+      expect(a.slug).toMatch(/^[a-z0-9-]+$/)
+    }
+  })
+
+  it("slugs are unique", () => {
+    const slugs = KB_SEED_ARTICLES.map((a) => a.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  describe("filterArticles", () => {
+    it("filters by type", () => {
+      const diy = filterArticles(KB_SEED_ARTICLES, { type: "DIY" })
+      expect(diy.length).toBeGreaterThanOrEqual(4)
+      expect(diy.every((a) => a.type === "DIY")).toBe(true)
+    })
+
+    it("filters container guides by climate zone and space", () => {
+      const cool = filterArticles(KB_SEED_ARTICLES, {
+        type: "CONTAINER_GARDENING",
+        climate_zone: "cool",
+      })
+      expect(cool).toHaveLength(1)
+      expect(cool[0].slug).toBe("container-gardening-cool-balcony")
+    })
+
+    it("matches free-text q against title and summary", () => {
+      const compost = filterArticles(KB_SEED_ARTICLES, { q: "compost" })
+      expect(compost.some((a) => a.slug === "diy-compost-at-home")).toBe(true)
+    })
+
+    it("returns all when no filter is given", () => {
+      expect(filterArticles(KB_SEED_ARTICLES, {})).toHaveLength(
+        KB_SEED_ARTICLES.length
+      )
+    })
+  })
+})

--- a/backend/src/modules/knowledge-base/catalog.ts
+++ b/backend/src/modules/knowledge-base/catalog.ts
@@ -1,0 +1,231 @@
+/**
+ * Knowledge Base seed catalog (§14). Code is the source of truth; seeded into
+ * `kb_article` at boot via `backend/src/scripts/seed-knowledge-base.ts`.
+ * Mirrors the playbook/startup-guide recipe-catalog convention.
+ *
+ * `filterArticles` is a pure, unit-tested helper the store route delegates to.
+ */
+
+export type KbType = "DIY" | "CONTAINER_GARDENING" | "SUBSTITUTION"
+
+export type KbSeedArticle = {
+  slug: string
+  title: string
+  type: KbType
+  summary: string
+  body: string
+  category: string
+  difficulty: "Beginner" | "Intermediate" | "Advanced"
+  climate_zone?: string
+  space?: string
+  materials: string[]
+  steps: string[]
+  /** opportunity subject key this guide relates to, for cross-linking. */
+  related_opportunity_key?: string
+}
+
+const DIY: KbSeedArticle[] = [
+  {
+    slug: "diy-laundry-detergent",
+    title: "Make Your Own Laundry Detergent",
+    type: "DIY",
+    summary:
+      "A low-cost powdered laundry detergent from three pantry-grade ingredients.",
+    body:
+      "Homemade laundry powder cleans well for a fraction of the retail cost and avoids single-use plastic jugs.",
+    category: "home-goods",
+    difficulty: "Beginner",
+    materials: [
+      "1 bar castile or laundry soap, grated",
+      "1 cup washing soda",
+      "1 cup borax (optional)",
+    ],
+    steps: [
+      "Grate the soap finely.",
+      "Mix with washing soda (and borax if using).",
+      "Use 1–2 tablespoons per load; store airtight.",
+    ],
+    related_opportunity_key: "home-goods",
+  },
+  {
+    slug: "diy-compost-at-home",
+    title: "Start a Home Compost Pile",
+    type: "DIY",
+    summary: "Turn kitchen and yard waste into finished compost in 8–12 weeks.",
+    body:
+      "Composting recycles nutrients back into soil and is the production basis of a compost micro-business.",
+    category: "agriculture",
+    difficulty: "Beginner",
+    materials: [
+      "Browns (leaves, cardboard)",
+      "Greens (food scraps, grass)",
+      "A bin or open pile, ~1 cubic yard",
+    ],
+    steps: [
+      "Layer browns and greens roughly 2:1.",
+      "Keep moist as a wrung-out sponge and turn weekly.",
+      "Harvest when dark, crumbly, and earthy-smelling.",
+    ],
+    related_opportunity_key: "agriculture",
+  },
+  {
+    slug: "diy-seed-starting",
+    title: "Seed Starting Indoors",
+    type: "DIY",
+    summary: "Grow strong transplants from seed weeks before the last frost.",
+    body:
+      "Starting seeds indoors extends the season and is the basis of a seedling business.",
+    category: "gardening",
+    difficulty: "Beginner",
+    materials: [
+      "Seed trays + humidity dome",
+      "Seed-starting mix",
+      "Grow light or bright window",
+    ],
+    steps: [
+      "Sow at the depth on the packet and keep warm.",
+      "Provide 14–16 hours of light once sprouted.",
+      "Harden off outdoors before transplanting.",
+    ],
+    related_opportunity_key: "gardening",
+  },
+  {
+    slug: "diy-food-preservation",
+    title: "Food Preservation Basics",
+    type: "DIY",
+    summary: "Water-bath canning, freezing, and drying to store the harvest.",
+    body:
+      "Preserving the harvest reduces waste and creates shelf-stable products to sell.",
+    category: "food",
+    difficulty: "Intermediate",
+    materials: [
+      "Canning jars + lids",
+      "Water-bath canner",
+      "Acid (lemon juice/vinegar) for high-acid recipes",
+    ],
+    steps: [
+      "Follow a tested recipe for acidity and times.",
+      "Process jars fully submerged in boiling water.",
+      "Check seals after 24 hours; refrigerate any that failed.",
+    ],
+    related_opportunity_key: "food",
+  },
+]
+
+const CONTAINER_GARDENING: KbSeedArticle[] = [
+  {
+    slug: "container-gardening-cool-balcony",
+    title: "Container Gardening: Cool Climate, Small Balcony",
+    type: "CONTAINER_GARDENING",
+    summary: "Cold-tolerant crops for a compact, partly-shaded balcony.",
+    body: "Greens and roots thrive in cool climates and tight spaces.",
+    category: "gardening",
+    difficulty: "Beginner",
+    climate_zone: "cool",
+    space: "balcony",
+    materials: ["3–5 gallon pots", "Quality potting mix", "Lettuce, kale, radish seed"],
+    steps: [
+      "Choose 3–5 gallon containers with drainage.",
+      "Sow cool-season greens and roots.",
+      "Water consistently; harvest outer leaves.",
+    ],
+    related_opportunity_key: "gardening",
+  },
+  {
+    slug: "container-gardening-warm-patio",
+    title: "Container Gardening: Warm Climate, Patio",
+    type: "CONTAINER_GARDENING",
+    summary: "Heat-loving fruiting crops for a sunny patio.",
+    body: "Tomatoes and peppers reward warm climates and full-sun patios.",
+    category: "gardening",
+    difficulty: "Intermediate",
+    climate_zone: "warm",
+    space: "patio",
+    materials: ["7–10 gallon pots", "Tomato/pepper transplants", "Stakes or cages"],
+    steps: [
+      "Use large containers for fruiting crops.",
+      "Provide 6+ hours of sun and support.",
+      "Feed every 2 weeks during fruiting.",
+    ],
+    related_opportunity_key: "gardening",
+  },
+]
+
+const SUBSTITUTION: KbSeedArticle[] = [
+  {
+    slug: "make-vs-buy-cleaning-supplies",
+    title: "Make vs. Buy: Household Cleaners",
+    type: "SUBSTITUTION",
+    summary: "When making your own cleaners beats buying — and when it doesn't.",
+    body:
+      "Vinegar, baking soda, and castile soap replace most general cleaners cheaply.",
+    category: "home-goods",
+    difficulty: "Beginner",
+    materials: ["White vinegar", "Baking soda", "Castile soap"],
+    steps: [
+      "Make: all-purpose, glass, and scouring cleaners.",
+      "Buy: disinfectants that need EPA registration.",
+      "Compare cost-per-use before switching.",
+    ],
+    related_opportunity_key: "home-goods",
+  },
+  {
+    slug: "upcycling-containers-for-growing",
+    title: "Upcycle Containers for Growing",
+    type: "SUBSTITUTION",
+    summary: "Turn buckets, totes, and jugs into productive planters.",
+    body: "Reusing containers cuts startup cost for a gardening business.",
+    category: "gardening",
+    difficulty: "Beginner",
+    materials: ["Food-safe buckets/totes", "Drill for drainage", "Potting mix"],
+    steps: [
+      "Drill drainage holes in the base.",
+      "Avoid containers that held chemicals.",
+      "Match container size to crop root depth.",
+    ],
+    related_opportunity_key: "gardening",
+  },
+]
+
+export const KB_SEED_ARTICLES: KbSeedArticle[] = [
+  ...DIY,
+  ...CONTAINER_GARDENING,
+  ...SUBSTITUTION,
+]
+
+export type KbFilter = {
+  type?: string
+  category?: string
+  difficulty?: string
+  climate_zone?: string
+  space?: string
+  q?: string
+}
+
+/** Pure filter over an article list (works on seed shape or DB rows). */
+export function filterArticles<
+  T extends {
+    type: string
+    category?: string | null
+    difficulty?: string | null
+    climate_zone?: string | null
+    space?: string | null
+    title: string
+    summary?: string
+  }
+>(articles: T[], filter: KbFilter): T[] {
+  const eq = (a?: string | null, b?: string) =>
+    !b || (a ?? "").toLowerCase() === b.toLowerCase()
+  const q = (filter.q || "").trim().toLowerCase()
+  return articles.filter(
+    (a) =>
+      eq(a.type, filter.type) &&
+      eq(a.category, filter.category) &&
+      eq(a.difficulty, filter.difficulty) &&
+      eq(a.climate_zone, filter.climate_zone) &&
+      eq(a.space, filter.space) &&
+      (!q ||
+        a.title.toLowerCase().includes(q) ||
+        (a.summary ?? "").toLowerCase().includes(q))
+  )
+}

--- a/backend/src/modules/knowledge-base/index.ts
+++ b/backend/src/modules/knowledge-base/index.ts
@@ -1,0 +1,17 @@
+import { Module } from "@medusajs/framework/utils"
+import KnowledgeBaseService from "./service"
+
+export const KNOWLEDGE_BASE_MODULE = "knowledge-base"
+
+export default Module(KNOWLEDGE_BASE_MODULE, {
+  service: KnowledgeBaseService,
+})
+
+export * from "./models"
+export {
+  KB_SEED_ARTICLES,
+  filterArticles,
+  type KbSeedArticle,
+  type KbType,
+  type KbFilter,
+} from "./catalog"

--- a/backend/src/modules/knowledge-base/migrations/Migration20260608CreateKnowledgeBase.ts
+++ b/backend/src/modules/knowledge-base/migrations/Migration20260608CreateKnowledgeBase.ts
@@ -1,0 +1,68 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: create `kb_article` and `kb_contribution` tables backing the
+ * Product Knowledge Base / DIY Library (§14).
+ */
+export class Migration20260608CreateKnowledgeBase extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "kb_article" (
+        "id" TEXT NOT NULL,
+        "slug" TEXT NOT NULL UNIQUE,
+        "title" TEXT NOT NULL,
+        "type" TEXT NOT NULL DEFAULT 'DIY',
+        "summary" TEXT NOT NULL,
+        "body" TEXT NOT NULL,
+        "category" TEXT NULL,
+        "difficulty" TEXT NOT NULL DEFAULT 'Beginner',
+        "climate_zone" TEXT NULL,
+        "space" TEXT NULL,
+        "materials" JSONB NULL,
+        "steps" JSONB NULL,
+        "related_product_ids" JSONB NULL,
+        "author_id" TEXT NULL,
+        "contributed_by_community" BOOLEAN NOT NULL DEFAULT false,
+        "status" TEXT NOT NULL DEFAULT 'PUBLISHED',
+        "upvotes" INTEGER NOT NULL DEFAULT 0,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "kb_article_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_kb_article_slug" ON "kb_article" ("slug") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_kb_article_type" ON "kb_article" ("type") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_kb_article_category" ON "kb_article" ("category") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_kb_article_status" ON "kb_article" ("status") WHERE "deleted_at" IS NULL;`)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "kb_contribution" (
+        "id" TEXT NOT NULL,
+        "submitter_id" TEXT NOT NULL,
+        "submitter_type" TEXT NOT NULL DEFAULT 'CUSTOMER',
+        "title" TEXT NOT NULL,
+        "type" TEXT NOT NULL DEFAULT 'DIY',
+        "payload" JSONB NOT NULL,
+        "status" TEXT NOT NULL DEFAULT 'PENDING',
+        "review_note" TEXT NULL,
+        "decided_by" TEXT NULL,
+        "decided_at" TIMESTAMPTZ NULL,
+        "resulting_article_id" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "kb_contribution_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_kb_contribution_status" ON "kb_contribution" ("status") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_kb_contribution_submitter" ON "kb_contribution" ("submitter_id") WHERE "deleted_at" IS NULL;`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`DROP TABLE IF EXISTS "kb_article";`)
+    this.addSql(`DROP TABLE IF EXISTS "kb_contribution";`)
+  }
+}

--- a/backend/src/modules/knowledge-base/models/index.ts
+++ b/backend/src/modules/knowledge-base/models/index.ts
@@ -1,0 +1,5 @@
+export { default as KbArticle } from "./kb-article"
+export { default as KbContribution } from "./kb-contribution"
+
+export { KbArticleType, KbArticleStatus } from "./kb-article"
+export { KbContributionStatus } from "./kb-contribution"

--- a/backend/src/modules/knowledge-base/models/kb-article.ts
+++ b/backend/src/modules/knowledge-base/models/kb-article.ts
@@ -1,0 +1,56 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum KbArticleType {
+  DIY = "DIY",
+  CONTAINER_GARDENING = "CONTAINER_GARDENING",
+  SUBSTITUTION = "SUBSTITUTION",
+}
+
+export enum KbArticleStatus {
+  DRAFT = "DRAFT",
+  PUBLISHED = "PUBLISHED",
+}
+
+/**
+ * A Product Knowledge Base article (§14): a DIY recipe, a container-gardening
+ * guide, or a make-vs-buy / substitution guide. Seeded from the in-code catalog
+ * (`catalog.ts`) and extended by approved community contributions.
+ */
+const KbArticle = model
+  .define("kb_article", {
+    id: model.id().primaryKey(),
+    slug: model.text().unique(),
+    title: model.text().searchable(),
+    type: model
+      .enum(Object.values(KbArticleType))
+      .default(KbArticleType.DIY),
+    summary: model.text(),
+    body: model.text(),
+
+    category: model.text().nullable(),
+    difficulty: model.text().default("Beginner"),
+    // Container-gardening facets.
+    climate_zone: model.text().nullable(),
+    space: model.text().nullable(),
+
+    materials: model.json().nullable(),
+    steps: model.json().nullable(),
+    related_product_ids: model.json().nullable(),
+
+    author_id: model.text().nullable(),
+    contributed_by_community: model.boolean().default(false),
+    status: model
+      .enum(Object.values(KbArticleStatus))
+      .default(KbArticleStatus.PUBLISHED),
+    upvotes: model.number().default(0),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    { on: ["slug"], name: "IDX_kb_article_slug" },
+    { on: ["type"], name: "IDX_kb_article_type" },
+    { on: ["category"], name: "IDX_kb_article_category" },
+    { on: ["status"], name: "IDX_kb_article_status" },
+  ])
+
+export default KbArticle

--- a/backend/src/modules/knowledge-base/models/kb-contribution.ts
+++ b/backend/src/modules/knowledge-base/models/kb-contribution.ts
@@ -1,0 +1,39 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum KbContributionStatus {
+  PENDING = "PENDING",
+  APPROVED = "APPROVED",
+  REJECTED = "REJECTED",
+}
+
+/**
+ * A community-submitted tutorial/guide/method awaiting moderation (§14
+ * "Community Contributions"). On approval it becomes a published `kb_article`.
+ */
+const KbContribution = model
+  .define("kb_contribution", {
+    id: model.id().primaryKey(),
+    submitter_id: model.text(),
+    submitter_type: model.enum(["CUSTOMER", "SELLER"]).default("CUSTOMER"),
+
+    title: model.text(),
+    type: model.text().default("DIY"),
+    /** Proposed article payload (summary, body, materials, steps, …). */
+    payload: model.json(),
+
+    status: model
+      .enum(Object.values(KbContributionStatus))
+      .default(KbContributionStatus.PENDING),
+    review_note: model.text().nullable(),
+    decided_by: model.text().nullable(),
+    decided_at: model.dateTime().nullable(),
+    resulting_article_id: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    { on: ["status"], name: "IDX_kb_contribution_status" },
+    { on: ["submitter_id"], name: "IDX_kb_contribution_submitter" },
+  ])
+
+export default KbContribution

--- a/backend/src/modules/knowledge-base/service.ts
+++ b/backend/src/modules/knowledge-base/service.ts
@@ -1,0 +1,120 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { KbArticle, KbContribution } from "./models"
+import { KbArticleStatus } from "./models/kb-article"
+import { KbContributionStatus } from "./models/kb-contribution"
+
+/**
+ * Product Knowledge Base (§14) module service. Owns DIY/gardening/substitution
+ * articles and the community-contribution moderation queue.
+ */
+class KnowledgeBaseService extends MedusaService({
+  KbArticle,
+  KbContribution,
+}) {
+  /** Submit a community contribution (pending moderation). */
+  async submitContribution(input: {
+    submitter_id: string
+    submitter_type?: "CUSTOMER" | "SELLER"
+    title: string
+    type?: string
+    payload: Record<string, unknown>
+  }) {
+    const [contribution] = await this.createKbContributions([
+      {
+        submitter_id: input.submitter_id,
+        submitter_type: input.submitter_type || "CUSTOMER",
+        title: input.title,
+        type: input.type || "DIY",
+        payload: input.payload,
+        status: KbContributionStatus.PENDING,
+      },
+    ])
+    return contribution
+  }
+
+  /**
+   * Approve a contribution: publish it as an article and link the two.
+   * Idempotent — a contribution already APPROVED returns its existing article.
+   */
+  async approveContribution(
+    contributionId: string,
+    reviewerId: string,
+    overrides?: { slug?: string; category?: string; difficulty?: string }
+  ) {
+    const [c] = await this.listKbContributions({ id: contributionId })
+    if (!c) {
+      throw new Error(`Contribution ${contributionId} not found`)
+    }
+    if (c.status === KbContributionStatus.APPROVED && c.resulting_article_id) {
+      const [existing] = await this.listKbArticles({
+        id: c.resulting_article_id,
+      })
+      return existing
+    }
+
+    const payload = (c.payload || {}) as Record<string, any>
+    const slug =
+      overrides?.slug ||
+      payload.slug ||
+      `${slugify(c.title)}-${contributionId.slice(-6)}`
+
+    const [article] = await this.createKbArticles([
+      {
+        slug,
+        title: c.title,
+        type: (c.type as any) || "DIY",
+        summary: payload.summary || "",
+        body: payload.body || "",
+        category: overrides?.category || payload.category || null,
+        difficulty: overrides?.difficulty || payload.difficulty || "Beginner",
+        climate_zone: payload.climate_zone || null,
+        space: payload.space || null,
+        materials: payload.materials || null,
+        steps: payload.steps || null,
+        author_id: c.submitter_id,
+        contributed_by_community: true,
+        status: KbArticleStatus.PUBLISHED,
+      },
+    ])
+
+    await this.updateKbContributions({
+      id: contributionId,
+      status: KbContributionStatus.APPROVED,
+      decided_by: reviewerId,
+      decided_at: new Date(),
+      resulting_article_id: article.id,
+    })
+
+    return article
+  }
+
+  async rejectContribution(
+    contributionId: string,
+    reviewerId: string,
+    note?: string
+  ) {
+    const [c] = await this.listKbContributions({ id: contributionId })
+    if (!c) {
+      throw new Error(`Contribution ${contributionId} not found`)
+    }
+    await this.updateKbContributions({
+      id: contributionId,
+      status: KbContributionStatus.REJECTED,
+      decided_by: reviewerId,
+      decided_at: new Date(),
+      review_note: note ?? null,
+    })
+    const [updated] = await this.listKbContributions({ id: contributionId })
+    return updated
+  }
+}
+
+function slugify(s: string): string {
+  return (s || "article")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 60)
+}
+
+export default KnowledgeBaseService

--- a/backend/src/modules/opportunity-engine/__tests__/scoring.unit.spec.ts
+++ b/backend/src/modules/opportunity-engine/__tests__/scoring.unit.spec.ts
@@ -1,0 +1,180 @@
+import {
+  computeOpportunityScore,
+  normalizeDemand,
+  normalizeCompetition,
+  normalizeStartupCost,
+  priceTrend,
+  band,
+  OPPORTUNITY_WEIGHTS,
+} from "../_scoring"
+import {
+  startupCostDollarsForSubject,
+  listStartupGuides,
+  getStartupGuide,
+} from "../startup-guides"
+
+describe("opportunity-engine/_scoring", () => {
+  describe("computeOpportunityScore", () => {
+    it("rewards high demand + low competition + low startup cost (≈ spec 9.1)", () => {
+      const { composite, bands } = computeOpportunityScore({
+        demand: 0.95,
+        competition: 0.1,
+        startupCost: 0.1,
+      })
+      // 0.95*0.5 + 0.9*0.3 + 0.9*0.2 = 0.475 + 0.27 + 0.18 = 0.925 → 9.3
+      expect(composite).toBeGreaterThanOrEqual(9)
+      expect(composite).toBeLessThanOrEqual(10)
+      expect(bands.demand).toBe("High")
+      expect(bands.competition).toBe("Low")
+    })
+
+    it("punishes a crowded, expensive, low-demand subject", () => {
+      const { composite } = computeOpportunityScore({
+        demand: 0.05,
+        competition: 0.95,
+        startupCost: 0.95,
+      })
+      expect(composite).toBeLessThan(1.5)
+    })
+
+    it("never exceeds 10 or drops below 0", () => {
+      expect(
+        computeOpportunityScore({ demand: 10, competition: -5, startupCost: -1 })
+          .composite
+      ).toBeLessThanOrEqual(10)
+      expect(
+        computeOpportunityScore({ demand: -1, competition: 10, startupCost: 10 })
+          .composite
+      ).toBeGreaterThanOrEqual(0)
+    })
+
+    it("weights sum to 1 (a fully-ideal subject scores 10)", () => {
+      const sum =
+        OPPORTUNITY_WEIGHTS.demand +
+        OPPORTUNITY_WEIGHTS.competition +
+        OPPORTUNITY_WEIGHTS.startupCost
+      expect(sum).toBeCloseTo(1, 6)
+      expect(
+        computeOpportunityScore({ demand: 1, competition: 0, startupCost: 0 })
+          .composite
+      ).toBe(10)
+    })
+  })
+
+  describe("band", () => {
+    it("buckets into Low/Medium/High", () => {
+      expect(band(0.1)).toBe("Low")
+      expect(band(0.5)).toBe("Medium")
+      expect(band(0.8)).toBe("High")
+    })
+  })
+
+  describe("normalizeDemand", () => {
+    it("is 0 with no signal and rises with breadth/fill/money", () => {
+      expect(
+        normalizeDemand({
+          openDemandPosts: 0,
+          committedQuantity: 0,
+          targetQuantity: 0,
+          bountyDollars: 0,
+          wishlistCount: 0,
+          coalitionNeeds: 0,
+        })
+      ).toBe(0)
+
+      const hot = normalizeDemand({
+        openDemandPosts: 40,
+        committedQuantity: 80,
+        targetQuantity: 100,
+        bountyDollars: 5000,
+        wishlistCount: 30,
+        coalitionNeeds: 10,
+      })
+      expect(hot).toBeGreaterThan(0.5)
+      expect(hot).toBeLessThanOrEqual(1)
+    })
+  })
+
+  describe("normalizeCompetition / normalizeStartupCost", () => {
+    it("saturate toward 1 and floor at 0", () => {
+      expect(normalizeCompetition({ activeSellers: 0, activeListings: 0 })).toBe(0)
+      expect(
+        normalizeCompetition({ activeSellers: 500, activeListings: 5000 })
+      ).toBeGreaterThan(0.9)
+      expect(normalizeStartupCost(0)).toBe(0)
+      expect(normalizeStartupCost(100000)).toBeGreaterThan(0.9)
+      // A cheap business reads as low startup cost.
+      expect(normalizeStartupCost(350)).toBeLessThan(0.6)
+    })
+  })
+
+  describe("priceTrend", () => {
+    it("returns flat on empty input", () => {
+      const t = priceTrend([])
+      expect(t.direction).toBe("flat")
+      expect(t.samples).toBe(0)
+    })
+
+    it("detects a rising series", () => {
+      const t = priceTrend([
+        { price_cents: 100, observed_at: "2026-01-01" },
+        { price_cents: 110, observed_at: "2026-02-01" },
+        { price_cents: 130, observed_at: "2026-03-01" },
+      ])
+      expect(t.direction).toBe("rising")
+      expect(t.pctChange).toBeGreaterThan(0)
+      expect(t.latestCents).toBe(130)
+      expect(t.earliestCents).toBe(100)
+    })
+
+    it("detects a falling series", () => {
+      const t = priceTrend([
+        { price_cents: 200, observed_at: "2026-01-01" },
+        { price_cents: 150, observed_at: "2026-02-01" },
+        { price_cents: 120, observed_at: "2026-03-01" },
+      ])
+      expect(t.direction).toBe("falling")
+      expect(t.pctChange).toBeLessThan(0)
+    })
+
+    it("is order-independent (sorts by time)", () => {
+      const a = priceTrend([
+        { price_cents: 130, observed_at: "2026-03-01" },
+        { price_cents: 100, observed_at: "2026-01-01" },
+        { price_cents: 110, observed_at: "2026-02-01" },
+      ])
+      expect(a.direction).toBe("rising")
+    })
+  })
+})
+
+describe("opportunity-engine/startup-guides (§12)", () => {
+  it("exposes the four seed businesses with positive costs", () => {
+    const guides = listStartupGuides()
+    expect(guides.map((g) => g.id).sort()).toEqual([
+      "compost",
+      "gardening",
+      "seedling",
+      "soap",
+    ])
+    for (const g of guides) {
+      expect(g.estimated_startup_cost_cents).toBeGreaterThan(0)
+      expect(g.required_equipment.length).toBeGreaterThan(0)
+      expect(g.production_suggestions.length).toBeGreaterThan(0)
+      expect(g.related_opportunity_key).toBeTruthy()
+    }
+  })
+
+  it("resolves a guide by slug or id", () => {
+    expect(getStartupGuide("compost-business")?.id).toBe("compost")
+    expect(getStartupGuide("compost")?.slug).toBe("compost-business")
+    expect(getStartupGuide("nope")).toBeUndefined()
+  })
+
+  it("derives the cheapest startup cost for an opportunity subject", () => {
+    // compost + gardening both map to agriculture; compost ($750) is cheaper.
+    expect(startupCostDollarsForSubject("agriculture")).toBe(750)
+    expect(startupCostDollarsForSubject("gardening")).toBe(350)
+    expect(startupCostDollarsForSubject("unmapped")).toBeNull()
+  })
+})

--- a/backend/src/modules/opportunity-engine/_scoring.ts
+++ b/backend/src/modules/opportunity-engine/_scoring.ts
@@ -1,0 +1,228 @@
+/**
+ * Opportunity Engine scoring (v1, no ML).
+ *
+ * Pure, deterministic, unit-testable functions — mirroring the design of
+ * `src/api/v1/seller/matching/_ranking.ts`. The service layer assembles raw
+ * signals from existing modules (demand-pool, wishlist, cooperative, the
+ * product catalog, startup-guide catalog, price observations) and calls these
+ * functions. No DB access here.
+ *
+ * The composite is reported on a 0..10 scale so it reads like the spec's
+ * worked example ("Compost … Opportunity Score: 9.1").
+ */
+
+export type OpportunitySignals = {
+  /** 0..1 normalized market demand (higher = more wanted). */
+  demand: number
+  /** 0..1 normalized competition (higher = more crowded). Inverted in the score. */
+  competition: number
+  /** 0..1 normalized startup cost (higher = more expensive). Inverted in the score. */
+  startupCost: number
+}
+
+export const OPPORTUNITY_WEIGHTS = {
+  demand: 0.5,
+  competition: 0.3, // contributes (1 - competition)
+  startupCost: 0.2, // contributes (1 - startupCost)
+} as const
+
+export type OpportunityBand = "Low" | "Medium" | "High"
+
+export type OpportunityScore = {
+  /** 0..10 composite, rounded to one decimal. */
+  composite: number
+  breakdown: {
+    demand: number
+    competitionInverse: number
+    startupCostInverse: number
+  }
+  bands: {
+    demand: OpportunityBand
+    competition: OpportunityBand
+    startupCost: OpportunityBand
+  }
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v) || v <= 0) {
+    return 0
+  }
+  return v >= 1 ? 1 : v
+}
+
+/** Bucket a 0..1 value into Low/Medium/High for human-readable opportunity pages. */
+export function band(v: number): OpportunityBand {
+  const x = clamp01(v)
+  if (x >= 0.66) {
+    return "High"
+  }
+  if (x >= 0.33) {
+    return "Medium"
+  }
+  return "Low"
+}
+
+/**
+ * Compose the 0..10 opportunity score. High demand + low competition + low
+ * startup cost ⇒ high score. Deterministic and bounded.
+ */
+export function computeOpportunityScore(s: OpportunitySignals): OpportunityScore {
+  const demand = clamp01(s.demand)
+  const competition = clamp01(s.competition)
+  const startupCost = clamp01(s.startupCost)
+
+  const competitionInverse = 1 - competition
+  const startupCostInverse = 1 - startupCost
+
+  const weighted =
+    demand * OPPORTUNITY_WEIGHTS.demand +
+    competitionInverse * OPPORTUNITY_WEIGHTS.competition +
+    startupCostInverse * OPPORTUNITY_WEIGHTS.startupCost
+
+  const composite = Math.round(weighted * 10 * 10) / 10
+
+  return {
+    composite,
+    breakdown: {
+      demand: Math.round(demand * 1000) / 1000,
+      competitionInverse: Math.round(competitionInverse * 1000) / 1000,
+      startupCostInverse: Math.round(startupCostInverse * 1000) / 1000,
+    },
+    bands: {
+      demand: band(demand),
+      // A crowded market is a "High" competition band even though it lowers
+      // the score; the band describes the signal, not its contribution.
+      competition: band(competition),
+      startupCost: band(startupCost),
+    },
+  }
+}
+
+/** Saturating log normalizer mapping 0..10^scale onto 0..1. Shared shape with _ranking. */
+export function logSaturate(value: number, scale: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0
+  }
+  return Math.min(1, Math.log10(1 + value) / scale)
+}
+
+export type DemandInputs = {
+  /** Count of open demand posts in the category/subject. */
+  openDemandPosts: number
+  /** Sum of committed quantity across those posts. */
+  committedQuantity: number
+  /** Sum of target quantity across those posts. */
+  targetQuantity: number
+  /** Total bounty dollars attached (major units). */
+  bountyDollars: number
+  /** Wishlist references for the subject. */
+  wishlistCount: number
+  /** Coalition (cooperative) needs referencing the subject. */
+  coalitionNeeds: number
+}
+
+/**
+ * Normalize raw demand signals to 0..1. A blend of breadth (how many distinct
+ * signals) and intensity (fill progress + money on the table).
+ */
+export function normalizeDemand(d: DemandInputs): number {
+  const breadth = logSaturate(
+    d.openDemandPosts + d.wishlistCount + d.coalitionNeeds,
+    2 // ~100 distinct signals saturates breadth
+  )
+  const fill =
+    d.targetQuantity > 0
+      ? Math.min(1, d.committedQuantity / d.targetQuantity)
+      : 0
+  const money = logSaturate(d.bountyDollars, 4) // ~$10k bounty saturates
+  // Weighted blend; breadth dominates, intensity refines.
+  return clamp01(breadth * 0.5 + fill * 0.3 + money * 0.2)
+}
+
+export type CompetitionInputs = {
+  /** Distinct active sellers offering in the subject. */
+  activeSellers: number
+  /** Distinct active products/listings in the subject. */
+  activeListings: number
+}
+
+/** Normalize competition to 0..1 (higher = more crowded). */
+export function normalizeCompetition(c: CompetitionInputs): number {
+  const sellers = logSaturate(c.activeSellers, 2) // ~100 sellers saturates
+  const listings = logSaturate(c.activeListings, 3) // ~1000 listings saturates
+  return clamp01(sellers * 0.6 + listings * 0.4)
+}
+
+/**
+ * Normalize startup cost to 0..1 (higher = more expensive) from a dollar
+ * figure. $0 → 0, ~$50k → ~1 on a log curve so low-cost businesses stand out.
+ */
+export function normalizeStartupCost(startupCostDollars: number): number {
+  return logSaturate(startupCostDollars, 4.7) // 10^4.7 ≈ $50k saturates
+}
+
+export type PriceObservation = {
+  price_cents: number
+  observed_at: Date | string | number
+}
+
+export type PriceTrend = {
+  direction: "rising" | "falling" | "flat"
+  /** Signed percentage change from earliest to latest, rounded to one decimal. */
+  pctChange: number
+  latestCents: number | null
+  earliestCents: number | null
+  samples: number
+}
+
+/**
+ * Summarize a price-observation series into a trend. Sorts by time, compares
+ * the mean of the oldest third against the mean of the newest third to damp
+ * single-point noise. "flat" when |pctChange| < 1%.
+ */
+export function priceTrend(observations: PriceObservation[]): PriceTrend {
+  const points = (observations || [])
+    .filter((o) => o && Number.isFinite(Number(o.price_cents)))
+    .map((o) => ({
+      cents: Number(o.price_cents),
+      t: new Date(o.observed_at).getTime(),
+    }))
+    .filter((p) => Number.isFinite(p.t))
+    .sort((a, b) => a.t - b.t)
+
+  if (points.length === 0) {
+    return {
+      direction: "flat",
+      pctChange: 0,
+      latestCents: null,
+      earliestCents: null,
+      samples: 0,
+    }
+  }
+
+  const third = Math.max(1, Math.floor(points.length / 3))
+  const head = points.slice(0, third)
+  const tail = points.slice(points.length - third)
+  const mean = (arr: { cents: number }[]) =>
+    arr.reduce((s, p) => s + p.cents, 0) / arr.length
+
+  const earliest = mean(head)
+  const latest = mean(tail)
+  const pctChange =
+    earliest > 0 ? Math.round(((latest - earliest) / earliest) * 1000) / 10 : 0
+
+  let direction: PriceTrend["direction"] = "flat"
+  if (pctChange >= 1) {
+    direction = "rising"
+  } else if (pctChange <= -1) {
+    direction = "falling"
+  }
+
+  return {
+    direction,
+    pctChange,
+    latestCents: Math.round(points[points.length - 1].cents),
+    earliestCents: Math.round(points[0].cents),
+    samples: points.length,
+  }
+}

--- a/backend/src/modules/opportunity-engine/_signals.ts
+++ b/backend/src/modules/opportunity-engine/_signals.ts
@@ -1,0 +1,187 @@
+/**
+ * Cross-module signal gathering for the Opportunity Engine.
+ *
+ * Impure (reads other modules through the Medusa scope) — kept separate from
+ * the pure `_scoring.ts` so the math stays unit-testable. Used by both the
+ * `recompute-opportunity-scores` job and the `/store/opportunities/[id]` route.
+ *
+ * Every cross-module read is defensive (try/catch → 0), mirroring
+ * `api/v1/seller/matching/creators/route.ts`: a missing link or shape
+ * difference degrades a signal to zero rather than failing the request.
+ */
+
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { DEMAND_POOL_MODULE } from "../demand-pool"
+import type DemandPoolModuleService from "../demand-pool/service"
+import {
+  normalizeDemand,
+  normalizeCompetition,
+  normalizeStartupCost,
+  computeOpportunityScore,
+  type OpportunityScore as ComputedScore,
+} from "./_scoring"
+import { startupCostDollarsForSubject } from "./startup-guides"
+
+type Scope = {
+  resolve: <T = any>(key: string) => T
+}
+
+export type CategorySignalSnapshot = {
+  demand_raw: {
+    openDemandPosts: number
+    committedQuantity: number
+    targetQuantity: number
+    bountyDollars: number
+    wishlistCount: number
+    coalitionNeeds: number
+  }
+  competition_raw: { activeSellers: number; activeListings: number }
+  startup_cost_dollars: number | null
+  normalized: { demand: number; competition: number; startupCost: number }
+  score: ComputedScore
+}
+
+const OPEN_STATUSES = ["OPEN", "THRESHOLD_MET"]
+
+/** Gather + score signals for a category subject in a region. */
+export async function gatherCategorySignals(
+  scope: Scope,
+  opts: { category: string; region?: string }
+): Promise<CategorySignalSnapshot> {
+  const region = opts.region || "US"
+  const category = opts.category
+
+  // ── Demand (robust: demand-pool is in-module-family and always present) ──
+  let openDemandPosts = 0
+  let committedQuantity = 0
+  let targetQuantity = 0
+  let bountyDollars = 0
+  let coalitionNeeds = 0
+  try {
+    const demand = scope.resolve<DemandPoolModuleService>(DEMAND_POOL_MODULE)
+    const posts = await demand.listDemandPosts(
+      { category, status: OPEN_STATUSES },
+      { take: 500 }
+    )
+    for (const p of posts as any[]) {
+      // Region scoping is best-effort: a null delivery_region counts everywhere.
+      if (
+        region !== "US" &&
+        p.delivery_region &&
+        String(p.delivery_region) !== region
+      ) {
+        continue
+      }
+      openDemandPosts++
+      committedQuantity += Number(p.committed_quantity) || 0
+      targetQuantity += Number(p.target_quantity) || 0
+      bountyDollars += Number(p.total_bounty_amount) || 0
+      if (p.cooperative_id) {
+        coalitionNeeds++
+      }
+    }
+  } catch {
+    // leave demand signals at 0
+  }
+
+  // ── Wishlist breadth (best-effort via query graph) ──
+  let wishlistCount = 0
+  try {
+    const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "wishlist_item",
+      fields: ["id", "product.categories.name"],
+      pagination: { take: 1000 },
+    })
+    wishlistCount = (data || []).filter((w: any) =>
+      (w?.product?.categories ?? []).some(
+        (c: any) =>
+          typeof c?.name === "string" &&
+          c.name.toLowerCase() === category.toLowerCase()
+      )
+    ).length
+  } catch {
+    wishlistCount = 0
+  }
+
+  // ── Competition (active sellers/listings in the category) ──
+  let activeSellers = 0
+  let activeListings = 0
+  try {
+    const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: products } = await query.graph({
+      entity: "product",
+      fields: ["id", "status", "categories.name"],
+      filters: { status: "published" },
+      pagination: { take: 2000 },
+    })
+    const inCat = (products || []).filter((p: any) =>
+      (p?.categories ?? []).some(
+        (c: any) =>
+          typeof c?.name === "string" &&
+          c.name.toLowerCase() === category.toLowerCase()
+      )
+    )
+    activeListings = inCat.length
+    // Distinct sellers, when the seller link is resolvable.
+    const sellerIds = new Set<string>()
+    try {
+      const { data: sellerProducts } = await query.graph({
+        entity: "seller_product",
+        fields: ["seller_id", "product.categories.name"],
+        pagination: { take: 4000 },
+      })
+      for (const sp of sellerProducts || []) {
+        const matches = (sp?.product?.categories ?? []).some(
+          (c: any) =>
+            typeof c?.name === "string" &&
+            c.name.toLowerCase() === category.toLowerCase()
+        )
+        if (matches && sp?.seller_id) {
+          sellerIds.add(sp.seller_id)
+        }
+      }
+    } catch {
+      // seller link unavailable; approximate sellers from listing count
+    }
+    activeSellers = sellerIds.size || Math.ceil(activeListings / 3)
+  } catch {
+    activeSellers = 0
+    activeListings = 0
+  }
+
+  // ── Startup cost from the guide catalog ──
+  const startup_cost_dollars = startupCostDollarsForSubject(category)
+
+  const demand = normalizeDemand({
+    openDemandPosts,
+    committedQuantity,
+    targetQuantity,
+    bountyDollars,
+    wishlistCount,
+    coalitionNeeds,
+  })
+  const competition = normalizeCompetition({ activeSellers, activeListings })
+  // Unknown startup cost → neutral 0.5 (don't over-reward or punish).
+  const startupCost =
+    startup_cost_dollars === null
+      ? 0.5
+      : normalizeStartupCost(startup_cost_dollars)
+
+  const score = computeOpportunityScore({ demand, competition, startupCost })
+
+  return {
+    demand_raw: {
+      openDemandPosts,
+      committedQuantity,
+      targetQuantity,
+      bountyDollars,
+      wishlistCount,
+      coalitionNeeds,
+    },
+    competition_raw: { activeSellers, activeListings },
+    startup_cost_dollars,
+    normalized: { demand, competition, startupCost },
+    score,
+  }
+}

--- a/backend/src/modules/opportunity-engine/index.ts
+++ b/backend/src/modules/opportunity-engine/index.ts
@@ -1,0 +1,34 @@
+import { Module } from "@medusajs/framework/utils"
+import OpportunityEngineService from "./service"
+
+export const OPPORTUNITY_ENGINE_MODULE = "opportunity-engine"
+
+export default Module(OPPORTUNITY_ENGINE_MODULE, {
+  service: OpportunityEngineService,
+})
+
+export * from "./models"
+
+// Explicit re-exports below avoid name collisions with the persisted models
+// (the model `OpportunityScore`/`PriceObservation`/`StartupGuide` vs the pure
+// helper types of the same name in `_scoring`/`startup-guides`).
+export {
+  computeOpportunityScore,
+  normalizeDemand,
+  normalizeCompetition,
+  normalizeStartupCost,
+  priceTrend,
+  band,
+  logSaturate,
+  OPPORTUNITY_WEIGHTS,
+} from "./_scoring"
+export type { OpportunitySignals, OpportunityBand, PriceTrend } from "./_scoring"
+
+export {
+  STARTUP_GUIDES,
+  STARTUP_GUIDE_IDS,
+  listStartupGuides,
+  getStartupGuide,
+  startupCostDollarsForSubject,
+} from "./startup-guides"
+export type { StartupGuideId } from "./startup-guides"

--- a/backend/src/modules/opportunity-engine/migrations/Migration20260608CreateOpportunityEngine.ts
+++ b/backend/src/modules/opportunity-engine/migrations/Migration20260608CreateOpportunityEngine.ts
@@ -1,0 +1,88 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: create `price_observation`, `opportunity_score`, and
+ * `startup_guide` tables backing the Opportunity Engine (§5), Economic
+ * Intelligence (§15), and the Business Launch System startup guides (§12).
+ */
+export class Migration20260608CreateOpportunityEngine extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "price_observation" (
+        "id" TEXT NOT NULL,
+        "category" TEXT NOT NULL,
+        "product_id" TEXT NULL,
+        "region" TEXT NOT NULL DEFAULT 'US',
+        "state" TEXT NULL,
+        "unit" TEXT NOT NULL DEFAULT 'each',
+        "price_cents" INTEGER NOT NULL,
+        "currency_code" TEXT NOT NULL DEFAULT 'USD',
+        "source" TEXT NOT NULL DEFAULT 'manual',
+        "observed_at" TIMESTAMPTZ NOT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "price_observation_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_price_observation_cat_region_time" ON "price_observation" ("category", "region", "observed_at") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_price_observation_category" ON "price_observation" ("category") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_price_observation_region" ON "price_observation" ("region") WHERE "deleted_at" IS NULL;`)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "opportunity_score" (
+        "id" TEXT NOT NULL,
+        "subject_type" TEXT NOT NULL DEFAULT 'CATEGORY',
+        "subject_key" TEXT NOT NULL,
+        "subject_label" TEXT NULL,
+        "region" TEXT NOT NULL DEFAULT 'US',
+        "demand_score" REAL NOT NULL DEFAULT 0,
+        "competition_score" REAL NOT NULL DEFAULT 0,
+        "startup_cost_score" REAL NOT NULL DEFAULT 0,
+        "composite" REAL NOT NULL DEFAULT 0,
+        "signals" JSONB NULL,
+        "computed_at" TIMESTAMPTZ NOT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "opportunity_score_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_opportunity_score_subject" ON "opportunity_score" ("subject_type", "subject_key", "region") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_opportunity_score_composite" ON "opportunity_score" ("composite") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_opportunity_score_region" ON "opportunity_score" ("region") WHERE "deleted_at" IS NULL;`)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "startup_guide" (
+        "id" TEXT NOT NULL,
+        "guide_id" TEXT NOT NULL UNIQUE,
+        "slug" TEXT NOT NULL UNIQUE,
+        "title" TEXT NOT NULL,
+        "category" TEXT NOT NULL,
+        "summary" TEXT NOT NULL,
+        "estimated_startup_cost_cents" INTEGER NOT NULL DEFAULT 0,
+        "difficulty" TEXT NOT NULL DEFAULT 'Beginner',
+        "required_equipment" JSONB NOT NULL,
+        "production_suggestions" JSONB NOT NULL,
+        "related_archetypes" JSONB NOT NULL,
+        "related_opportunity_key" TEXT NOT NULL,
+        "is_active" BOOLEAN NOT NULL DEFAULT true,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "startup_guide_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_startup_guide_slug" ON "startup_guide" ("slug") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_startup_guide_category" ON "startup_guide" ("category") WHERE "deleted_at" IS NULL;`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`DROP TABLE IF EXISTS "price_observation";`)
+    this.addSql(`DROP TABLE IF EXISTS "opportunity_score";`)
+    this.addSql(`DROP TABLE IF EXISTS "startup_guide";`)
+  }
+}

--- a/backend/src/modules/opportunity-engine/models/index.ts
+++ b/backend/src/modules/opportunity-engine/models/index.ts
@@ -1,0 +1,5 @@
+export { default as PriceObservation } from "./price-observation"
+export { default as OpportunityScore } from "./opportunity-score"
+export { default as StartupGuide } from "./startup-guide"
+
+export { OpportunitySubjectType } from "./opportunity-score"

--- a/backend/src/modules/opportunity-engine/models/opportunity-score.ts
+++ b/backend/src/modules/opportunity-engine/models/opportunity-score.ts
@@ -1,0 +1,50 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum OpportunitySubjectType {
+  CATEGORY = "CATEGORY",
+  PRODUCT = "PRODUCT",
+}
+
+/**
+ * A materialized opportunity score for a subject (a category, or a specific
+ * product) in a region, recomputed by the `recompute-opportunity-scores` job
+ * from live demand / competition / startup-cost signals.
+ */
+const OpportunityScore = model
+  .define("opportunity_score", {
+    id: model.id().primaryKey(),
+
+    subject_type: model
+      .enum(Object.values(OpportunitySubjectType))
+      .default(OpportunitySubjectType.CATEGORY),
+    /** category slug, or product id, depending on subject_type. */
+    subject_key: model.text().searchable(),
+    subject_label: model.text().nullable(),
+    region: model.text().default("US"),
+
+    // 0..1 normalized inputs.
+    demand_score: model.float().default(0),
+    competition_score: model.float().default(0),
+    startup_cost_score: model.float().default(0),
+
+    // 0..10 composite (spec's "9.1").
+    composite: model.float().default(0),
+
+    /** Raw signal snapshot + human-readable bands for the opportunity page. */
+    signals: model.json().nullable(),
+
+    computed_at: model.dateTime(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["subject_type", "subject_key", "region"],
+      name: "IDX_opportunity_score_subject",
+      unique: true,
+    },
+    { on: ["composite"], name: "IDX_opportunity_score_composite" },
+    { on: ["region"], name: "IDX_opportunity_score_region" },
+  ])
+
+export default OpportunityScore

--- a/backend/src/modules/opportunity-engine/models/price-observation.ts
+++ b/backend/src/modules/opportunity-engine/models/price-observation.ts
@@ -1,0 +1,38 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A single price reading for a category/product in a place at a time. The
+ * Price Tracker (§5) and Economic-Intelligence trends (§15) read this series.
+ */
+const PriceObservation = model
+  .define("price_observation", {
+    id: model.id().primaryKey(),
+
+    // Subject of the price reading.
+    category: model.text().searchable(),
+    product_id: model.text().nullable(),
+
+    // Place. region is a coarse bucket ("US", a state code, or a named region).
+    region: model.text().default("US"),
+    state: model.text().nullable(),
+
+    // Reading.
+    unit: model.text().default("each"),
+    price_cents: model.number(),
+    currency_code: model.text().default("USD"),
+    source: model.text().default("manual"),
+
+    observed_at: model.dateTime(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["category", "region", "observed_at"],
+      name: "IDX_price_observation_cat_region_time",
+    },
+    { on: ["category"], name: "IDX_price_observation_category" },
+    { on: ["region"], name: "IDX_price_observation_region" },
+  ])
+
+export default PriceObservation

--- a/backend/src/modules/opportunity-engine/models/startup-guide.ts
+++ b/backend/src/modules/opportunity-engine/models/startup-guide.ts
@@ -1,0 +1,31 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Persisted projection of the in-code startup-guide catalog (§12). Code
+ * (`startup-guides/index.ts`) is the source of truth; this table is seeded from
+ * it so guides can be linked/queried alongside other entities. Mirrors the
+ * playbook registry pattern.
+ */
+const StartupGuide = model
+  .define("startup_guide", {
+    id: model.id().primaryKey(),
+    guide_id: model.text().unique(),
+    slug: model.text().unique(),
+    title: model.text().searchable(),
+    category: model.text(),
+    summary: model.text(),
+    estimated_startup_cost_cents: model.number().default(0),
+    difficulty: model.text().default("Beginner"),
+    required_equipment: model.json(),
+    production_suggestions: model.json(),
+    related_archetypes: model.json(),
+    related_opportunity_key: model.text(),
+    is_active: model.boolean().default(true),
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    { on: ["slug"], name: "IDX_startup_guide_slug" },
+    { on: ["category"], name: "IDX_startup_guide_category" },
+  ])
+
+export default StartupGuide

--- a/backend/src/modules/opportunity-engine/service.ts
+++ b/backend/src/modules/opportunity-engine/service.ts
@@ -1,0 +1,154 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { PriceObservation, OpportunityScore, StartupGuide } from "./models"
+import { OpportunitySubjectType } from "./models/opportunity-score"
+import {
+  computeOpportunityScore,
+  priceTrend,
+  type OpportunitySignals,
+  type PriceTrend,
+} from "./_scoring"
+
+/**
+ * Opportunity Engine (§5) + Economic Intelligence (§15) module service.
+ *
+ * Owns price observations, materialized opportunity scores, and the startup
+ * guide registry. Cross-module signal gathering (demand-pool, wishlist,
+ * cooperative, product catalog) is done by the recompute job and the API
+ * routes via the request scope — the service stays focused on its own models
+ * plus the pure scoring lib.
+ */
+class OpportunityEngineService extends MedusaService({
+  PriceObservation,
+  OpportunityScore,
+  StartupGuide,
+}) {
+  /** Pure scoring passthrough (kept on the service for ergonomic callers). */
+  score(signals: OpportunitySignals) {
+    return computeOpportunityScore(signals)
+  }
+
+  async recordPriceObservation(input: {
+    category: string
+    product_id?: string
+    region?: string
+    state?: string
+    unit?: string
+    price_cents: number
+    currency_code?: string
+    source?: string
+    observed_at?: Date
+  }) {
+    const [obs] = await this.createPriceObservations([
+      {
+        category: input.category,
+        product_id: input.product_id ?? null,
+        region: input.region || "US",
+        state: input.state ?? null,
+        unit: input.unit || "each",
+        price_cents: input.price_cents,
+        currency_code: input.currency_code || "USD",
+        source: input.source || "manual",
+        observed_at: input.observed_at || new Date(),
+      },
+    ])
+    return obs
+  }
+
+  /** Ordered (oldest→newest) price series for a category/region. */
+  async getPriceSeries(filters: {
+    category: string
+    region?: string
+    limit?: number
+  }) {
+    const where: Record<string, unknown> = { category: filters.category }
+    if (filters.region) {
+      where.region = filters.region
+    }
+    return this.listPriceObservations(where, {
+      order: { observed_at: "ASC" },
+      take: filters.limit || 365,
+    })
+  }
+
+  /** Trend summary for a category/region built from the stored series. */
+  async getPriceTrend(filters: {
+    category: string
+    region?: string
+  }): Promise<PriceTrend> {
+    const series = await this.getPriceSeries({ ...filters, limit: 365 })
+    return priceTrend(
+      (series as Array<{ price_cents: number; observed_at: Date }>).map((s) => ({
+        price_cents: Number(s.price_cents),
+        observed_at: s.observed_at,
+      }))
+    )
+  }
+
+  /**
+   * Upsert a materialized opportunity score, unique on
+   * (subject_type, subject_key, region).
+   */
+  async upsertOpportunityScore(input: {
+    subject_type?: OpportunitySubjectType
+    subject_key: string
+    subject_label?: string
+    region?: string
+    demand_score: number
+    competition_score: number
+    startup_cost_score: number
+    composite: number
+    signals?: Record<string, unknown>
+  }) {
+    const subject_type = input.subject_type || OpportunitySubjectType.CATEGORY
+    const region = input.region || "US"
+    const [existing] = await this.listOpportunityScores({
+      subject_type,
+      subject_key: input.subject_key,
+      region,
+    })
+
+    const payload = {
+      subject_type,
+      subject_key: input.subject_key,
+      subject_label: input.subject_label ?? input.subject_key,
+      region,
+      demand_score: input.demand_score,
+      competition_score: input.competition_score,
+      startup_cost_score: input.startup_cost_score,
+      composite: input.composite,
+      signals: (input.signals ?? null) as Record<string, unknown> | null,
+      computed_at: new Date(),
+    }
+
+    if (existing) {
+      await this.updateOpportunityScores({ id: existing.id, ...payload })
+      const [updated] = await this.listOpportunityScores({ id: existing.id })
+      return updated
+    }
+    const [created] = await this.createOpportunityScores([payload])
+    return created
+  }
+
+  /** Top opportunities by composite score, optionally scoped to a region. */
+  async listTopOpportunities(filters?: {
+    region?: string
+    subject_type?: OpportunitySubjectType
+    limit?: number
+    offset?: number
+  }) {
+    const where: Record<string, unknown> = {}
+    if (filters?.region) {
+      where.region = filters.region
+    }
+    if (filters?.subject_type) {
+      where.subject_type = filters.subject_type
+    }
+    return this.listOpportunityScores(where, {
+      order: { composite: "DESC" },
+      take: filters?.limit || 20,
+      skip: filters?.offset || 0,
+    })
+  }
+}
+
+export default OpportunityEngineService

--- a/backend/src/modules/opportunity-engine/startup-guides/index.ts
+++ b/backend/src/modules/opportunity-engine/startup-guides/index.ts
@@ -1,0 +1,149 @@
+/**
+ * Startup-guide catalog (§12). Code is the source of truth; seeded into the
+ * optional `startup_guide` table at boot via
+ * `backend/src/scripts/seed-opportunity-engine.ts` (mirrors seed-playbooks).
+ */
+
+import type { StartupGuide, StartupGuideId } from "./types"
+
+const SEEDLING: StartupGuide = {
+  id: "seedling",
+  slug: "seedling-business",
+  title: "Seedling & Starts Business",
+  category: "gardening",
+  summary:
+    "Grow and sell vegetable, herb, and flower starts to local gardeners. Low cost, fast cycle, strong spring demand.",
+  estimated_startup_cost_cents: 35_000, // ~$350
+  difficulty: "Beginner",
+  required_equipment: [
+    "Seed-starting trays & humidity domes",
+    "Grow lights or a sunny structure",
+    "Seed-starting mix",
+    "Heat mat",
+    "Labels & small pots",
+  ],
+  production_suggestions: [
+    "Start with high-margin culinary herbs and tomato varieties",
+    "Stagger sowings for a continuous 6-8 week selling window",
+    "Pre-sell trays to coalitions and CSA members",
+  ],
+  related_archetypes: ["AGRICULTURAL_RAW"],
+  related_opportunity_key: "gardening",
+}
+
+const COMPOST: StartupGuide = {
+  id: "compost",
+  slug: "compost-business",
+  title: "Compost Business",
+  category: "agriculture",
+  summary:
+    "Turn local food and yard waste into finished compost and sell by the bag or yard. High demand, low competition, low startup cost.",
+  estimated_startup_cost_cents: 75_000, // ~$750
+  difficulty: "Beginner",
+  required_equipment: [
+    "Compost bins or windrow space",
+    "Thermometer & moisture meter",
+    "Screening mesh",
+    "Bags or bulk containers",
+    "Pitchfork / aerator",
+  ],
+  production_suggestions: [
+    "Collect feedstock from coalition kitchens and gardens",
+    "Offer a subscription pickup + finished-compost return",
+    "Sell soil blends and worm castings as add-ons",
+  ],
+  related_archetypes: ["AGRICULTURAL_PROCESSED"],
+  related_opportunity_key: "agriculture",
+}
+
+const SOAP: StartupGuide = {
+  id: "soap",
+  slug: "soap-business",
+  title: "Handmade Soap Business",
+  category: "home-goods",
+  summary:
+    "Produce cold-process or melt-and-pour soaps and body bars. Differentiated by local ingredients and story.",
+  estimated_startup_cost_cents: 50_000, // ~$500
+  difficulty: "Intermediate",
+  required_equipment: [
+    "Stick blender & stainless pots",
+    "Molds & cutter",
+    "Safety gear (gloves, goggles)",
+    "Scale & thermometer",
+    "Curing rack",
+  ],
+  production_suggestions: [
+    "Source tallow/oils and botanicals from coalition producers",
+    "Batch seasonal scents tied to local harvests",
+    "Bundle gift sets for the Black Market marketing packs",
+  ],
+  related_archetypes: ["NON_PERISHABLE"],
+  related_opportunity_key: "home-goods",
+}
+
+const GARDENING: StartupGuide = {
+  id: "gardening",
+  slug: "gardening-business",
+  title: "Market Gardening Business",
+  category: "agriculture",
+  summary:
+    "Grow vegetables on a small intensive plot for direct, CSA, and coalition sales. Scales with demand pools.",
+  estimated_startup_cost_cents: 250_000, // ~$2,500
+  difficulty: "Intermediate",
+  required_equipment: [
+    "Broadfork & hand tools",
+    "Irrigation lines & timer",
+    "Row cover & low tunnels",
+    "Harvest bins & wash station",
+    "Cooler / cold storage",
+  ],
+  production_suggestions: [
+    "Anchor revenue with a CSA subscription listing",
+    "Fill open demand-pool needs from local coalitions",
+    "Succession-plant fast crops between long-season beds",
+  ],
+  related_archetypes: ["AGRICULTURAL_RAW", "SUBSCRIPTION"],
+  related_opportunity_key: "agriculture",
+}
+
+export const STARTUP_GUIDES: Record<StartupGuideId, StartupGuide> = {
+  seedling: SEEDLING,
+  compost: COMPOST,
+  soap: SOAP,
+  gardening: GARDENING,
+}
+
+export const STARTUP_GUIDE_IDS: StartupGuideId[] = Object.keys(
+  STARTUP_GUIDES
+) as StartupGuideId[]
+
+export function listStartupGuides(): StartupGuide[] {
+  return STARTUP_GUIDE_IDS.map((id) => STARTUP_GUIDES[id])
+}
+
+export function getStartupGuide(slug: string): StartupGuide | undefined {
+  return listStartupGuides().find((g) => g.slug === slug || g.id === slug)
+}
+
+/**
+ * Estimated startup cost (dollars) for an opportunity subject/category, derived
+ * from the cheapest guide that targets it. Returns null when no guide maps to
+ * the subject (the §5 score then treats startup cost as unknown/neutral).
+ */
+export function startupCostDollarsForSubject(subjectKey: string): number | null {
+  const key = (subjectKey || "").trim().toLowerCase()
+  const matches = listStartupGuides().filter(
+    (g) =>
+      g.related_opportunity_key.toLowerCase() === key ||
+      g.category.toLowerCase() === key
+  )
+  if (matches.length === 0) {
+    return null
+  }
+  const cheapest = Math.min(
+    ...matches.map((g) => g.estimated_startup_cost_cents)
+  )
+  return cheapest / 100
+}
+
+export * from "./types"

--- a/backend/src/modules/opportunity-engine/startup-guides/types.ts
+++ b/backend/src/modules/opportunity-engine/startup-guides/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Startup-guide catalog types (§12 Business Launch System).
+ *
+ * Code is the source of truth for the guides — same convention as the playbook
+ * recipes (`modules/playbook/recipes`). A guide describes how to stand up a
+ * specific micro-business: estimated startup cost, equipment, production
+ * suggestions, and the links that connect it to the rest of the platform
+ * (product archetypes, an opportunity subject, related categories).
+ */
+
+export type StartupGuideId =
+  | "seedling"
+  | "compost"
+  | "soap"
+  | "gardening"
+
+export type StartupGuide = {
+  id: StartupGuideId
+  slug: string
+  title: string
+  /** Marketplace category this business produces into. Used to link opportunities. */
+  category: string
+  summary: string
+  /** Estimated all-in startup cost in cents (USD). Feeds the §5 startup-cost signal. */
+  estimated_startup_cost_cents: number
+  /** Difficulty for the storefront filter. */
+  difficulty: "Beginner" | "Intermediate" | "Advanced"
+  required_equipment: string[]
+  production_suggestions: string[]
+  /** product-archetype ids this business typically lists under. */
+  related_archetypes: string[]
+  /** The opportunity subject key (category) this guide maps to. */
+  related_opportunity_key: string
+}

--- a/backend/src/modules/plugin-registry/__tests__/catalog.unit.spec.ts
+++ b/backend/src/modules/plugin-registry/__tests__/catalog.unit.spec.ts
@@ -1,0 +1,21 @@
+import { PLUGIN_SEED } from "../catalog"
+
+describe("plugin-registry/catalog (§16)", () => {
+  it("covers all three plugin categories", () => {
+    const categories = new Set(PLUGIN_SEED.map((p) => p.category))
+    expect(categories).toEqual(
+      new Set(["MARKETPLACE_EXTENSION", "ANALYTICS", "AUTOMATION"])
+    )
+  })
+
+  it("has unique, well-formed slugs and versions", () => {
+    const slugs = PLUGIN_SEED.map((p) => p.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+    for (const p of PLUGIN_SEED) {
+      expect(p.slug).toMatch(/^[a-z0-9-]+$/)
+      expect(p.version).toMatch(/^\d+\.\d+\.\d+$/)
+      expect(p.name.length).toBeGreaterThan(0)
+      expect(p.description.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/backend/src/modules/plugin-registry/catalog.ts
+++ b/backend/src/modules/plugin-registry/catalog.ts
@@ -1,0 +1,55 @@
+/**
+ * First-party seed catalog for the plugin ecosystem (§16). Code is the source
+ * of truth; seeded into `plugin_listing` at boot. Third-party plugins are added
+ * as rows by their author sellers.
+ */
+
+export type PluginSeed = {
+  slug: string
+  name: string
+  category: "MARKETPLACE_EXTENSION" | "ANALYTICS" | "AUTOMATION"
+  description: string
+  version: string
+}
+
+export const PLUGIN_SEED: PluginSeed[] = [
+  {
+    slug: "storefront-themes",
+    name: "Storefront Themes",
+    category: "MARKETPLACE_EXTENSION",
+    description: "Swappable storefront themes and layout blocks for your shop.",
+    version: "1.0.0",
+  },
+  {
+    slug: "sales-analytics",
+    name: "Sales & Conversion Analytics",
+    category: "ANALYTICS",
+    description:
+      "Dashboards for revenue, conversion, and product performance over time.",
+    version: "1.0.0",
+  },
+  {
+    slug: "creator-attribution-insights",
+    name: "Creator Attribution Insights",
+    category: "ANALYTICS",
+    description:
+      "Break down sales by creator, campaign, and referral link with trends.",
+    version: "1.0.0",
+  },
+  {
+    slug: "auto-restock-alerts",
+    name: "Auto Restock Alerts",
+    category: "AUTOMATION",
+    description:
+      "Automatic low-inventory alerts and reorder reminders by threshold.",
+    version: "1.0.0",
+  },
+  {
+    slug: "bounty-autoposter",
+    name: "Bounty Auto-Poster",
+    category: "AUTOMATION",
+    description:
+      "Automatically open marketing bounties when you launch new products.",
+    version: "1.0.0",
+  },
+]

--- a/backend/src/modules/plugin-registry/index.ts
+++ b/backend/src/modules/plugin-registry/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import PluginRegistryService from "./service"
+
+export const PLUGIN_REGISTRY_MODULE = "plugin-registry"
+
+export default Module(PLUGIN_REGISTRY_MODULE, {
+  service: PluginRegistryService,
+})
+
+export * from "./models"
+export { PLUGIN_SEED, type PluginSeed } from "./catalog"

--- a/backend/src/modules/plugin-registry/migrations/Migration20260608CreatePluginRegistry.ts
+++ b/backend/src/modules/plugin-registry/migrations/Migration20260608CreatePluginRegistry.ts
@@ -1,0 +1,37 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: create `plugin_listing` backing the Black Market plugin
+ * ecosystem (§16).
+ */
+export class Migration20260608CreatePluginRegistry extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "plugin_listing" (
+        "id" TEXT NOT NULL,
+        "slug" TEXT NOT NULL UNIQUE,
+        "name" TEXT NOT NULL,
+        "category" TEXT NOT NULL DEFAULT 'MARKETPLACE_EXTENSION',
+        "description" TEXT NOT NULL,
+        "author_seller_id" TEXT NULL,
+        "manifest_url" TEXT NULL,
+        "icon_url" TEXT NULL,
+        "version" TEXT NOT NULL DEFAULT '1.0.0',
+        "status" TEXT NOT NULL DEFAULT 'PUBLISHED',
+        "install_count" INTEGER NOT NULL DEFAULT 0,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "plugin_listing_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_plugin_listing_slug" ON "plugin_listing" ("slug") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_plugin_listing_category" ON "plugin_listing" ("category") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_plugin_listing_status" ON "plugin_listing" ("status") WHERE "deleted_at" IS NULL;`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`DROP TABLE IF EXISTS "plugin_listing";`)
+  }
+}

--- a/backend/src/modules/plugin-registry/models/index.ts
+++ b/backend/src/modules/plugin-registry/models/index.ts
@@ -1,0 +1,2 @@
+export { default as PluginListing } from "./plugin-listing"
+export { PluginCategory, PluginStatus } from "./plugin-listing"

--- a/backend/src/modules/plugin-registry/models/plugin-listing.ts
+++ b/backend/src/modules/plugin-registry/models/plugin-listing.ts
@@ -1,0 +1,47 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum PluginCategory {
+  MARKETPLACE_EXTENSION = "MARKETPLACE_EXTENSION",
+  ANALYTICS = "ANALYTICS",
+  AUTOMATION = "AUTOMATION",
+}
+
+export enum PluginStatus {
+  PUBLISHED = "PUBLISHED",
+  DRAFT = "DRAFT",
+  DEPRECATED = "DEPRECATED",
+}
+
+/**
+ * A listing in the Black Market plugin ecosystem (§16): a marketplace
+ * extension, analytics tool, or automation tool a vendor can discover and
+ * install. Installation is recorded against the seller's `enabled_extensions`
+ * (seller-extension module) — this table is the discovery catalog.
+ */
+const PluginListing = model
+  .define("plugin_listing", {
+    id: model.id().primaryKey(),
+    slug: model.text().unique(),
+    name: model.text().searchable(),
+    category: model
+      .enum(Object.values(PluginCategory))
+      .default(PluginCategory.MARKETPLACE_EXTENSION),
+    description: model.text(),
+    /** Optional author seller; null for first-party plugins. */
+    author_seller_id: model.text().nullable(),
+    manifest_url: model.text().nullable(),
+    icon_url: model.text().nullable(),
+    version: model.text().default("1.0.0"),
+    status: model
+      .enum(Object.values(PluginStatus))
+      .default(PluginStatus.PUBLISHED),
+    install_count: model.number().default(0),
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    { on: ["slug"], name: "IDX_plugin_listing_slug" },
+    { on: ["category"], name: "IDX_plugin_listing_category" },
+    { on: ["status"], name: "IDX_plugin_listing_status" },
+  ])
+
+export default PluginListing

--- a/backend/src/modules/plugin-registry/service.ts
+++ b/backend/src/modules/plugin-registry/service.ts
@@ -1,0 +1,45 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import { PluginListing } from "./models"
+import { PluginStatus } from "./models/plugin-listing"
+
+/**
+ * Plugin ecosystem (§16) module service. Owns the discovery catalog of
+ * installable extensions/analytics/automation tools and the install counter.
+ * The actual per-seller enablement lives on seller-extension's
+ * `enabled_extensions`; this module is the registry + counts.
+ */
+class PluginRegistryService extends MedusaService({
+  PluginListing,
+}) {
+  async listPublished(filters?: { category?: string; limit?: number }) {
+    const where: Record<string, unknown> = { status: PluginStatus.PUBLISHED }
+    if (filters?.category) {
+      where.category = filters.category
+    }
+    return this.listPluginListings(where, {
+      take: filters?.limit || 100,
+      order: { install_count: "DESC", name: "ASC" },
+    })
+  }
+
+  async getBySlug(slug: string) {
+    const [plugin] = await this.listPluginListings({ slug })
+    return plugin || null
+  }
+
+  /** Increment install count (called when a seller installs the plugin). */
+  async incrementInstallCount(slug: string) {
+    const [plugin] = await this.listPluginListings({ slug })
+    if (!plugin) {
+      throw new Error(`Plugin "${slug}" not found`)
+    }
+    await this.updatePluginListings({
+      id: plugin.id,
+      install_count: Number(plugin.install_count) + 1,
+    })
+    const [updated] = await this.listPluginListings({ id: plugin.id })
+    return updated
+  }
+}
+
+export default PluginRegistryService

--- a/backend/src/scripts/seed-knowledge-base.ts
+++ b/backend/src/scripts/seed-knowledge-base.ts
@@ -1,0 +1,48 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { KNOWLEDGE_BASE_MODULE } from "../modules/knowledge-base"
+import { KB_SEED_ARTICLES } from "../modules/knowledge-base/catalog"
+
+/**
+ * Seed the Knowledge Base (§14) from the in-code catalog. Idempotent: upserts
+ * by slug. Mirrors seed-playbooks.ts.
+ *
+ * Run:
+ *   pnpm medusa exec ./src/scripts/seed-knowledge-base.ts
+ */
+export default async function seedKnowledgeBase({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const kb: any = container.resolve(KNOWLEDGE_BASE_MODULE)
+
+  logger.info("[seed-knowledge-base] starting")
+
+  let upserted = 0
+  for (const a of KB_SEED_ARTICLES) {
+    const [existing] = await kb.listKbArticles({ slug: a.slug })
+    const payload = {
+      slug: a.slug,
+      title: a.title,
+      type: a.type,
+      summary: a.summary,
+      body: a.body,
+      category: a.category,
+      difficulty: a.difficulty,
+      climate_zone: a.climate_zone ?? null,
+      space: a.space ?? null,
+      materials: a.materials,
+      steps: a.steps,
+      contributed_by_community: false,
+      status: "PUBLISHED",
+    }
+    if (existing) {
+      await kb.updateKbArticles({ id: existing.id, ...payload })
+    } else {
+      await kb.createKbArticles(payload)
+    }
+    upserted++
+  }
+
+  logger.info(`[seed-knowledge-base] upserted ${upserted} articles`)
+  logger.info("[seed-knowledge-base] done")
+}

--- a/backend/src/scripts/seed-opportunity-engine.ts
+++ b/backend/src/scripts/seed-opportunity-engine.ts
@@ -1,0 +1,96 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { OPPORTUNITY_ENGINE_MODULE } from "../modules/opportunity-engine"
+import {
+  STARTUP_GUIDES,
+  STARTUP_GUIDE_IDS,
+} from "../modules/opportunity-engine/startup-guides"
+
+/**
+ * Seed the Opportunity Engine: upsert the startup-guide registry from the
+ * in-code catalog and lay down a baseline of price observations so the Price
+ * Tracker and Economic-Intelligence trends render before live data arrives.
+ *
+ * Idempotent — re-running upserts any code↔DB drift. Mirrors seed-playbooks.ts.
+ *
+ * Run:
+ *   pnpm medusa exec ./src/scripts/seed-opportunity-engine.ts
+ */
+export default async function seedOpportunityEngine({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const engine: any = container.resolve(OPPORTUNITY_ENGINE_MODULE)
+
+  logger.info("[seed-opportunity-engine] starting")
+
+  // ── Startup guides (§12) ──
+  let guidesUpserted = 0
+  for (const id of STARTUP_GUIDE_IDS) {
+    const g = STARTUP_GUIDES[id]
+    const [existing] = await engine.listStartupGuides({ guide_id: g.id })
+    const payload = {
+      guide_id: g.id,
+      slug: g.slug,
+      title: g.title,
+      category: g.category,
+      summary: g.summary,
+      estimated_startup_cost_cents: g.estimated_startup_cost_cents,
+      difficulty: g.difficulty,
+      required_equipment: g.required_equipment,
+      production_suggestions: g.production_suggestions,
+      related_archetypes: g.related_archetypes,
+      related_opportunity_key: g.related_opportunity_key,
+      is_active: true,
+    }
+    if (existing) {
+      await engine.updateStartupGuides({ id: existing.id, ...payload })
+    } else {
+      await engine.createStartupGuides(payload)
+    }
+    guidesUpserted++
+  }
+  logger.info(`[seed-opportunity-engine] upserted ${guidesUpserted} startup guides`)
+
+  // ── Baseline price observations (§5 Price Tracker / §15 trends) ──
+  // A small synthetic series per focus category so the tracker has shape.
+  // Skipped entirely if observations already exist (don't duplicate on re-run).
+  const focus: Array<{ category: string; base: number; unit: string }> = [
+    { category: "food", base: 320, unit: "lb" },
+    { category: "gardening", base: 450, unit: "each" },
+    { category: "agriculture", base: 1800, unit: "cubic-yard" },
+    { category: "home-goods", base: 650, unit: "each" },
+  ]
+  const regions = ["US", "CA", "TX", "NY"]
+  let obsCreated = 0
+  for (const f of focus) {
+    const [existing] = await engine.listPriceObservations({
+      category: f.category,
+    })
+    if (existing) {
+      continue
+    }
+    for (const region of regions) {
+      // 6 monthly points with a mild upward drift + per-region offset.
+      for (let m = 5; m >= 0; m--) {
+        const observed = new Date()
+        observed.setMonth(observed.getMonth() - m)
+        const drift = 1 + (5 - m) * 0.02
+        const regionOffset =
+          region === "US" ? 1 : 1 + (region.charCodeAt(0) % 7) / 100
+        await engine.recordPriceObservation({
+          category: f.category,
+          region,
+          unit: f.unit,
+          price_cents: Math.round(f.base * drift * regionOffset),
+          source: "seed",
+          observed_at: observed,
+        })
+        obsCreated++
+      }
+    }
+  }
+  logger.info(
+    `[seed-opportunity-engine] created ${obsCreated} baseline price observations`
+  )
+  logger.info("[seed-opportunity-engine] done")
+}

--- a/backend/src/scripts/seed-plugins.ts
+++ b/backend/src/scripts/seed-plugins.ts
@@ -1,0 +1,41 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PLUGIN_REGISTRY_MODULE } from "../modules/plugin-registry"
+import { PLUGIN_SEED } from "../modules/plugin-registry/catalog"
+
+/**
+ * Seed the plugin ecosystem (§16) first-party catalog. Idempotent: upserts by
+ * slug. Mirrors seed-playbooks.ts.
+ *
+ * Run:
+ *   pnpm medusa exec ./src/scripts/seed-plugins.ts
+ */
+export default async function seedPlugins({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const registry: any = container.resolve(PLUGIN_REGISTRY_MODULE)
+
+  logger.info("[seed-plugins] starting")
+
+  let upserted = 0
+  for (const p of PLUGIN_SEED) {
+    const [existing] = await registry.listPluginListings({ slug: p.slug })
+    const payload = {
+      slug: p.slug,
+      name: p.name,
+      category: p.category,
+      description: p.description,
+      version: p.version,
+      status: "PUBLISHED",
+    }
+    if (existing) {
+      await registry.updatePluginListings({ id: existing.id, ...payload })
+    } else {
+      await registry.createPluginListings(payload)
+    }
+    upserted++
+  }
+
+  logger.info(`[seed-plugins] upserted ${upserted} plugins`)
+  logger.info("[seed-plugins] done")
+}

--- a/storefront/src/app/[locale]/(main)/knowledge-base/[slug]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/knowledge-base/[slug]/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { getKbArticle } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Guide",
+}
+
+export default async function KbArticlePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const article = await getKbArticle(slug)
+
+  if (!article) {
+    return (
+      <main className="container py-10">
+        <h1 className="text-2xl font-semibold">Guide not found</h1>
+        <LocalizedClientLink
+          href="/knowledge-base"
+          className="mt-4 inline-block text-green-700 hover:underline"
+        >
+          ← Knowledge base
+        </LocalizedClientLink>
+      </main>
+    )
+  }
+
+  const materials: string[] = Array.isArray(article.materials)
+    ? article.materials
+    : []
+  const steps: string[] = Array.isArray(article.steps) ? article.steps : []
+
+  return (
+    <main className="container max-w-3xl py-10">
+      <LocalizedClientLink
+        href="/knowledge-base"
+        className="text-sm text-green-700 hover:underline"
+      >
+        ← Knowledge base
+      </LocalizedClientLink>
+      <header className="mt-2 mb-6">
+        <p className="text-xs uppercase tracking-wide text-ui-fg-muted">
+          {String(article.type).replace("_", " ").toLowerCase()}
+          {article.difficulty ? ` · ${article.difficulty}` : ""}
+          {article.contributed_by_community ? " · community" : ""}
+        </p>
+        <h1 className="text-3xl font-semibold">{article.title}</h1>
+        <p className="mt-2 text-ui-fg-subtle">{article.summary}</p>
+      </header>
+
+      {article.body ? (
+        <p className="mb-6 text-ui-fg-base">{article.body}</p>
+      ) : null}
+
+      {materials.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-xl font-semibold">Materials</h2>
+          <ul className="list-inside list-disc text-ui-fg-subtle">
+            {materials.map((m, i) => (
+              <li key={i}>{m}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {steps.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-xl font-semibold">Steps</h2>
+          <ol className="list-inside list-decimal space-y-1 text-ui-fg-base">
+            {steps.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ol>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/knowledge-base/page.tsx
+++ b/storefront/src/app/[locale]/(main)/knowledge-base/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { listKnowledgeBase, type KbArticleSummary } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Knowledge Base",
+  description:
+    "DIY guides, container gardening, and make-vs-buy substitution guides.",
+}
+
+const TYPES = [
+  { value: "", label: "All" },
+  { value: "DIY", label: "DIY" },
+  { value: "CONTAINER_GARDENING", label: "Container Gardening" },
+  { value: "SUBSTITUTION", label: "Substitution" },
+]
+
+export default async function KnowledgeBasePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ type?: string; q?: string }>
+}) {
+  const { type, q } = await searchParams
+  let articles: KbArticleSummary[] = []
+  try {
+    articles = await listKnowledgeBase({ type, q })
+  } catch {
+    articles = []
+  }
+
+  return (
+    <main className="container py-10">
+      <header className="mb-6">
+        <p className="text-sm font-semibold uppercase tracking-wide text-green-700">
+          Make It Yourself
+        </p>
+        <h1 className="text-3xl font-semibold">Knowledge base</h1>
+        <p className="mt-2 max-w-2xl text-ui-fg-subtle">
+          DIY recipes, container-gardening guides, and make-vs-buy comparisons.
+        </p>
+      </header>
+
+      <form method="get" className="mb-8 flex flex-wrap items-end gap-3 rounded-xl border p-4">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-ui-fg-subtle" htmlFor="type">
+            Type
+          </label>
+          <select
+            id="type"
+            name="type"
+            defaultValue={type ?? ""}
+            className="rounded-md border px-3 py-2 text-sm"
+          >
+            {TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-ui-fg-subtle" htmlFor="q">
+            Search
+          </label>
+          <input
+            id="q"
+            name="q"
+            defaultValue={q ?? ""}
+            placeholder="compost, detergent…"
+            className="rounded-md border px-3 py-2 text-sm"
+          />
+        </div>
+        <button
+          type="submit"
+          className="rounded-lg bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800"
+        >
+          Filter
+        </button>
+      </form>
+
+      {articles.length === 0 ? (
+        <div className="rounded-md border p-6 text-sm text-ui-fg-subtle">
+          No guides match these filters.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {articles.map((a) => (
+            <LocalizedClientLink
+              key={a.slug}
+              href={`/knowledge-base/${a.slug}`}
+              className="flex flex-col rounded-xl border p-4 hover:border-green-600"
+            >
+              <span className="text-xs uppercase tracking-wide text-ui-fg-muted">
+                {a.type.replace("_", " ").toLowerCase()}
+                {a.difficulty ? ` · ${a.difficulty}` : ""}
+              </span>
+              <span className="mt-1 font-semibold">{a.title}</span>
+              <span className="mt-2 line-clamp-2 text-sm text-ui-fg-subtle">
+                {a.summary}
+              </span>
+            </LocalizedClientLink>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/opportunities/[subject]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/opportunities/[subject]/page.tsx
@@ -1,0 +1,154 @@
+import type { Metadata } from "next"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { getOpportunity } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Opportunity",
+}
+
+const dollars = (cents?: number | null) =>
+  cents == null ? "—" : `$${(cents / 100).toLocaleString()}`
+
+export default async function OpportunityDetailPage({
+  params,
+}: {
+  params: Promise<{ subject: string }>
+}) {
+  const { subject } = await params
+  const data = await getOpportunity(subject)
+
+  if (!data) {
+    return (
+      <main className="container py-10">
+        <h1 className="text-2xl font-semibold capitalize">{subject}</h1>
+        <p className="mt-2 text-ui-fg-subtle">
+          No opportunity data yet for this subject.
+        </p>
+        <LocalizedClientLink
+          href="/opportunities"
+          className="mt-4 inline-block text-green-700 hover:underline"
+        >
+          ← All opportunities
+        </LocalizedClientLink>
+      </main>
+    )
+  }
+
+  const guides = data.startup_requirements || []
+  const trend = data.price_trend || {}
+
+  return (
+    <main className="container py-10">
+      <LocalizedClientLink
+        href="/opportunities"
+        className="text-sm text-green-700 hover:underline"
+      >
+        ← All opportunities
+      </LocalizedClientLink>
+      <header className="mt-2 mb-6 flex items-center justify-between">
+        <h1 className="text-3xl font-semibold capitalize">
+          {data.subject_key}
+        </h1>
+        <span className="rounded-full bg-green-100 px-3 py-1 text-lg font-bold text-green-800">
+          {Number(data.opportunity_score).toFixed(1)}
+        </span>
+      </header>
+
+      <section className="mb-8 grid gap-4 sm:grid-cols-3">
+        <div className="rounded-xl border p-4">
+          <p className="text-xs uppercase text-ui-fg-subtle">Demand</p>
+          <p className="text-lg font-semibold">{data.bands?.demand ?? "—"}</p>
+          <p className="text-xs text-ui-fg-subtle">
+            {data.market_demand?.openDemandPosts ?? 0} open needs ·{" "}
+            {data.market_demand?.wishlistCount ?? 0} wishlists
+          </p>
+        </div>
+        <div className="rounded-xl border p-4">
+          <p className="text-xs uppercase text-ui-fg-subtle">Competition</p>
+          <p className="text-lg font-semibold">
+            {data.bands?.competition ?? "—"}
+          </p>
+          <p className="text-xs text-ui-fg-subtle">
+            {data.competition?.activeSellers ?? 0} sellers ·{" "}
+            {data.competition?.activeListings ?? 0} listings
+          </p>
+        </div>
+        <div className="rounded-xl border p-4">
+          <p className="text-xs uppercase text-ui-fg-subtle">Price trend</p>
+          <p className="text-lg font-semibold capitalize">
+            {trend.direction ?? "—"}
+          </p>
+          <p className="text-xs text-ui-fg-subtle">
+            {trend.pctChange != null
+              ? `${trend.pctChange > 0 ? "+" : ""}${trend.pctChange}%`
+              : ""}
+          </p>
+        </div>
+      </section>
+
+      {guides.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-xl font-semibold">Startup requirements</h2>
+          {guides.map((g: any) => (
+            <div key={g.slug} className="mb-4 rounded-xl border p-4">
+              <div className="flex items-center justify-between">
+                <LocalizedClientLink
+                  href={`/start-business/${g.slug}`}
+                  className="font-semibold hover:text-green-700"
+                >
+                  {g.title}
+                </LocalizedClientLink>
+                <span className="text-sm text-ui-fg-subtle">
+                  est. {dollars(g.estimated_startup_cost_cents)}
+                </span>
+              </div>
+              {g.required_equipment?.length ? (
+                <ul className="mt-2 list-inside list-disc text-sm text-ui-fg-subtle">
+                  {g.required_equipment.slice(0, 5).map((e: string, i: number) => (
+                    <li key={i}>{e}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ))}
+        </section>
+      )}
+
+      <section className="grid gap-6 sm:grid-cols-2">
+        <div>
+          <h2 className="mb-3 text-xl font-semibold">Related products</h2>
+          {data.related_products?.length ? (
+            <ul className="flex flex-col gap-1">
+              {data.related_products.map((p: any) => (
+                <li key={p.id}>
+                  <LocalizedClientLink
+                    href={`/products/${p.handle}`}
+                    className="text-sm hover:text-green-700"
+                  >
+                    {p.title}
+                  </LocalizedClientLink>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-ui-fg-subtle">None yet.</p>
+          )}
+        </div>
+        <div>
+          <h2 className="mb-3 text-xl font-semibold">Related coalitions</h2>
+          {data.related_coalitions?.length ? (
+            <ul className="flex flex-col gap-1">
+              {data.related_coalitions.map((c: any) => (
+                <li key={c.id} className="text-sm">
+                  {c.name}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-ui-fg-subtle">None yet.</p>
+          )}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/opportunities/page.tsx
+++ b/storefront/src/app/[locale]/(main)/opportunities/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { listOpportunities, type OpportunityRow } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Opportunities",
+  description:
+    "Discover what to produce: local-production opportunities ranked by demand, competition, and startup cost.",
+}
+
+const band = (v: number) => (v >= 0.66 ? "High" : v >= 0.33 ? "Medium" : "Low")
+
+export default async function OpportunitiesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ region?: string }>
+}) {
+  const { region } = await searchParams
+  let opportunities: OpportunityRow[] = []
+  try {
+    opportunities = await listOpportunities({ region: region || "US", limit: 50 })
+  } catch {
+    opportunities = []
+  }
+
+  return (
+    <main className="container py-10">
+      <header className="mb-6">
+        <p className="text-sm font-semibold uppercase tracking-wide text-green-700">
+          Opportunity Engine
+        </p>
+        <h1 className="text-3xl font-semibold">Local-production opportunities</h1>
+        <p className="mt-2 max-w-2xl text-ui-fg-subtle">
+          Where demand is high, competition is low, and startup cost is
+          manageable. Scored 0–10 from live marketplace signals.
+        </p>
+      </header>
+
+      {opportunities.length === 0 ? (
+        <div className="rounded-md border p-6 text-sm text-ui-fg-subtle">
+          No scored opportunities yet — they populate as demand builds.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {opportunities.map((o) => (
+            <LocalizedClientLink
+              key={o.id}
+              href={`/opportunities/${encodeURIComponent(o.subject_key)}`}
+              className="flex flex-col rounded-xl border p-4 hover:border-green-600"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-semibold capitalize">
+                  {o.subject_label || o.subject_key}
+                </span>
+                <span className="rounded-full bg-green-100 px-2 py-0.5 text-sm font-bold text-green-800">
+                  {o.opportunity_score.toFixed(1)}
+                </span>
+              </div>
+              <dl className="mt-3 grid grid-cols-3 gap-2 text-xs text-ui-fg-subtle">
+                <div>
+                  <dt>Demand</dt>
+                  <dd className="font-medium text-ui-fg-base">
+                    {band(o.demand)}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Competition</dt>
+                  <dd className="font-medium text-ui-fg-base">
+                    {band(o.competition)}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Startup</dt>
+                  <dd className="font-medium text-ui-fg-base">
+                    {band(o.startup_cost)}
+                  </dd>
+                </div>
+              </dl>
+            </LocalizedClientLink>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/price-tracker/page.tsx
+++ b/storefront/src/app/[locale]/(main)/price-tracker/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next"
+import { getPriceTracker, type PriceTrack } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Price Tracker",
+  description:
+    "Track prices for food, gardening, agriculture, and household goods by region.",
+}
+
+const dollars = (cents?: number | null) =>
+  cents == null ? "—" : `$${(cents / 100).toFixed(2)}`
+
+const arrow = (d: string) => (d === "rising" ? "▲" : d === "falling" ? "▼" : "—")
+const color = (d: string) =>
+  d === "rising" ? "text-red-600" : d === "falling" ? "text-green-700" : "text-ui-fg-subtle"
+
+export default async function PriceTrackerPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ region?: string }>
+}) {
+  const { region } = await searchParams
+  let tracks: PriceTrack[] = []
+  try {
+    tracks = await getPriceTracker({ region: region || "US" })
+  } catch {
+    tracks = []
+  }
+
+  return (
+    <main className="container py-10">
+      <header className="mb-6">
+        <p className="text-sm font-semibold uppercase tracking-wide text-green-700">
+          Economic Intelligence
+        </p>
+        <h1 className="text-3xl font-semibold">Price tracker</h1>
+        <p className="mt-2 max-w-2xl text-ui-fg-subtle">
+          Recent price trends for food, gardening, agriculture, and household
+          goods in {region || "US"}.
+        </p>
+      </header>
+
+      {tracks.length === 0 ? (
+        <div className="rounded-md border p-6 text-sm text-ui-fg-subtle">
+          No price data yet.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {tracks.map((t) => (
+            <div key={t.category} className="rounded-xl border p-4">
+              <div className="flex items-center justify-between">
+                <span className="font-semibold capitalize">{t.category}</span>
+                <span className={`text-sm font-medium ${color(t.trend.direction)}`}>
+                  {arrow(t.trend.direction)}{" "}
+                  {t.trend.pctChange > 0 ? "+" : ""}
+                  {t.trend.pctChange}%
+                </span>
+              </div>
+              <p className="mt-2 text-2xl font-semibold">
+                {dollars(t.trend.latestCents)}
+              </p>
+              <p className="text-xs text-ui-fg-subtle">
+                latest · {t.series.length} observations
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/products/[handle]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/products/[handle]/page.tsx
@@ -3,8 +3,85 @@ import { listProducts } from "@/lib/data/products"
 import { generateProductMetadata } from "@/lib/helpers/seo"
 import { selectPresentation } from "@/lib/listing/presentation"
 import { getStorefrontContext } from "@/lib/data/cookies"
+import { getProductCommunity } from "@/lib/data/discovery"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
+
+// §13 Community Product Page panel: related coalitions, creator content, and a
+// Blackout Dens discussion link (threads are Blackout-hosted). Self-contained
+// so it never blocks the product render — failures degrade to nothing.
+async function ProductCommunitySection({ handle }: { handle: string }) {
+  const community = await getProductCommunity(handle)
+  if (!community) {
+    return null
+  }
+  const { coalition_recommendations, creator_content, discussion } = community
+  if (
+    !coalition_recommendations?.length &&
+    !creator_content?.length &&
+    !discussion?.deep_link
+  ) {
+    return null
+  }
+  return (
+    <section className="my-10 border-t pt-8">
+      <h2 className="mb-4 text-xl font-semibold">Community</h2>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div>
+          <h3 className="mb-2 text-sm font-semibold uppercase text-ui-fg-subtle">
+            Related coalitions
+          </h3>
+          {coalition_recommendations?.length ? (
+            <ul className="flex flex-col gap-1 text-sm">
+              {coalition_recommendations.map((c) => (
+                <li key={c.id}>{c.name}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-ui-fg-subtle">None yet.</p>
+          )}
+        </div>
+        <div>
+          <h3 className="mb-2 text-sm font-semibold uppercase text-ui-fg-subtle">
+            Guides &amp; tutorials
+          </h3>
+          {creator_content?.length ? (
+            <ul className="flex flex-col gap-1 text-sm">
+              {creator_content.map((a) => (
+                <li key={a.slug}>
+                  <LocalizedClientLink
+                    href={`/knowledge-base/${a.slug}`}
+                    className="hover:text-green-700"
+                  >
+                    {a.title}
+                  </LocalizedClientLink>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-ui-fg-subtle">None yet.</p>
+          )}
+        </div>
+        <div>
+          <h3 className="mb-2 text-sm font-semibold uppercase text-ui-fg-subtle">
+            Discussion
+          </h3>
+          {discussion?.deep_link ? (
+            <a
+              href={discussion.deep_link}
+              className="text-sm text-green-700 hover:underline"
+            >
+              Join the discussion on Blackout →
+            </a>
+          ) : (
+            <p className="text-sm text-ui-fg-subtle">No thread yet.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
 
 export async function generateMetadata({
   params,
@@ -49,6 +126,7 @@ export default async function ProductPage({
   return (
     <main className="container">
       <ProductDetailsPage handle={handle} locale={locale} presentation={presentation} />
+      <ProductCommunitySection handle={handle} />
     </main>
   )
 }

--- a/storefront/src/app/[locale]/(main)/start-business/[slug]/page.tsx
+++ b/storefront/src/app/[locale]/(main)/start-business/[slug]/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from "next"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { getStartupGuide } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Startup Guide",
+}
+
+const dollars = (cents?: number) =>
+  cents == null ? "—" : `$${(cents / 100).toLocaleString()}`
+
+export default async function StartupGuideDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const data = await getStartupGuide(slug)
+  const guide = data?.guide
+
+  if (!guide) {
+    return (
+      <main className="container py-10">
+        <h1 className="text-2xl font-semibold">Guide not found</h1>
+        <LocalizedClientLink
+          href="/start-business"
+          className="mt-4 inline-block text-green-700 hover:underline"
+        >
+          ← Start a business
+        </LocalizedClientLink>
+      </main>
+    )
+  }
+
+  return (
+    <main className="container max-w-3xl py-10">
+      <LocalizedClientLink
+        href="/start-business"
+        className="text-sm text-green-700 hover:underline"
+      >
+        ← Start a business
+      </LocalizedClientLink>
+      <header className="mt-2 mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold">{guide.title}</h1>
+          <p className="mt-2 text-ui-fg-subtle">{guide.summary}</p>
+        </div>
+        <span className="whitespace-nowrap rounded-full bg-green-100 px-3 py-1 text-sm font-semibold text-green-800">
+          est. {dollars(guide.estimated_startup_cost_cents)}
+        </span>
+      </header>
+
+      <div className="mb-8 flex gap-3">
+        <LocalizedClientLink
+          href={`/opportunities/${guide.related_opportunity_key}`}
+          className="rounded-lg border px-4 py-2 text-sm font-semibold hover:border-green-600"
+        >
+          View market opportunity →
+        </LocalizedClientLink>
+        <LocalizedClientLink
+          href="/sell"
+          className="rounded-lg bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800"
+        >
+          Launch this business
+        </LocalizedClientLink>
+      </div>
+
+      <section className="mb-6 grid gap-6 sm:grid-cols-2">
+        <div>
+          <h2 className="mb-2 text-xl font-semibold">Required equipment</h2>
+          <ul className="list-inside list-disc text-ui-fg-subtle">
+            {(guide.required_equipment || []).map((e: string, i: number) => (
+              <li key={i}>{e}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h2 className="mb-2 text-xl font-semibold">Production tips</h2>
+          <ul className="list-inside list-disc text-ui-fg-subtle">
+            {(guide.production_suggestions || []).map((s: string, i: number) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {data.related_coalitions?.length ? (
+        <section>
+          <h2 className="mb-2 text-xl font-semibold">Related coalitions</h2>
+          <ul className="flex flex-col gap-1 text-sm">
+            {data.related_coalitions.map((c: any) => (
+              <li key={c.id}>{c.name}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </main>
+  )
+}

--- a/storefront/src/app/[locale]/(main)/start-business/page.tsx
+++ b/storefront/src/app/[locale]/(main)/start-business/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { listStartupGuides, type StartupGuideSummary } from "@/lib/data/discovery"
+
+export const metadata: Metadata = {
+  title: "Start a Business",
+  description:
+    "Step-by-step startup guides — seedlings, compost, soap, market gardening.",
+}
+
+const dollars = (cents: number) => `$${(cents / 100).toLocaleString()}`
+
+export default async function StartBusinessPage() {
+  let guides: StartupGuideSummary[] = []
+  try {
+    guides = await listStartupGuides()
+  } catch {
+    guides = []
+  }
+
+  return (
+    <main className="container py-10">
+      <header className="mb-6">
+        <p className="text-sm font-semibold uppercase tracking-wide text-green-700">
+          Business Launch System
+        </p>
+        <h1 className="text-3xl font-semibold">Start a business</h1>
+        <p className="mt-2 max-w-2xl text-ui-fg-subtle">
+          Proven micro-business playbooks with estimated costs, equipment, and a
+          path straight into the Launch Center.
+        </p>
+      </header>
+
+      {guides.length === 0 ? (
+        <div className="rounded-md border p-6 text-sm text-ui-fg-subtle">
+          No startup guides available yet.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {guides.map((g) => (
+            <LocalizedClientLink
+              key={g.slug}
+              href={`/start-business/${g.slug}`}
+              className="flex flex-col rounded-xl border p-4 hover:border-green-600"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-semibold">{g.title}</span>
+                <span className="text-xs text-ui-fg-subtle">{g.difficulty}</span>
+              </div>
+              <span className="mt-2 line-clamp-2 text-sm text-ui-fg-subtle">
+                {g.summary}
+              </span>
+              <span className="mt-3 text-sm font-medium text-green-700">
+                est. {dollars(g.estimated_startup_cost_cents)} to start
+              </span>
+            </LocalizedClientLink>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/storefront/src/components/molecules/CategoryNavbar/CategoryNavbar.tsx
+++ b/storefront/src/components/molecules/CategoryNavbar/CategoryNavbar.tsx
@@ -90,6 +90,17 @@ export const CategoryNavbar = ({
       </LocalizedClientLink>
 
       <LocalizedClientLink
+        href="/opportunities"
+        onClick={() => (onClose ? onClose(false) : null)}
+        className={cn(
+          "label-md uppercase px-4 my-3 md:my-0 flex items-center justify-between",
+          pathname?.includes("/opportunities") && "md:border-b md:border-primary"
+        )}
+      >
+        Opportunities
+      </LocalizedClientLink>
+
+      <LocalizedClientLink
         href="/community-resources"
         onClick={() => (onClose ? onClose(false) : null)}
         className={cn(

--- a/storefront/src/lib/data/discovery.ts
+++ b/storefront/src/lib/data/discovery.ts
@@ -150,3 +150,23 @@ export async function getStartupGuide(slug: string): Promise<any | null> {
     return null
   }
 }
+
+// ── §13 Community product page panel ──
+export type ProductCommunity = {
+  coalition_recommendations: { id: string; name: string }[]
+  creator_content: { slug: string; title: string; type: string }[]
+  discussion: { provider: string; deep_link: string | null }
+}
+
+export async function getProductCommunity(
+  handle: string
+): Promise<ProductCommunity | null> {
+  try {
+    return await medusaFetch<ProductCommunity>(
+      `/store/products/${encodeURIComponent(handle)}/community`,
+      { method: "GET", cache: "no-store" }
+    )
+  } catch {
+    return null
+  }
+}

--- a/storefront/src/lib/data/discovery.ts
+++ b/storefront/src/lib/data/discovery.ts
@@ -1,0 +1,152 @@
+"use server"
+
+import { medusaFetch } from "@/lib/config"
+
+// ── §5 Opportunity Engine ──
+export type OpportunityRow = {
+  id: string
+  subject_key: string
+  subject_label?: string
+  region: string
+  opportunity_score: number
+  demand: number
+  competition: number
+  startup_cost: number
+}
+
+export async function listOpportunities(query?: {
+  region?: string
+  limit?: number
+}): Promise<OpportunityRow[]> {
+  const params: Record<string, string | number> = {}
+  if (query?.region) params.region = query.region
+  if (query?.limit) params.limit = query.limit
+  try {
+    const r = await medusaFetch<{ opportunities: OpportunityRow[] }>(
+      "/store/opportunities",
+      { method: "GET", query: params, cache: "no-store" }
+    )
+    return r.opportunities || []
+  } catch {
+    return []
+  }
+}
+
+export async function getOpportunity(
+  subject: string,
+  region = "US"
+): Promise<any | null> {
+  try {
+    return await medusaFetch<any>(
+      `/store/opportunities/${encodeURIComponent(subject)}`,
+      { method: "GET", query: { region }, cache: "no-store" }
+    )
+  } catch {
+    return null
+  }
+}
+
+// ── §5/§15 Price tracker ──
+export type PriceTrack = {
+  category: string
+  region: string
+  trend: { direction: string; pctChange: number; latestCents: number | null }
+  series: { price_cents: number; unit: string; observed_at: string }[]
+}
+
+export async function getPriceTracker(query?: {
+  category?: string
+  region?: string
+}): Promise<PriceTrack[]> {
+  const params: Record<string, string> = {}
+  if (query?.category) params.category = query.category
+  if (query?.region) params.region = query.region
+  try {
+    const r = await medusaFetch<{ tracks: PriceTrack[] }>(
+      "/store/price-tracker",
+      { method: "GET", query: params, cache: "no-store" }
+    )
+    return r.tracks || []
+  } catch {
+    return []
+  }
+}
+
+// ── §14 Knowledge Base ──
+export type KbArticleSummary = {
+  slug: string
+  title: string
+  type: string
+  summary: string
+  category?: string | null
+  difficulty?: string
+  climate_zone?: string | null
+  space?: string | null
+}
+
+export async function listKnowledgeBase(query?: {
+  type?: string
+  category?: string
+  difficulty?: string
+  q?: string
+}): Promise<KbArticleSummary[]> {
+  const params: Record<string, string> = {}
+  for (const k of ["type", "category", "difficulty", "q"] as const) {
+    const v = query?.[k]
+    if (v) params[k] = v
+  }
+  try {
+    const r = await medusaFetch<{ articles: KbArticleSummary[] }>(
+      "/store/knowledge-base",
+      { method: "GET", query: params, cache: "no-store" }
+    )
+    return r.articles || []
+  } catch {
+    return []
+  }
+}
+
+export async function getKbArticle(slug: string): Promise<any | null> {
+  try {
+    const r = await medusaFetch<{ article: any }>(
+      `/store/knowledge-base/${encodeURIComponent(slug)}`,
+      { method: "GET", cache: "no-store" }
+    )
+    return r.article || null
+  } catch {
+    return null
+  }
+}
+
+// ── §12 Startup guides ──
+export type StartupGuideSummary = {
+  slug: string
+  title: string
+  category: string
+  summary: string
+  estimated_startup_cost_cents: number
+  difficulty: string
+}
+
+export async function listStartupGuides(): Promise<StartupGuideSummary[]> {
+  try {
+    const r = await medusaFetch<{ guides: StartupGuideSummary[] }>(
+      "/store/startup-guides",
+      { method: "GET", cache: "no-store" }
+    )
+    return r.guides || []
+  } catch {
+    return []
+  }
+}
+
+export async function getStartupGuide(slug: string): Promise<any | null> {
+  try {
+    return await medusaFetch<any>(
+      `/store/startup-guides/${encodeURIComponent(slug)}`,
+      { method: "GET", cache: "no-store" }
+    )
+  } catch {
+    return null
+  }
+}

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -126,6 +126,22 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/launch-business"),
           },
           {
+            path: "growth",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Growth",
+            },
+            lazy: () => import("../../routes/growth"),
+          },
+          {
+            path: "plugins",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Plugins",
+            },
+            lazy: () => import("../../routes/plugins"),
+          },
+          {
             path: "/requests",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/routes/growth/growth.tsx
+++ b/vendor-panel/src/routes/growth/growth.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react"
+import { Badge, Container, Heading, Text } from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+interface RankedCreator {
+  creator_seller_id: string
+  score: number
+  reasons: string[]
+}
+interface Coalition {
+  id: string
+  name: string
+}
+interface HighDemand {
+  subject_key: string
+  opportunity_score: number
+}
+interface Suggestions {
+  recommended_creators: RankedCreator[]
+  recommended_coalitions: Coalition[]
+  high_demand_products: HighDemand[]
+}
+
+interface PriceTrend {
+  direction: "rising" | "falling" | "flat"
+  pctChange: number
+}
+interface TrendRow {
+  category: string
+  opportunity_score: number | null
+  demand_direction: string
+  price_trend: PriceTrend
+}
+interface TrendsResponse {
+  trends: TrendRow[]
+  rising_opportunities: HighDemand[]
+}
+
+async function authedFetch<T>(path: string): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`${res.status}: ${res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+const directionBadge = (d: string) => {
+  if (d === "rising") return <Badge color="green">rising</Badge>
+  if (d === "falling") return <Badge color="red">falling</Badge>
+  return <Badge color="grey">steady</Badge>
+}
+
+export const GrowthPage = () => {
+  const [suggestions, setSuggestions] = useState<Suggestions | null>(null)
+  const [trends, setTrends] = useState<TrendsResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const [s, t] = await Promise.all([
+          authedFetch<Suggestions>("/v1/seller/growth/suggestions").catch(
+            () => null
+          ),
+          authedFetch<TrendsResponse>(
+            "/v1/seller/economic-intelligence/trends"
+          ).catch(() => null),
+        ])
+        setSuggestions(s)
+        setTrends(t)
+      } catch (e) {
+        setError((e as Error).message)
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h1">Growth</Heading>
+        <Text className="text-ui-fg-subtle" size="small">
+          Recommended creators, coalitions, and high-demand opportunities —
+          plus market trends to act on.
+        </Text>
+      </div>
+
+      {loading && (
+        <div className="px-6 py-4">
+          <Text size="small">Loading…</Text>
+        </div>
+      )}
+      {error && (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-error">
+            {error}
+          </Text>
+        </div>
+      )}
+
+      <div className="px-6 py-4">
+        <Heading level="h2" className="mb-2">
+          High-demand opportunities
+        </Heading>
+        {suggestions?.high_demand_products?.length ? (
+          <div className="flex flex-wrap gap-2">
+            {suggestions.high_demand_products.map((h) => (
+              <Badge key={h.subject_key} color="blue">
+                {h.subject_key} · {h.opportunity_score.toFixed(1)}
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <Text size="small" className="text-ui-fg-subtle">
+            No scored opportunities yet — they populate as demand builds.
+          </Text>
+        )}
+      </div>
+
+      <div className="px-6 py-4">
+        <Heading level="h2" className="mb-2">
+          Recommended creators
+        </Heading>
+        {suggestions?.recommended_creators?.length ? (
+          <ul className="flex flex-col gap-2">
+            {suggestions.recommended_creators.map((c) => (
+              <li key={c.creator_seller_id} className="flex items-center gap-2">
+                <Badge color="purple">{c.score.toFixed(2)}</Badge>
+                <Text size="small">{c.creator_seller_id}</Text>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {c.reasons.join(" · ")}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Text size="small" className="text-ui-fg-subtle">
+            No creator matches yet.
+          </Text>
+        )}
+      </div>
+
+      <div className="px-6 py-4">
+        <Heading level="h2" className="mb-2">
+          Recommended coalitions
+        </Heading>
+        {suggestions?.recommended_coalitions?.length ? (
+          <div className="flex flex-wrap gap-2">
+            {suggestions.recommended_coalitions.map((c) => (
+              <Badge key={c.id} color="orange">
+                {c.name}
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <Text size="small" className="text-ui-fg-subtle">
+            No coalition suggestions yet.
+          </Text>
+        )}
+      </div>
+
+      <div className="px-6 py-4">
+        <Heading level="h2" className="mb-2">
+          Market trends
+        </Heading>
+        {trends?.trends?.length ? (
+          <table className="w-full text-left">
+            <thead>
+              <tr className="text-ui-fg-subtle">
+                <th className="py-1">Category</th>
+                <th className="py-1">Demand</th>
+                <th className="py-1">Price</th>
+                <th className="py-1">Opportunity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {trends.trends.map((t) => (
+                <tr key={t.category} className="border-t">
+                  <td className="py-1">{t.category}</td>
+                  <td className="py-1">{directionBadge(t.demand_direction)}</td>
+                  <td className="py-1">
+                    {directionBadge(t.price_trend.direction)}{" "}
+                    <Text size="small" className="text-ui-fg-subtle inline">
+                      {t.price_trend.pctChange > 0 ? "+" : ""}
+                      {t.price_trend.pctChange}%
+                    </Text>
+                  </td>
+                  <td className="py-1">
+                    {t.opportunity_score != null
+                      ? t.opportunity_score.toFixed(1)
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <Text size="small" className="text-ui-fg-subtle">
+            Trends populate after the first opportunity recompute.
+          </Text>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/vendor-panel/src/routes/growth/index.ts
+++ b/vendor-panel/src/routes/growth/index.ts
@@ -1,0 +1,1 @@
+export { GrowthPage as Component } from "./growth"

--- a/vendor-panel/src/routes/plugins/index.ts
+++ b/vendor-panel/src/routes/plugins/index.ts
@@ -1,0 +1,1 @@
+export { PluginsPage as Component } from "./plugins"

--- a/vendor-panel/src/routes/plugins/plugins.tsx
+++ b/vendor-panel/src/routes/plugins/plugins.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react"
+import { Badge, Button, Container, Heading, Text, toast } from "@medusajs/ui"
+import { backendUrl, getAuthToken } from "../../lib/client"
+
+interface PluginRow {
+  slug: string
+  name: string
+  category: string
+  description: string
+  install_count: number
+}
+
+async function authedFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken()
+  const url = `${backendUrl.replace(/\/$/, "")}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`${res.status}: ${res.statusText}`)
+  }
+  return (await res.json()) as T
+}
+
+const categoryColor = (c: string) => {
+  if (c === "ANALYTICS") return "blue" as const
+  if (c === "AUTOMATION") return "green" as const
+  return "purple" as const
+}
+
+export const PluginsPage = () => {
+  const [available, setAvailable] = useState<PluginRow[]>([])
+  const [installed, setInstalled] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const reload = async () => {
+    setLoading(true)
+    try {
+      const data = await authedFetch<{
+        installed: string[]
+        available: PluginRow[]
+      }>("/v1/seller/plugins/installed")
+      setInstalled(data.installed || [])
+      setAvailable(data.available || [])
+    } catch (e) {
+      toast.error((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    reload()
+  }, [])
+
+  const install = async (slug: string) => {
+    setBusy(slug)
+    try {
+      const data = await authedFetch<{ installed: string[] }>(
+        `/v1/seller/plugins/${slug}/install`,
+        { method: "POST", body: "{}" }
+      )
+      setInstalled(data.installed || [])
+      toast.success("Plugin installed")
+    } catch (e) {
+      toast.error((e as Error).message)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h1">Plugins</Heading>
+        <Text className="text-ui-fg-subtle" size="small">
+          Marketplace extensions, analytics, and automation tools for your shop.
+        </Text>
+      </div>
+
+      {loading && (
+        <div className="px-6 py-4">
+          <Text size="small">Loading…</Text>
+        </div>
+      )}
+
+      <div className="flex flex-col divide-y">
+        {available.map((p) => {
+          const isInstalled = installed.includes(p.slug)
+          return (
+            <div
+              key={p.slug}
+              className="flex items-center justify-between px-6 py-4"
+            >
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <Text weight="plus">{p.name}</Text>
+                  <Badge color={categoryColor(p.category)} size="2xsmall">
+                    {p.category.toLowerCase().replace("_", " ")}
+                  </Badge>
+                </div>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {p.description}
+                </Text>
+              </div>
+              {isInstalled ? (
+                <Badge color="green">Installed</Badge>
+              ) : (
+                <Button
+                  size="small"
+                  variant="secondary"
+                  disabled={busy === p.slug}
+                  onClick={() => install(p.slug)}
+                >
+                  {busy === p.slug ? "Installing…" : "Install"}
+                </Button>
+              )}
+            </div>
+          )
+        })}
+        {!loading && available.length === 0 && (
+          <div className="px-6 py-4">
+            <Text size="small" className="text-ui-fg-subtle">
+              No plugins available yet.
+            </Text>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}


### PR DESCRIPTION
New opportunity-engine module: deterministic 0–10 opportunity scoring over
live demand/competition/startup-cost signals, a price tracker + trend
analysis, and the in-code startup-guide catalog (seedling/compost/soap/
gardening). Adds materialized opportunity_score + price_observation models,
a recompute job, a seed script, and store/seller API routes:
  GET /store/opportunities[/:subject], /store/price-tracker,
  /store/startup-guides[/:slug], /v1/seller/economic-intelligence/trends.
Pure scoring is unit-tested (14 tests). Reuses demand-pool, wishlist,
cooperative, and the product catalog for signals.