### PR TITLE
chore(logging): route runtime console.* through gated loggers (LG-1/2/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check vendor/module completeness
         run: pnpm check:vendor-completeness
 
+      - name: Check logging hygiene (no bare console.* in runtime code)
+        run: pnpm check:no-console
+
       - name: Lint storefront
         working-directory: storefront
         run: pnpm lint

--- a/TODO_TRACKER.md
+++ b/TODO_TRACKER.md
@@ -2,7 +2,7 @@
 
 Generated from in-code `TODO`/`FIXME` markers in `admin-panel/src`, `storefront/src`, and `vendor-panel/src`.
 
-**Open items:** 15 *(14 code markers + 1 open audit-derived manual follow-up)*
+**Open items:** 14 *(14 admin-panel code markers; the audit-derived manual follow-up is now resolved — see below)*
 
 ## Summary by area and severity
 
@@ -63,7 +63,7 @@ The following open issues were identified in the storefront routes/links/pages a
 |---|---|---|---|---|
 | ✅ | High | `storefront/routes` | Add route metadata to 20 pages missing `generateMetadata`/`metadata` exports (including `/sell`, `/collections/[handle]`, `/collective/demand-pools/[id]`, and account/password pages). | `storefront/docs/storefront-pages-audit.md` |
 | ✅ | High | `storefront/routes` | Add explicit `notFound()` handling to 10 dynamic routes missing fallback behavior (including `/collections/[handle]`, `/products/[handle]`, and `/user/orders/[id]` paths). | `storefront/docs/storefront-pages-audit.md` |
-| ⬜ | Medium | `storefront/qa` | Add recurring static internal-link route validation in QA/release checks to detect unmatched hard-coded hrefs before release. | `storefront/docs/storefront-pages-audit.md` |
+| ✅ | Medium | `storefront/qa` | Add recurring static internal-link route validation in QA/release checks to detect unmatched hard-coded hrefs before release. **Done** — implemented as `storefront/qa/validate-static-routes.mjs` (`pnpm qa:internal-links` / `pnpm release:check`), wired into the CI `lint` job; tracked as resolved (QA-1) in `docs/AUDIT_DEBT.md`. | `storefront/docs/storefront-pages-audit.md` |
 
 ## Usage
 

--- a/admin-panel/src/components/create-digital-product-form/index.tsx
+++ b/admin-panel/src/components/create-digital-product-form/index.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { useState } from "react"
 import { Input, Button, Select, toast } from "@medusajs/ui"
 import { MediaType } from "@/types"
@@ -147,14 +148,14 @@ const CreateDigitalProductForm = ({
         onSuccess?.()
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         toast.error("Error", {
           description: `An error occurred while creating the digital product: ${e}`
         })
       })
       .finally(() => setLoading(false))
     } catch (e) {
-      console.error(e)
+      logger.error(e)
       setLoading(false)
     }
   }

--- a/admin-panel/src/components/data-grid/hooks/use-data-grid-column-visibility.tsx
+++ b/admin-panel/src/components/data-grid/hooks/use-data-grid-column-visibility.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import type { Column, Table } from "@tanstack/react-table"
 import { useCallback } from "react"
 import type { FieldValues } from "react-hook-form"
@@ -59,7 +60,7 @@ function getColumnName<TData>(column: Column<TData, unknown>): string {
   }
 
   if (process.env.NODE_ENV === "development" && !meta?.name && enableHiding) {
-    console.warn(
+    logger.warn(
       `Column "${id}" does not have a name. You should add a name to the column definition. Falling back to the column id.`
     )
   }

--- a/admin-panel/src/components/layout/pages/single-column-page/single-column-page.tsx
+++ b/admin-panel/src/components/layout/pages/single-column-page/single-column-page.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { Outlet } from "react-router-dom"
 import { JsonViewSection } from "@components/common/json-view-section"
 import { MetadataSection } from "@components/common/metadata-section"
@@ -28,7 +29,7 @@ export const SingleColumnPage = <TData,>({
 
   if (showJSON && !data) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
+      logger.warn(
         "`showJSON` is true but no data is provided. To display JSON, provide data prop."
       )
     }
@@ -38,7 +39,7 @@ export const SingleColumnPage = <TData,>({
 
   if (showMetadata && !data) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
+      logger.warn(
         "`showMetadata` is true but no data is provided. To display metadata, provide data prop."
       )
     }

--- a/admin-panel/src/components/layout/pages/two-column-page/two-column-page.tsx
+++ b/admin-panel/src/components/layout/pages/two-column-page/two-column-page.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { clx } from "@medusajs/ui"
 import type { ComponentPropsWithoutRef, ComponentType } from "react";
 import { Children } from "react"
@@ -43,7 +44,7 @@ const Root = <TData,>({
 
   if (showJSON && !data) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
+      logger.warn(
         "`showJSON` is true but no data is provided. To display JSON, provide data prop."
       )
     }
@@ -53,7 +54,7 @@ const Root = <TData,>({
 
   if (showMetadata && !data) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
+      logger.warn(
         "`showMetadata` is true but no data is provided. To display metadata, provide data prop."
       )
     }

--- a/admin-panel/src/components/table/view-selector/view-pills.tsx
+++ b/admin-panel/src/components/table/view-selector/view-pills.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import type React from "react";
 import { useEffect, useState } from "react"
 import {
@@ -68,7 +69,7 @@ return
         await setActiveView.mutateAsync(viewId)
       }
     } catch (error) {
-      console.error("Error in handleViewSelect:", error)
+      logger.error("Error in handleViewSelect:", error)
     }
   }
 

--- a/admin-panel/src/components/utilities/error-boundary/error-boundary.tsx
+++ b/admin-panel/src/components/utilities/error-boundary/error-boundary.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { ExclamationCircle } from "@medusajs/icons"
 import { Text } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
@@ -27,7 +28,7 @@ export const ErrorBoundary = () => {
    * so this ensures that we always log it.
    */
   if (process.env.NODE_ENV === "development") {
-    console.error(error)
+    logger.error(error)
   }
 
   let title: string

--- a/admin-panel/src/dashboard-app/dashboard-app.tsx
+++ b/admin-panel/src/dashboard-app/dashboard-app.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import type {
   CustomFieldContainerZone,
   CustomFieldFormTab,
@@ -128,7 +129,7 @@ export class DashboardApp {
     allMenuItems.forEach((item) => {
       if (item.path.includes("/:")) {
         if (process.env.NODE_ENV === "development") {
-          console.warn(
+          logger.warn(
             `[@medusajs/dashboard] Menu item for path "${item.path}" can't be added to the sidebar as it contains a parameter.`
           )
         }
@@ -145,7 +146,7 @@ return
       // Check if this is a nested settings path
       if (isSettingsPath && pathParts.length > 2) {
         if (process.env.NODE_ENV === "development") {
-          console.warn(
+          logger.warn(
             `[@medusajs/dashboard] Nested settings menu item "${item.path}" can't be added to the sidebar. Only top-level settings items are allowed.`
           )
         }
@@ -165,7 +166,7 @@ return // Skip this item entirely
         pathParts.length > 1
       ) {
         if (process.env.NODE_ENV === "development") {
-          console.warn(
+          logger.warn(
             `[@medusajs/dashboard] Nested menu item "${item.path}" can't be added to the sidebar as it is nested under "${parentItem.nested}".`
           )
         }

--- a/admin-panel/src/lib/logger.ts
+++ b/admin-panel/src/lib/logger.ts
@@ -1,0 +1,29 @@
+type LoggerArgs = Parameters<typeof console.log>
+
+const isProduction = process.env.NODE_ENV === "production"
+
+/**
+ * Gated logger for the admin panel.
+ *
+ * `info`/`debug` are silenced in production builds; `warn`/`error` always emit.
+ * Centralizes console usage so log output is consistent and can be tuned in one
+ * place (see audit-debt item LG-3).
+ */
+export const logger = {
+  info: (...args: LoggerArgs) => {
+    if (!isProduction) {
+      console.info(...args)
+    }
+  },
+  warn: (...args: LoggerArgs) => {
+    console.warn(...args)
+  },
+  error: (...args: LoggerArgs) => {
+    console.error(...args)
+  },
+  debug: (...args: LoggerArgs) => {
+    if (!isProduction) {
+      console.debug(...args)
+    }
+  },
+}

--- a/admin-panel/src/lib/query-client.ts
+++ b/admin-panel/src/lib/query-client.ts
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query"
 
 const runtimeBackend = typeof window !== 'undefined' && (window as any).__MEDUSA_BACKEND_URL__
@@ -25,7 +26,7 @@ export const queryClient = new QueryClient({
     onError: (error, query) => {
       // Log errors for debugging in development
       if (process.env.NODE_ENV === 'development') {
-        console.error(`Query error [${query.queryKey}]:`, error)
+        logger.error(`Query error [${query.queryKey}]:`, error)
       }
     },
   }),
@@ -33,7 +34,7 @@ export const queryClient = new QueryClient({
     onError: (error) => {
       // Log mutation errors for debugging in development
       if (process.env.NODE_ENV === 'development') {
-        console.error('Mutation error:', error)
+        logger.error('Mutation error:', error)
       }
     },
   }),

--- a/admin-panel/src/lib/telemetry.ts
+++ b/admin-panel/src/lib/telemetry.ts
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 // Browser telemetry init for the admin panel.
 // Loaded by the app entrypoint (e.g. main.tsx). Sentry init is dynamic so the
 // dep is optional until the team commits to a SaaS provider.
@@ -20,6 +21,6 @@ export async function initTelemetry(): Promise<void> {
     })
   } catch {
     // eslint-disable-next-line no-console
-    console.warn("[telemetry] @sentry/browser is not installed; skipping init.")
+    logger.warn("[telemetry] @sentry/browser is not installed; skipping init.")
   }
 }

--- a/admin-panel/src/providers/keybind-provider/utils.ts
+++ b/admin-panel/src/providers/keybind-provider/utils.ts
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import type { Keys, Platform, Shortcut } from "@providers/keybind-provider/types"
 
 export const findFirstPlatformMatch = (keys: Keys) => {
@@ -22,7 +23,7 @@ export const getShortcutKeys = (shortcut: Shortcut) => {
   if (!keys) {
     const defaultPlatform = findFirstPlatformMatch(shortcut.keys)
 
-    console.warn(
+    logger.warn(
       `No keys found for platform "${platform}" in "${shortcut.label}" ${
         defaultPlatform
           ? `using keys for platform "${defaultPlatform.platform}"`

--- a/admin-panel/src/routes/attributes/attribute-create/attribute-create.tsx
+++ b/admin-panel/src/routes/attributes/attribute-create/attribute-create.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { useQueryClient } from "@tanstack/react-query";
 import { FocusModal, Button, toast, ProgressTabs } from "@medusajs/ui";
 import { useNavigate } from "react-router-dom";
@@ -33,7 +34,7 @@ export const AttributeCreate = () => {
 
         setCategories(product_categories);
       } catch (error) {
-        console.error("Failed to fetch categories:", error);
+        logger.error("Failed to fetch categories:", error);
       }
     };
     fetchCategories();
@@ -55,7 +56,7 @@ export const AttributeCreate = () => {
       navigate(-1);
     } catch (error) {
       toast.error((error as Error).message);
-      console.error(error);
+      logger.error(error);
     }
   };
 

--- a/admin-panel/src/routes/attributes/attribute-edit/attribute-edit.tsx
+++ b/admin-panel/src/routes/attributes/attribute-edit/attribute-edit.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { useQueryClient } from "@tanstack/react-query";
 import { FocusModal, Button, toast, ProgressTabs } from "@medusajs/ui";
 import { useNavigate, useParams } from "react-router-dom";
@@ -48,7 +49,7 @@ export const AttributeEdit = () => {
         });
         setCategories(response.product_categories);
       } catch (error) {
-        console.error("Failed to fetch categories:", error);
+        logger.error("Failed to fetch categories:", error);
       }
     };
     fetchCategories();
@@ -67,7 +68,7 @@ export const AttributeEdit = () => {
       navigate(-1);
     } catch (error) {
       toast.error((error as Error).message);
-      console.error(error);
+      logger.error(error);
     }
   };
 

--- a/admin-panel/src/routes/attributes/attribute-edit/components/attribute-form.tsx
+++ b/admin-panel/src/routes/attributes/attribute-edit/components/attribute-form.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import {
   Text,
   Input,
@@ -97,7 +98,7 @@ export const AttributeForm = ({
 
       await onSubmit(data);
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   });
 

--- a/admin-panel/src/routes/attributes/attribute-list/components/CategorySelectionModal.tsx
+++ b/admin-panel/src/routes/attributes/attribute-list/components/CategorySelectionModal.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import type React from "react";
 import { useState, useEffect } from "react";
 import { Prompt } from "@medusajs/ui";
@@ -36,7 +37,7 @@ export const CategorySelectionModal: React.FC<CategorySelectionModalProps> = ({
       });
       setCategories(response.product_categories || []);
     } catch (error) {
-      console.error("Failed to fetch categories:", error);
+      logger.error("Failed to fetch categories:", error);
     } finally {
       setIsLoading(false);
     }

--- a/admin-panel/src/routes/commission/components/create-commission-rule-form.tsx
+++ b/admin-panel/src/routes/commission/components/create-commission-rule-form.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { useEffect, useState } from "react";
 
 import { Button, Input, Label, Select, Switch, toast } from "@medusajs/ui";
@@ -102,7 +103,7 @@ const CreateCommissionRuleForm = ({ onSuccess }: Props) => {
       onSuccess?.();
     } catch (e: unknown) {
       toast.error("Error!");
-      console.error(e);
+      logger.error(e);
       setLoading(false);
     }
   };

--- a/admin-panel/src/routes/commission/components/upsert-default-commission-rule.tsx
+++ b/admin-panel/src/routes/commission/components/upsert-default-commission-rule.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { useEffect, useState } from "react";
 
 import { Button, Input, Label, Switch, toast } from "@medusajs/ui";
@@ -80,7 +81,7 @@ const UpsertDefaultCommissionRuleForm = ({ onSuccess, rule }: Props) => {
       onSuccess?.();
     } catch (e: unknown) {
       toast.error("Error!");
-      console.error(e);
+      logger.error(e);
       setLoading(false);
     }
   };

--- a/admin-panel/src/routes/configuration/components/create-rule-form.tsx
+++ b/admin-panel/src/routes/configuration/components/create-rule-form.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import { useState } from "react";
 
 import { Button, Label, Select, Switch, toast } from "@medusajs/ui";
@@ -35,7 +36,7 @@ const CreateConfigurationRuleForm = ({ onSuccess }: Props) => {
       setLoading(false);
     } catch (e: unknown) {
       toast.error((e as Error).message);
-      console.error(e);
+      logger.error(e);
       setLoading(false);
     }
   };

--- a/admin-panel/src/routes/locations/location-detail/components/location-general-section/location-general-section.tsx
+++ b/admin-panel/src/routes/locations/location-detail/components/location-general-section/location-general-section.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@lib/logger"
 import {
   ArchiveBox,
   CurrencyDollar,
@@ -336,7 +337,7 @@ function ServiceZone({
       process.env.NODE_ENV === "development" &&
       countryGeoZones.length !== countries.length
     ) {
-      console.warn(
+      logger.warn(
         "Some countries are missing in the static countries list",
         countryGeoZones
           .filter((g) => !countries.find((c) => c.iso_2 === g.country_code))

--- a/backend/src/admin/components/create-digital-product-form/index.tsx
+++ b/backend/src/admin/components/create-digital-product-form/index.tsx
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("admin/create-digital-product-form")
 import { useState } from "react"
 import { Input, Button, Select, toast } from "@medusajs/ui"
 import { MediaType } from "../../types/index"
@@ -147,14 +149,14 @@ const CreateDigitalProductForm = ({
         onSuccess?.()
       })
       .catch((e) => {
-        console.error(e)
+        log.error(e)
         toast.error("Error", {
           description: `An error occurred while creating the digital product: ${e}`
         })
       })
       .finally(() => setLoading(false))
     } catch (e) {
-      console.error(e)
+      log.error(e)
       setLoading(false)
     }
   }

--- a/backend/src/api/admin/auth-debug/route.ts
+++ b/backend/src/api/admin/auth-debug/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/admin/auth-debug")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
@@ -192,7 +194,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       diagnosis,
     })
   } catch (error: any) {
-    console.error("[auth-debug] Error:", error)
+    log.error("[auth-debug] Error:", error)
     return res.status(500).json({
       error: error.message,
       stack: process.env.NODE_ENV === "development" ? error.stack : undefined,

--- a/backend/src/api/admin/backfill-seller-auth/route.ts
+++ b/backend/src/api/admin/backfill-seller-auth/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/admin/backfill-seller-auth")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
@@ -97,7 +99,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     })
 
   } catch (error: any) {
-    console.error("Backfill error:", error)
+    log.error("Backfill error:", error)
     res.status(500).json({
       success: false,
       error: error.message,

--- a/backend/src/api/admin/chat/route.ts
+++ b/backend/src/api/admin/chat/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/admin/chat")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { requireAdminId } from "../../../shared/auth-helpers"
@@ -58,7 +60,7 @@ export async function GET(
       })
       login = await matrixService.mintLoginToken(mxid)
     } catch (error: any) {
-      console.error("[GET /admin/chat] Provisioning failed:", error.message)
+      log.error("[GET /admin/chat] Provisioning failed:", error.message)
     }
 
     const response: Record<string, unknown> = {
@@ -77,7 +79,7 @@ export async function GET(
 
     res.json(response)
   } catch (error: any) {
-    console.error("[GET /admin/chat] Error:", error)
+    log.error("[GET /admin/chat] Error:", error)
     res.status(500).json({
       message: error.message || "Failed to retrieve chat configuration",
     })

--- a/backend/src/api/admin/chat/unread/route.ts
+++ b/backend/src/api/admin/chat/unread/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/chat/unread")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { requireAdminId } from "../../../../shared/auth-helpers"
@@ -34,7 +36,7 @@ export async function GET(
     const unreadCount = await matrixService.getUnreadCount(mxid)
     res.json({ unread_count: unreadCount })
   } catch (error: any) {
-    console.warn(
+    log.warn(
       "[GET /admin/chat/unread] Matrix unavailable, returning degraded count:",
       error?.message
     )

--- a/backend/src/api/admin/collective/bargaining-groups/[id]/route.ts
+++ b/backend/src/api/admin/collective/bargaining-groups/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/admin/collective/bargaining-groups/[id]")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../../modules/bargaining"
 import BargainingModuleService from "../../../../../modules/bargaining/service"
@@ -14,7 +16,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     const details = await bargainingService.getGroupDetails(id)
     res.json({ bargaining_group: details })
   } catch (error: any) {
-    console.error(`[GET /admin/collective/bargaining-groups/${id}] Error:`, error.message)
+    log.error(`[GET /admin/collective/bargaining-groups/${id}] Error:`, error.message)
     res.status(error.message.includes("not found") ? 404 : 500).json({
       error: error.message,
     })
@@ -43,7 +45,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
 
     res.status(400).json({ error: "Invalid action" })
   } catch (error: any) {
-    console.error(`[POST /admin/collective/bargaining-groups/${id}] Error:`, error.message)
+    log.error(`[POST /admin/collective/bargaining-groups/${id}] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/admin/collective/bargaining-groups/route.ts
+++ b/backend/src/api/admin/collective/bargaining-groups/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/collective/bargaining-groups")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../modules/bargaining"
@@ -41,7 +43,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[GET /admin/collective/bargaining-groups] Error:", error.message)
+    log.error("[GET /admin/collective/bargaining-groups] Error:", error.message)
     res.status(500).json({ error: "Failed to retrieve bargaining groups" })
   }
 }

--- a/backend/src/api/admin/collective/buyer-networks/[id]/route.ts
+++ b/backend/src/api/admin/collective/buyer-networks/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/admin/collective/buyer-networks/[id]")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BUYER_NETWORK_MODULE } from "../../../../../modules/buyer-network"
 import BuyerNetworkModuleService from "../../../../../modules/buyer-network/service"
@@ -15,7 +17,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     const details = await networkService.getNetworkDetails(id)
     res.json({ buyer_network: details })
   } catch (error: any) {
-    console.error(`[GET /admin/collective/buyer-networks/${id}] Error:`, error.message)
+    log.error(`[GET /admin/collective/buyer-networks/${id}] Error:`, error.message)
     res.status(error.message.includes("not found") ? 404 : 500).json({
       error: error.message,
     })
@@ -61,7 +63,7 @@ export async function PATCH(req: AuthenticatedMedusaRequest, res: MedusaResponse
     const [updated] = await networkService.listBuyerNetworks({ id })
     res.json({ buyer_network: updated })
   } catch (error: any) {
-    console.error(`[PATCH /admin/collective/buyer-networks/${id}] Error:`, error.message)
+    log.error(`[PATCH /admin/collective/buyer-networks/${id}] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/admin/collective/buyer-networks/route.ts
+++ b/backend/src/api/admin/collective/buyer-networks/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/collective/buyer-networks")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BUYER_NETWORK_MODULE } from "../../../../modules/buyer-network"
@@ -43,7 +45,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[GET /admin/collective/buyer-networks] Error:", error.message)
+    log.error("[GET /admin/collective/buyer-networks] Error:", error.message)
     res.status(500).json({ error: "Failed to retrieve buyer networks" })
   }
 }

--- a/backend/src/api/admin/collective/demand-pools/[id]/route.ts
+++ b/backend/src/api/admin/collective/demand-pools/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/admin/collective/demand-pools/[id]")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../modules/demand-pool"
 import DemandPoolModuleService from "../../../../../modules/demand-pool/service"
@@ -23,7 +25,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
 
     res.json({ demand_pool: details, savings })
   } catch (error: any) {
-    console.error(`[GET /admin/collective/demand-pools/${id}] Error:`, error.message)
+    log.error(`[GET /admin/collective/demand-pools/${id}] Error:`, error.message)
     res.status(error.message.includes("not found") ? 404 : 500).json({
       error: error.message,
     })
@@ -81,7 +83,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
 
     res.status(400).json({ error: "Invalid action" })
   } catch (error: any) {
-    console.error(`[POST /admin/collective/demand-pools/${id}] Error:`, error.message)
+    log.error(`[POST /admin/collective/demand-pools/${id}] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }
@@ -109,7 +111,7 @@ export async function DELETE(req: AuthenticatedMedusaRequest, res: MedusaRespons
     await demandPoolService.deleteDemandPosts(id)
     res.json({ message: "Demand pool deleted", deleted: { id } })
   } catch (error: any) {
-    console.error(`[DELETE /admin/collective/demand-pools/${id}] Error:`, error.message)
+    log.error(`[DELETE /admin/collective/demand-pools/${id}] Error:`, error.message)
     res.status(500).json({ error: "Failed to delete demand pool" })
   }
 }

--- a/backend/src/api/admin/collective/demand-pools/route.ts
+++ b/backend/src/api/admin/collective/demand-pools/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/collective/demand-pools")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../modules/demand-pool"
@@ -43,7 +45,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[GET /admin/collective/demand-pools] Error:", error.message)
+    log.error("[GET /admin/collective/demand-pools] Error:", error.message)
     res.status(500).json({ error: "Failed to retrieve demand pools" })
   }
 }

--- a/backend/src/api/admin/creator-attribution/rollup/route.ts
+++ b/backend/src/api/admin/creator-attribution/rollup/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/creator-attribution/rollup")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { CREATOR_ATTRIBUTION_MODULE } from "../../../../modules/creator-attribution"
@@ -35,7 +37,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
         .status(400)
         .json({ message: "Validation failed", details: error.issues })
     }
-    console.error("[GET /admin/creator-attribution/rollup] Error:", error.message)
+    log.error("[GET /admin/creator-attribution/rollup] Error:", error.message)
     return res.status(400).json({ message: error.message })
   }
 }

--- a/backend/src/api/admin/debug/route.ts
+++ b/backend/src/api/admin/debug/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/admin/debug")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
@@ -40,7 +42,7 @@ export async function GET(
       instruction: "POST to this endpoint with {\"action\": \"fix\"} to link orphaned products to sellers"
     })
   } catch (error: any) {
-    console.error("Debug endpoint error:", error)
+    log.error("Debug endpoint error:", error)
     res.status(500).json({
       error: error.message
     })
@@ -120,7 +122,7 @@ export async function POST(
       error: "Invalid action. Use 'diagnose' or 'fix'."
     })
   } catch (error: any) {
-    console.error("Debug endpoint error:", error)
+    log.error("Debug endpoint error:", error)
     res.status(500).json({
       error: error.message
     })

--- a/backend/src/api/admin/hawala/transfers/route.ts
+++ b/backend/src/api/admin/hawala/transfers/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/hawala/transfers")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -97,7 +99,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     res.status(201).json({ entry })
   } catch (error) {
-    console.error("Error creating transfer:", error)
+    log.error("Error creating transfer:", error)
     res.status(400).json({ error: "Failed to create transfer" })
   }
 }

--- a/backend/src/api/admin/requests/[id]/approve/route.ts
+++ b/backend/src/api/admin/requests/[id]/approve/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/admin/requests/[id]/approve")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { REQUEST_MODULE } from "../../../../../modules/request"
 import RequestModuleService from "../../../../../modules/request/service"
@@ -81,7 +83,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       return
     }
 
-    console.error(`[POST /admin/requests/${id}/approve] Error:`, error.message)
+    log.error(`[POST /admin/requests/${id}/approve] Error:`, error.message)
     res.status(500).json({
       message: error.message || "Failed to approve request",
     })

--- a/backend/src/api/admin/requests/[id]/reject/route.ts
+++ b/backend/src/api/admin/requests/[id]/reject/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/admin/requests/[id]/reject")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { RequestStatus } from "../../../../../modules/request/models"
@@ -59,7 +61,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       return
     }
 
-    console.error(`[POST /admin/requests/${id}/reject] Error:`, error.message)
+    log.error(`[POST /admin/requests/${id}/reject] Error:`, error.message)
     res.status(500).json({
       message: error.message || "Failed to reject request",
     })

--- a/backend/src/api/admin/requests/[id]/route.ts
+++ b/backend/src/api/admin/requests/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/requests/[id]")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { REQUEST_MODULE } from "../../../../modules/request"
@@ -45,7 +47,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
 
     res.json({ request: requests[0] })
   } catch (error: any) {
-    console.error(`[GET /admin/requests/${id}] Error:`, error.message)
+    log.error(`[GET /admin/requests/${id}] Error:`, error.message)
     res.status(500).json({ message: "Failed to retrieve request" })
   }
 }
@@ -140,7 +142,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       return
     }
 
-    console.error(`[POST /admin/requests/${id}] Error:`, error.message)
+    log.error(`[POST /admin/requests/${id}] Error:`, error.message)
     res.status(500).json({
       message: error.message || "Failed to review request",
     })
@@ -188,7 +190,7 @@ export async function PATCH(req: AuthenticatedMedusaRequest, res: MedusaResponse
       res.status(400).json({ message: "Validation failed", errors: error.issues })
       return
     }
-    console.error(`[PATCH /admin/requests/${id}] Error:`, error.message)
+    log.error(`[PATCH /admin/requests/${id}] Error:`, error.message)
     res.status(500).json({ message: "Failed to update request" })
   }
 }
@@ -227,7 +229,7 @@ export async function DELETE(req: AuthenticatedMedusaRequest, res: MedusaRespons
     }
 
     // Audit log the deletion
-    console.log(`[DELETE /admin/requests/${id}] Request deleted by admin ${actorId}. Type: ${request.type}, Status: ${request.status}`)
+    log.info(`[DELETE /admin/requests/${id}] Request deleted by admin ${actorId}. Type: ${request.type}, Status: ${request.status}`)
 
     await requestService.deleteRequests(id)
 
@@ -236,7 +238,7 @@ export async function DELETE(req: AuthenticatedMedusaRequest, res: MedusaRespons
       deleted: { id, type: request.type, status: request.status },
     })
   } catch (error: any) {
-    console.error(`[DELETE /admin/requests/${id}] Error:`, error.message)
+    log.error(`[DELETE /admin/requests/${id}] Error:`, error.message)
     res.status(500).json({ message: "Failed to delete request" })
   }
 }

--- a/backend/src/api/admin/requests/route.ts
+++ b/backend/src/api/admin/requests/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/admin/requests")
 import { z } from "zod"
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { REQUEST_MODULE } from "../../../modules/request"
@@ -68,7 +70,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       res.status(400).json({ message: "Validation failed", errors: error.issues })
       return
     }
-    console.error("[GET /admin/requests] Error:", error.message)
+    log.error("[GET /admin/requests] Error:", error.message)
     res.status(500).json({ message: "Failed to retrieve requests" })
   }
 }
@@ -99,7 +101,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     })
 
     // Get actor info for audit logging
-    console.log(`[POST /admin/requests] Request ${request.id} created by admin ${adminId}. Type: ${body.type}`)
+    log.info(`[POST /admin/requests] Request ${request.id} created by admin ${adminId}. Type: ${body.type}`)
 
     res.status(201).json({
       request,
@@ -110,7 +112,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       res.status(400).json({ message: "Validation failed", errors: error.issues })
       return
     }
-    console.error("[POST /admin/requests] Error:", error.message)
+    log.error("[POST /admin/requests] Error:", error.message)
     res.status(500).json({ message: "Failed to create request" })
   }
 }

--- a/backend/src/api/admin/seller-metadata/[seller_id]/route.ts
+++ b/backend/src/api/admin/seller-metadata/[seller_id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/seller-metadata/[seller_id]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { IEventBusModuleService } from "@medusajs/framework/types"
@@ -118,7 +120,7 @@ export const PUT = async (
         seller_id,
       },
     })
-    console.log(`Emitted vendor.verified event for seller ${seller_id}`)
+    log.info(`Emitted vendor.verified event for seller ${seller_id}`)
   }
 
   return res.json({

--- a/backend/src/api/admin/seller-metadata/route.ts
+++ b/backend/src/api/admin/seller-metadata/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/admin/seller-metadata")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SELLER_EXTENSION_MODULE } from "../../../modules/seller-extension"
@@ -89,7 +91,7 @@ export const POST = async (
       },
     })
   } catch (error) {
-    console.warn("Could not create seller-metadata link:", error)
+    log.warn("Could not create seller-metadata link:", error)
   }
 
   return res.status(201).json({

--- a/backend/src/api/admin/sellers/invite/route.ts
+++ b/backend/src/api/admin/sellers/invite/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/admin/sellers/invite")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { INotificationModuleService } from "@medusajs/framework/types"
@@ -52,7 +54,7 @@ export const POST = async (
       email,
     })
   } catch (error) {
-    console.error("Failed to send seller invitation:", error)
+    log.error("Failed to send seller invitation:", error)
     return res.status(500).json({
       message: error instanceof Error ? error.message : "Failed to send invitation",
     })

--- a/backend/src/api/auth/seller/session/route.ts
+++ b/backend/src/api/auth/seller/session/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/auth/seller/session")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { fetchSellerProfile } from "../../../../shared/seller-profile"
 import { getSellerRegistrationStatus } from "../../../../shared/seller-registration"
@@ -51,7 +53,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     })
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Unknown error"
-    console.error("[GET /auth/seller/session] Error:", message)
+    log.error("[GET /auth/seller/session] Error:", message)
     return res.status(500).json({
       registration_status: {
         status: "error",

--- a/backend/src/api/deliveries/[id]/accept/route.ts
+++ b/backend/src/api/deliveries/[id]/accept/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/deliveries/[id]/accept")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { MedusaError } from "@medusajs/framework/utils";
 import { DeliveryStatus } from "../../../../modules/delivery/types";
@@ -25,7 +27,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       },
     })
     .catch((error) => {
-      console.error("[delivery/accept] Failed to update delivery:", error);
+      log.error("[delivery/accept] Failed to update delivery:", error);
       return MedusaError.Types.UNEXPECTED_STATE;
     });
 

--- a/backend/src/api/deliveries/[id]/ready/route.ts
+++ b/backend/src/api/deliveries/[id]/ready/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/deliveries/[id]/ready")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { MedusaError } from "@medusajs/framework/utils";
 import { DeliveryStatus } from "../../../../modules/delivery/types";
@@ -20,7 +22,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       },
     })
     .catch((error) => {
-      console.log(error)
+      log.info(error)
       return MedusaError.Types.UNEXPECTED_STATE;
     });
 

--- a/backend/src/api/health/ready/route.ts
+++ b/backend/src/api/health/ready/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/health/ready")
 /**
  * Readiness Check Endpoint
  *
@@ -61,7 +63,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       checks.database = result !== null
       lastDbCheck = { healthy: checks.database, timestamp: now }
     } catch (error) {
-      console.error("[Health] Database check failed:", error)
+      log.error("[Health] Database check failed:", error)
       checks.database = false
       lastDbCheck = { healthy: false, timestamp: now }
     }
@@ -74,7 +76,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       const redisCheckPromise = cache.isAvailable()
       checks.redis = await withTimeout(redisCheckPromise, 2000, false)
     } catch (error) {
-      console.error("[Health] Redis check failed:", error)
+      log.error("[Health] Redis check failed:", error)
       checks.redis = false
     }
   }

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("api/middlewares")
 import {
   defineMiddlewares,
   authenticate,
@@ -359,7 +361,7 @@ function vendorCorsMiddleware(
       // Invalid URL, continue to rejection
     }
 
-    console.warn(`[VENDOR CORS] Origin not allowed: ${reqOrigin}`);
+    log.warn(`[VENDOR CORS] Origin not allowed: ${reqOrigin}`);
     callback(null, false);
   };
 

--- a/backend/src/api/middlewares/password-history.ts
+++ b/backend/src/api/middlewares/password-history.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("api/middlewares/password-history")
 import type {
   MedusaRequest,
   MedusaResponse,
@@ -18,7 +20,7 @@ async function verifyPassword(password: string, hashBase64: string): Promise<boo
     const hashBuffer = Buffer.from(hashBase64, "base64")
     return await Scrypt.verify(hashBuffer, password)
   } catch (error) {
-    console.error("[password-history] Error verifying password:", error)
+    log.error("[password-history] Error verifying password:", error)
     return false
   }
 }
@@ -55,7 +57,7 @@ function decodeResetToken(token: string): { entityId: string; provider: string }
 
     return { entityId, provider }
   } catch (error) {
-    console.error("[password-history] Failed to decode reset token:", error)
+    log.error("[password-history] Failed to decode reset token:", error)
     return null
   }
 }
@@ -75,18 +77,18 @@ export async function preventPasswordReuseMiddleware(
   res: MedusaResponse,
   next: MedusaNextFunction
 ) {
-  console.log(`[password-history] Middleware invoked for ${req.method} ${req.path}`)
+  log.info(`[password-history] Middleware invoked for ${req.method} ${req.path}`)
 
   // Skip if password history is disabled
   if (!PASSWORD_HISTORY_CONFIG.enabled) {
-    console.log("[password-history] Password history disabled, skipping")
+    log.info("[password-history] Password history disabled, skipping")
     return next()
   }
 
   // Only process requests with password in the body
   const body = req.body as Record<string, unknown> | undefined
   if (!body?.password || typeof body.password !== "string") {
-    console.log("[password-history] No password in body, skipping")
+    log.info("[password-history] No password in body, skipping")
     return next()
   }
 
@@ -99,14 +101,14 @@ export async function preventPasswordReuseMiddleware(
     : (req.query.token as string)
 
   if (!token) {
-    console.log("[password-history] No token found, skipping")
+    log.info("[password-history] No token found, skipping")
     return next()
   }
 
   // Decode the reset token to get auth identity info
   const tokenInfo = decodeResetToken(token)
   if (!tokenInfo) {
-    console.warn("[password-history] Could not decode reset token - skipping history check")
+    log.warn("[password-history] Could not decode reset token - skipping history check")
     return next()
   }
 
@@ -127,7 +129,7 @@ export async function preventPasswordReuseMiddleware(
 
     const providerData = providerResult.rows?.[0]
     if (!providerData?.auth_identity_id) {
-      console.warn(`[password-history] Could not find auth identity for email: ${entityId}`)
+      log.warn(`[password-history] Could not find auth identity for email: ${entityId}`)
       return next()
     }
 
@@ -140,7 +142,7 @@ export async function preventPasswordReuseMiddleware(
         try {
           providerMetadata = JSON.parse(providerData.provider_metadata)
         } catch (e) {
-          console.warn("[password-history] Failed to parse provider_metadata:", e)
+          log.warn("[password-history] Failed to parse provider_metadata:", e)
         }
       } else {
         // Already an object (e.g., if using a different query method)
@@ -150,11 +152,11 @@ export async function preventPasswordReuseMiddleware(
 
     const currentPasswordHash = providerMetadata.password as string | undefined
 
-    console.log(`[password-history] Auth identity: ${authIdentityId}`)
-    console.log(`[password-history] Provider metadata keys: ${Object.keys(providerMetadata).join(", ")}`)
-    console.log(`[password-history] Has current password hash: ${!!currentPasswordHash}`)
+    log.info(`[password-history] Auth identity: ${authIdentityId}`)
+    log.info(`[password-history] Provider metadata keys: ${Object.keys(providerMetadata).join(", ")}`)
+    log.info(`[password-history] Has current password hash: ${!!currentPasswordHash}`)
     if (currentPasswordHash) {
-      console.log(`[password-history] Password hash prefix: ${currentPasswordHash.substring(0, 10)}...`)
+      log.info(`[password-history] Password hash prefix: ${currentPasswordHash.substring(0, 10)}...`)
     }
 
     // Get password history for this auth identity
@@ -163,24 +165,24 @@ export async function preventPasswordReuseMiddleware(
       passwordHistoryService = req.scope.resolve(PASSWORD_HISTORY_MODULE)
     } catch (e) {
       // Module not registered yet - skip history check but continue
-      console.warn("[password-history] Password history module not available - skipping history check")
+      log.warn("[password-history] Password history module not available - skipping history check")
     }
 
     // Always check against current password (shouldn't set same password)
     // This check runs regardless of whether the password history module is available
     if (currentPasswordHash) {
-      console.log(`[password-history] Comparing new password against current hash using scrypt...`)
+      log.info(`[password-history] Comparing new password against current hash using scrypt...`)
       const matchesCurrent = await verifyPassword(newPassword, currentPasswordHash)
-      console.log(`[password-history] Password match result: ${matchesCurrent}`)
+      log.info(`[password-history] Password match result: ${matchesCurrent}`)
       if (matchesCurrent) {
-        console.log(`[password-history] User tried to reuse current password for auth_identity: ${authIdentityId}`)
+        log.info(`[password-history] User tried to reuse current password for auth_identity: ${authIdentityId}`)
         return res.status(400).json({
           message: "New password must be different from your current password.",
           type: "password_same_as_current",
         })
       }
     } else {
-      console.log(`[password-history] No current password hash found, skipping current password check`)
+      log.info(`[password-history] No current password hash found, skipping current password check`)
     }
 
     if (passwordHistoryService) {
@@ -197,7 +199,7 @@ export async function preventPasswordReuseMiddleware(
       for (const entry of historyEntries) {
         const isMatch = await verifyPassword(newPassword, entry.password_hash)
         if (isMatch) {
-          console.log(`[password-history] Password reuse detected for auth_identity: ${authIdentityId}`)
+          log.info(`[password-history] Password reuse detected for auth_identity: ${authIdentityId}`)
           return res.status(400).json({
             message: "This password has been used before. Please choose a different password.",
             type: "password_reuse",
@@ -222,10 +224,10 @@ export async function preventPasswordReuseMiddleware(
             },
           ])
           .then(() => {
-            console.log(`[password-history] Stored old password hash for auth_identity: ${authIdentityId}`)
+            log.info(`[password-history] Stored old password hash for auth_identity: ${authIdentityId}`)
           })
           .catch((err) => {
-            console.error("[password-history] Failed to store password history:", err)
+            log.error("[password-history] Failed to store password history:", err)
           })
       }
       return originalSend(data)
@@ -233,7 +235,7 @@ export async function preventPasswordReuseMiddleware(
 
     next()
   } catch (error) {
-    console.error("[password-history] Error checking password history:", error)
+    log.error("[password-history] Error checking password history:", error)
     // Don't block password reset on error - log and continue
     next()
   }

--- a/backend/src/api/middlewares/seller-context-v1.ts
+++ b/backend/src/api/middlewares/seller-context-v1.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("api/middlewares/seller-context-v1")
 import type {
   MedusaRequest,
   MedusaResponse,
@@ -64,7 +66,7 @@ export async function requireSellerContextV1(
       )
       sellerId = result.rows?.[0]?.seller_id ?? null
     } catch (err) {
-      console.error("[v1 seller context] member lookup failed", err)
+      log.error("[v1 seller context] member lookup failed", err)
     }
   } else if (authContext.auth_identity_id) {
     try {
@@ -89,7 +91,7 @@ export async function requireSellerContextV1(
         sellerId = result.rows?.[0]?.seller_id ?? null
       }
     } catch (err) {
-      console.error("[v1 seller context] auth identity lookup failed", err)
+      log.error("[v1 seller context] auth identity lookup failed", err)
     }
   }
 

--- a/backend/src/api/product-feed/route.ts
+++ b/backend/src/api/product-feed/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("api/product-feed")
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import generateProductFeedWorkflow from "../../workflows/product-feed"
 
@@ -23,7 +25,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     res.setHeader("Cache-Control", "public, max-age=3600") // Cache for 1 hour
     res.status(200).send(result.xml)
   } catch (error) {
-    console.error("Error generating product feed:", error)
+    log.error("Error generating product feed:", error)
     res.status(500).json({
       message: "Failed to generate product feed",
       error: error instanceof Error ? error.message : "Unknown error"

--- a/backend/src/api/r/[shortCode]/route.ts
+++ b/backend/src/api/r/[shortCode]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/r/[shortCode]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { createHash, randomUUID } from "crypto"
 import { CREATOR_ATTRIBUTION_MODULE } from "../../../modules/creator-attribution"
@@ -145,7 +147,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       country,
     })
     .catch((err) => {
-      console.error("[creator-attribution] recordClick failed", err)
+      log.error("[creator-attribution] recordClick failed", err)
     })
 
   // Compose the redirect URL.

--- a/backend/src/api/shared/seller-registration.ts
+++ b/backend/src/api/shared/seller-registration.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("api/shared/seller-registration")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { REQUEST_MODULE } from "../../modules/request"
@@ -18,7 +20,7 @@ export const handleSellerRegistration = async (
   try {
     body = createSellerRegistrationSchema.parse(req.body)
   } catch (validationError: any) {
-    console.error("[Seller registration] Validation error")
+    log.error("[Seller registration] Validation error")
     return res.status(400).json({
       type: "invalid_data",
       message: validationError.errors?.[0]?.message || "Invalid request data",
@@ -26,7 +28,7 @@ export const handleSellerRegistration = async (
     })
   }
 
-  console.log(
+  log.info(
     `[Seller registration] Creating request: "${body.name}" (email: ${maskEmail(
       body.member.email
     )})`
@@ -41,7 +43,7 @@ export const handleSellerRegistration = async (
     })
 
     if (!authIdentity) {
-      console.error(
+      log.error(
         `[Seller registration] Auth identity not found for email: ${maskEmail(
           body.member.email
         )}`
@@ -52,7 +54,7 @@ export const handleSellerRegistration = async (
       })
     }
 
-    console.log(`[Seller registration] Found auth identity: ${authIdentity.id}`)
+    log.info(`[Seller registration] Found auth identity: ${authIdentity.id}`)
 
     const requestService = req.scope.resolve<RequestModuleService>(REQUEST_MODULE)
     const existingRequests = await requestService.listRequests({
@@ -64,7 +66,7 @@ export const handleSellerRegistration = async (
     const userExistingRequest = existingRequests[0]
 
     if (userExistingRequest) {
-      console.log(
+      log.info(
         `[Seller registration] Found existing pending request: ${userExistingRequest.id}`
       )
       return res.status(200).json({
@@ -94,7 +96,7 @@ export const handleSellerRegistration = async (
       reviewer_note: `Seller registration request for "${body.name}"`,
     })
 
-    console.log(`[Seller registration] Created request: ${sellerRequest.id}`)
+    log.info(`[Seller registration] Created request: ${sellerRequest.id}`)
 
     return res.status(201).json({
       request: {
@@ -105,7 +107,7 @@ export const handleSellerRegistration = async (
       },
     })
   } catch (error: any) {
-    console.error("[Seller registration] Failed to create request:", error.message)
+    log.error("[Seller registration] Failed to create request:", error.message)
 
     return res.status(400).json({
       type: "invalid_data",

--- a/backend/src/api/store/analytics/events/route.ts
+++ b/backend/src/api/store/analytics/events/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/analytics/events")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { CREATOR_ATTRIBUTION_MODULE } from "../../../../modules/creator-attribution"
 import type CreatorAttributionService from "../../../../modules/creator-attribution/service"
@@ -125,7 +127,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     })
   } catch (err) {
     // Never block the storefront on analytics failure — log and 202.
-    console.error("[store/analytics/events] failed:", err)
+    log.error("[store/analytics/events] failed:", err)
     return res.status(202).json({ recorded: false })
   }
 

--- a/backend/src/api/store/character/recompute/route.ts
+++ b/backend/src/api/store/character/recompute/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/character/recompute")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PROGRESSION_MODULE } from "../../../../modules/progression"
@@ -28,7 +30,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     const character = await progression.getCharacterSheetSummary(customerId)
     res.json({ character })
   } catch (error) {
-    console.error("Error recomputing character sheet:", error)
+    log.error("Error recomputing character sheet:", error)
     res.status(500).json({ error: "Failed to recompute character sheet" })
   }
 }

--- a/backend/src/api/store/character/route.ts
+++ b/backend/src/api/store/character/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/store/character")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { PROGRESSION_MODULE } from "../../../modules/progression"
 import type ProgressionModuleService from "../../../modules/progression/service"
@@ -22,7 +24,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const character = await progression.getCharacterSheetSummary(customerId)
     res.json({ character })
   } catch (error) {
-    console.error("Error retrieving character sheet:", error)
+    log.error("Error retrieving character sheet:", error)
     res.status(500).json({ error: "Failed to retrieve character sheet" })
   }
 }

--- a/backend/src/api/store/character/stance/route.ts
+++ b/backend/src/api/store/character/stance/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/character/stance")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { PROGRESSION_MODULE } from "../../../../modules/progression"
 import { isStance } from "../../../../modules/progression/stance"
@@ -30,7 +32,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     const character = await progression.getCharacterSheetSummary(customerId)
     res.json({ character })
   } catch (error) {
-    console.error("Error setting stance:", error)
+    log.error("Error setting stance:", error)
     res.status(500).json({ error: "Failed to set stance" })
   }
 }

--- a/backend/src/api/store/chat/route.ts
+++ b/backend/src/api/store/chat/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/store/chat")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { getMatrixService } from "../../../shared/matrix-service"
@@ -58,7 +60,7 @@ export async function GET(
       mxid = ensured.mxid
       login = await matrixService.mintLoginToken(mxid)
     } catch (error: any) {
-      console.error("[GET /store/chat] Provisioning failed:", error.message)
+      log.error("[GET /store/chat] Provisioning failed:", error.message)
       // Graceful degradation: omit login so the client can still render Element.
     }
 
@@ -78,7 +80,7 @@ export async function GET(
 
     res.json(response)
   } catch (error: any) {
-    console.error("[GET /store/chat] Error:", error)
+    log.error("[GET /store/chat] Error:", error)
     res.status(500).json({
       message: error.message || "Failed to retrieve chat configuration",
     })

--- a/backend/src/api/store/chat/unread/route.ts
+++ b/backend/src/api/store/chat/unread/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/chat/unread")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { getMatrixService } from "../../../../shared/matrix-service"
@@ -37,7 +39,7 @@ export async function GET(
     const unreadCount = await matrixService.getUnreadCount(mxid)
     res.json({ unread_count: unreadCount })
   } catch (error: any) {
-    console.warn(
+    log.warn(
       "[GET /store/chat/unread] Matrix unavailable, returning degraded count:",
       error?.message
     )

--- a/backend/src/api/store/collective/bargaining-groups/[id]/join/route.ts
+++ b/backend/src/api/store/collective/bargaining-groups/[id]/join/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/bargaining-groups/[id]/join")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../../../modules/bargaining"
@@ -37,7 +39,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST /store/collective/bargaining-groups/${id}/join] Error:`, error.message)
+    log.error(`[POST /store/collective/bargaining-groups/${id}/join] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }
@@ -59,7 +61,7 @@ export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
     await bargainingService.leaveGroup(id, customerId)
     res.json({ message: "Successfully left bargaining group" })
   } catch (error: any) {
-    console.error(`[DELETE /store/collective/bargaining-groups/${id}/join] Error:`, error.message)
+    log.error(`[DELETE /store/collective/bargaining-groups/${id}/join] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/bargaining-groups/[id]/proposals/[proposalId]/vote/route.ts
+++ b/backend/src/api/store/collective/bargaining-groups/[id]/proposals/[proposalId]/vote/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../shared/logger"
+const log = createLogger("api/store/collective/bargaining-groups/[id]/proposals/[proposalId]/vote")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../../../../../modules/bargaining"
@@ -36,7 +38,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST vote] Error:`, error.message)
+    log.error(`[POST vote] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/bargaining-groups/[id]/proposals/route.ts
+++ b/backend/src/api/store/collective/bargaining-groups/[id]/proposals/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/bargaining-groups/[id]/proposals")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../../../modules/bargaining"
@@ -23,7 +25,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     res.json({ proposals })
   } catch (error: any) {
-    console.error(`[GET proposals] Error:`, error.message)
+    log.error(`[GET proposals] Error:`, error.message)
     res.status(500).json({ error: "Failed to retrieve proposals" })
   }
 }
@@ -54,7 +56,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST counter-offer] Error:`, error.message)
+    log.error(`[POST counter-offer] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/bargaining-groups/[id]/route.ts
+++ b/backend/src/api/store/collective/bargaining-groups/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/store/collective/bargaining-groups/[id]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../../modules/bargaining"
 import BargainingModuleService from "../../../../../modules/bargaining/service"
@@ -14,7 +16,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const details = await bargainingService.getGroupDetails(id)
     res.json({ bargaining_group: details })
   } catch (error: any) {
-    console.error(`[GET /store/collective/bargaining-groups/${id}] Error:`, error.message)
+    log.error(`[GET /store/collective/bargaining-groups/${id}] Error:`, error.message)
     res.status(error.message.includes("not found") ? 404 : 500).json({
       error: error.message,
     })
@@ -62,7 +64,7 @@ export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
 
     res.status(400).json({ error: "Invalid action" })
   } catch (error: any) {
-    console.error(`[PATCH /store/collective/bargaining-groups/${id}] Error:`, error.message)
+    log.error(`[PATCH /store/collective/bargaining-groups/${id}] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/bargaining-groups/[id]/threads/route.ts
+++ b/backend/src/api/store/collective/bargaining-groups/[id]/threads/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/bargaining-groups/[id]/threads")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../../../modules/bargaining"
@@ -24,7 +26,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const threads = await bargainingService.getThreads(id, proposalId)
     res.json({ threads })
   } catch (error: any) {
-    console.error(`[GET threads] Error:`, error.message)
+    log.error(`[GET threads] Error:`, error.message)
     res.status(500).json({ error: "Failed to retrieve threads" })
   }
 }
@@ -60,7 +62,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST thread] Error:`, error.message)
+    log.error(`[POST thread] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/bargaining-groups/route.ts
+++ b/backend/src/api/store/collective/bargaining-groups/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/collective/bargaining-groups")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BARGAINING_MODULE } from "../../../../modules/bargaining"
@@ -69,7 +71,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[GET /store/collective/bargaining-groups] Error:", error.message)
+    log.error("[GET /store/collective/bargaining-groups] Error:", error.message)
     res.status(500).json({ error: "Failed to retrieve bargaining groups" })
   }
 }
@@ -101,7 +103,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[POST /store/collective/bargaining-groups] Error:", error.message)
+    log.error("[POST /store/collective/bargaining-groups] Error:", error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/buyer-networks/[id]/join/route.ts
+++ b/backend/src/api/store/collective/buyer-networks/[id]/join/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/buyer-networks/[id]/join")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BUYER_NETWORK_MODULE } from "../../../../../../modules/buyer-network"
@@ -39,7 +41,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST join network] Error:`, error.message)
+    log.error(`[POST join network] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }
@@ -61,7 +63,7 @@ export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
     await networkService.leaveNetwork(id, customerId)
     res.json({ message: "Successfully left network" })
   } catch (error: any) {
-    console.error(`[DELETE leave network] Error:`, error.message)
+    log.error(`[DELETE leave network] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/buyer-networks/[id]/leaderboard/route.ts
+++ b/backend/src/api/store/collective/buyer-networks/[id]/leaderboard/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/buyer-networks/[id]/leaderboard")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BUYER_NETWORK_MODULE } from "../../../../../../modules/buyer-network"
 import BuyerNetworkModuleService from "../../../../../../modules/buyer-network/service"
@@ -15,7 +17,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const leaderboard = await networkService.getNetworkLeaderboard(id, limit)
     res.json({ leaderboard })
   } catch (error: any) {
-    console.error(`[GET leaderboard] Error:`, error.message)
+    log.error(`[GET leaderboard] Error:`, error.message)
     res.status(500).json({ error: "Failed to retrieve leaderboard" })
   }
 }

--- a/backend/src/api/store/collective/buyer-networks/[id]/route.ts
+++ b/backend/src/api/store/collective/buyer-networks/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/store/collective/buyer-networks/[id]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BUYER_NETWORK_MODULE } from "../../../../../modules/buyer-network"
 import BuyerNetworkModuleService from "../../../../../modules/buyer-network/service"
@@ -14,7 +16,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const details = await networkService.getNetworkDetails(id)
     res.json({ buyer_network: details })
   } catch (error: any) {
-    console.error(`[GET buyer-networks/${id}] Error:`, error.message)
+    log.error(`[GET buyer-networks/${id}] Error:`, error.message)
     res.status(error.message.includes("not found") ? 404 : 500).json({
       error: error.message,
     })

--- a/backend/src/api/store/collective/buyer-networks/route.ts
+++ b/backend/src/api/store/collective/buyer-networks/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/collective/buyer-networks")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { BUYER_NETWORK_MODULE } from "../../../../modules/buyer-network"
@@ -65,7 +67,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[GET buyer-networks] Error:", error.message)
+    log.error("[GET buyer-networks] Error:", error.message)
     res.status(500).json({ error: "Failed to retrieve networks" })
   }
 }
@@ -93,7 +95,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error("[POST buyer-networks] Error:", error.message)
+    log.error("[POST buyer-networks] Error:", error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/[id]/bounties/[bountyId]/claim/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/bounties/[bountyId]/claim/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/bounties/[bountyId]/claim")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../../../modules/demand-pool"
 import DemandPoolModuleService from "../../../../../../../../modules/demand-pool/service"
@@ -24,7 +26,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     res.status(200).json({ bounty })
   } catch (error: any) {
-    console.error(
+    log.error(
       `[POST /store/collective/demand-pools/${id}/bounties/${bountyId}/claim] Error:`,
       error.message
     )

--- a/backend/src/api/store/collective/demand-pools/[id]/bounties/[bountyId]/milestones/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/bounties/[bountyId]/milestones/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/bounties/[bountyId]/milestones")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../../../modules/demand-pool"
@@ -53,7 +55,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(
+    log.error(
       `[POST /store/collective/demand-pools/${id}/bounties/${bountyId}/milestones] Error:`,
       error.message
     )

--- a/backend/src/api/store/collective/demand-pools/[id]/bounties/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/bounties/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/bounties")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../modules/demand-pool"
@@ -64,7 +66,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     res.json({ bounties: visibleBounties })
   } catch (error: any) {
-    console.error(`[GET /store/collective/demand-pools/${id}/bounties] Error:`, error.message)
+    log.error(`[GET /store/collective/demand-pools/${id}/bounties] Error:`, error.message)
     res.status(500).json({ error: "Failed to retrieve bounties" })
   }
 }
@@ -121,7 +123,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST /store/collective/demand-pools/${id}/bounties] Error:`, error.message)
+    log.error(`[POST /store/collective/demand-pools/${id}/bounties] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/[id]/escrow/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/escrow/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/escrow")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../modules/demand-pool"
@@ -54,7 +56,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST escrow] Error:`, error.message)
+    log.error(`[POST escrow] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }
@@ -93,7 +95,7 @@ export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
       ledger_entry_id: entry.id,
     })
   } catch (error: any) {
-    console.error(`[DELETE escrow] Error:`, error.message)
+    log.error(`[DELETE escrow] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/[id]/join/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/join/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/join")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../modules/demand-pool"
@@ -35,7 +37,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST /store/collective/demand-pools/${id}/join] Error:`, error.message)
+    log.error(`[POST /store/collective/demand-pools/${id}/join] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }
@@ -57,7 +59,7 @@ export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
     await demandPoolService.withdrawFromPool(id, customerId)
     res.json({ message: "Successfully withdrawn from demand pool" })
   } catch (error: any) {
-    console.error(`[DELETE /store/collective/demand-pools/${id}/join] Error:`, error.message)
+    log.error(`[DELETE /store/collective/demand-pools/${id}/join] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/[id]/proposals/[proposalId]/vote/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/proposals/[proposalId]/vote/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/proposals/[proposalId]/vote")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../../../modules/demand-pool"
@@ -36,7 +38,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     if (error instanceof z.ZodError) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
-    console.error(`[POST vote] Error:`, error.message)
+    log.error(`[POST vote] Error:`, error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/[id]/proposals/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/proposals/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]/proposals")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../modules/demand-pool"
 import DemandPoolModuleService from "../../../../../../modules/demand-pool/service"
@@ -17,7 +19,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     res.json({ proposals })
   } catch (error: any) {
-    console.error(`[GET /store/collective/demand-pools/${id}/proposals] Error:`, error.message)
+    log.error(`[GET /store/collective/demand-pools/${id}/proposals] Error:`, error.message)
     res.status(500).json({ error: "Failed to retrieve proposals" })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/[id]/route.ts
+++ b/backend/src/api/store/collective/demand-pools/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools/[id]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../modules/demand-pool"
 import DemandPoolModuleService from "../../../../../modules/demand-pool/service"
@@ -27,7 +29,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     res.json({ demand_pool: details })
   } catch (error: unknown) {
     const message = getErrorMessage(error)
-    console.error(`[GET /store/collective/demand-pools/${id}] Error:`, message)
+    log.error(`[GET /store/collective/demand-pools/${id}] Error:`, message)
     res.status(message.toLowerCase().includes("not found") ? 404 : 500).json({
       error: message,
     })
@@ -81,7 +83,7 @@ export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
     res.json({ demand_post: updated })
   } catch (error: unknown) {
     const message = getErrorMessage(error)
-    console.error(`[PATCH /store/collective/demand-pools/${id}] Error:`, message)
+    log.error(`[PATCH /store/collective/demand-pools/${id}] Error:`, message)
     res.status(400).json({ error: message })
   }
 }

--- a/backend/src/api/store/collective/demand-pools/route.ts
+++ b/backend/src/api/store/collective/demand-pools/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/collective/demand-pools")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../modules/demand-pool"
@@ -69,7 +71,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
     const message = getErrorMessage(error)
-    console.error("[GET /store/collective/demand-pools] Error:", message)
+    log.error("[GET /store/collective/demand-pools] Error:", message)
     res.status(500).json({ error: "Failed to retrieve demand pools", details: message })
   }
 }
@@ -121,7 +123,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
     const message = getErrorMessage(error)
-    console.error("[POST /store/collective/demand-pools] Error:", message)
+    log.error("[POST /store/collective/demand-pools] Error:", message)
     res.status(400).json({ error: message })
   }
 }

--- a/backend/src/api/store/cooperatives/[handle]/join/route.ts
+++ b/backend/src/api/store/cooperatives/[handle]/join/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/store/cooperatives/[handle]/join")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { COOPERATIVE_MODULE } from "../../../../../modules/cooperative"
 import type CooperativeService from "../../../../../modules/cooperative/service"
@@ -35,7 +37,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     return res.status(201).json({ member })
   } catch (error: any) {
-    console.error(`[POST /store/cooperatives/${handle}/join] Error:`, error.message)
+    log.error(`[POST /store/cooperatives/${handle}/join] Error:`, error.message)
     return res.status(400).json({ error: error.message })
   }
 }
@@ -69,7 +71,7 @@ export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
 
     return res.status(200).json(result)
   } catch (error: any) {
-    console.error(`[DELETE /store/cooperatives/${handle}/join] Error:`, error.message)
+    log.error(`[DELETE /store/cooperatives/${handle}/join] Error:`, error.message)
     return res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/store/food-deliveries/[id]/subscribe/route.ts
+++ b/backend/src/api/store/food-deliveries/[id]/subscribe/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/store/food-deliveries/[id]/subscribe")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { FOOD_DISTRIBUTION_MODULE } from "../../../../../modules/food-distribution"
 import type FoodDistributionService from "../../../../../modules/food-distribution/service"
@@ -111,7 +113,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       // Send heartbeat to keep connection alive
       res.write(`: heartbeat\n\n`)
     } catch (error) {
-      console.error("SSE polling error:", error)
+      log.error("SSE polling error:", error)
     }
   }, 3000) // Poll every 3 seconds
 

--- a/backend/src/api/store/hawala/bank-accounts/route.ts
+++ b/backend/src/api/store/hawala/bank-accounts/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/hawala/bank-accounts")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -22,7 +24,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
 
     res.json({ bank_accounts: bankAccounts })
   } catch (error) {
-    console.error("Error listing bank accounts:", error)
+    log.error("Error listing bank accounts:", error)
     res.status(500).json({ error: "Failed to retrieve bank accounts" })
   }
 }
@@ -81,7 +83,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       })
     }
   } catch (error) {
-    console.error("Error linking bank account:", error)
+    log.error("Error linking bank account:", error)
     res.status(500).json({ error: "Failed to initiate bank account linking" })
   }
 }

--- a/backend/src/api/store/hawala/deposit/route.ts
+++ b/backend/src/api/store/hawala/deposit/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/hawala/deposit")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -108,7 +110,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
         : "Deposit completed successfully.",
     })
   } catch (error) {
-    console.error("Error processing deposit:", error)
+    log.error("Error processing deposit:", error)
     res.status(500).json({ error: "Failed to process deposit" })
   }
 }

--- a/backend/src/api/store/hawala/pools/route.ts
+++ b/backend/src/api/store/hawala/pools/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/hawala/pools")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -55,7 +57,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       offset: parseInt(offset as string),
     })
   } catch (error) {
-    console.error("Error listing pools:", error)
+    log.error("Error listing pools:", error)
     res.status(500).json({ error: "Failed to retrieve investment pools" })
   }
 }

--- a/backend/src/api/store/hawala/transactions/route.ts
+++ b/backend/src/api/store/hawala/transactions/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/hawala/transactions")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -41,7 +43,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       offset: parseInt(offset as string),
     })
   } catch (error) {
-    console.error("Error getting transactions:", error)
+    log.error("Error getting transactions:", error)
     res.status(500).json({ error: "Failed to retrieve transactions" })
   }
 }

--- a/backend/src/api/store/hawala/wallet/route.ts
+++ b/backend/src/api/store/hawala/wallet/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/hawala/wallet")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -38,7 +40,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     res.json({ wallet, balance })
   } catch (error) {
-    console.error("Error getting wallet:", error)
+    log.error("Error getting wallet:", error)
     res.status(500).json({ error: "Failed to retrieve wallet" })
   }
 }
@@ -79,7 +81,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     res.status(201).json({ wallet, balance, created: true })
   } catch (error) {
-    console.error("Error creating wallet:", error)
+    log.error("Error creating wallet:", error)
     res.status(500).json({ error: "Failed to create wallet" })
   }
 }

--- a/backend/src/api/store/hawala/withdraw/route.ts
+++ b/backend/src/api/store/hawala/withdraw/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/hawala/withdraw")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -96,7 +98,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       message: "Withdrawal initiated. Funds will arrive in 2-3 business days.",
     })
   } catch (error) {
-    console.error("Error processing withdrawal:", error)
+    log.error("Error processing withdrawal:", error)
     res.status(500).json({ error: "Failed to process withdrawal" })
   }
 }

--- a/backend/src/api/store/printful/webhooks/route.ts
+++ b/backend/src/api/store/printful/webhooks/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/printful/webhooks")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { createHmac, timingSafeEqual } from "crypto"
 
@@ -20,25 +22,25 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     switch (eventType) {
       case "package_shipped":
-        console.info("Printful package_shipped webhook received", payload.data)
+        log.info("Printful package_shipped webhook received", payload.data)
         break
       case "order_failed":
-        console.warn("Printful order_failed webhook received", payload.data)
+        log.warn("Printful order_failed webhook received", payload.data)
         break
       case "order_canceled":
-        console.info("Printful order_canceled webhook received", payload.data)
+        log.info("Printful order_canceled webhook received", payload.data)
         break
       case "product_synced":
-        console.info("Printful product_synced webhook received", payload.data)
+        log.info("Printful product_synced webhook received", payload.data)
         break
       default:
-        console.info(`Unhandled Printful webhook event: ${eventType}`)
+        log.info(`Unhandled Printful webhook event: ${eventType}`)
         break
     }
 
     return res.status(200).json({ received: true })
   } catch (error) {
-    console.error("Failed to process Printful webhook", error)
+    log.error("Failed to process Printful webhook", error)
     return res.status(500).json({ error: "Failed to process webhook" })
   }
 }

--- a/backend/src/api/store/vendors/route.ts
+++ b/backend/src/api/store/vendors/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/store/vendors")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 
 /**
@@ -463,7 +465,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
           })
         }
       } catch (err) {
-        console.warn("Could not fetch producers:", err)
+        log.warn("Could not fetch producers:", err)
       }
     }
 
@@ -522,7 +524,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
           })
         }
       } catch (err) {
-        console.warn("Could not fetch kitchens:", err)
+        log.warn("Could not fetch kitchens:", err)
       }
     }
 
@@ -577,7 +579,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
           })
         }
       } catch (err) {
-        console.warn("Could not fetch gardens:", err)
+        log.warn("Could not fetch gardens:", err)
       }
     }
 
@@ -664,7 +666,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
           }
         }
       } catch (err) {
-        console.warn("Could not fetch seller metadata:", err)
+        log.warn("Could not fetch seller metadata:", err)
       }
     }
 

--- a/backend/src/api/users/route.ts
+++ b/backend/src/api/users/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("api/users")
 import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
@@ -43,7 +45,7 @@ export const POST = async (
       user: result.user,
     })
   } catch (error) {
-    console.error("[POST /users] Registration failed:", error)
+    log.error("[POST /users] Registration failed:", error)
 
     if (error instanceof MedusaError) {
       return res.status(400).json({

--- a/backend/src/api/v1/admin/marketplace/attributions/[id]/disqualify/route.ts
+++ b/backend/src/api/v1/admin/marketplace/attributions/[id]/disqualify/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/admin/marketplace/attributions/[id]/disqualify")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import { CREATOR_ATTRIBUTION_MODULE } from "../../../../../../../modules/creator-attribution"
@@ -69,7 +71,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       }
     )
   } catch (err) {
-    console.error("[admin/disqualify] webhook dispatch failed", err)
+    log.error("[admin/disqualify] webhook dispatch failed", err)
   }
 
   return res.status(200).json({ attribution: updated })

--- a/backend/src/api/v1/admin/marketplace/proofs/[id]/reject/route.ts
+++ b/backend/src/api/v1/admin/marketplace/proofs/[id]/reject/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/admin/marketplace/proofs/[id]/reject")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import { WORK_VERIFICATION_MODULE } from "../../../../../../../modules/work-verification"
@@ -42,7 +44,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       reason: parsed.data.reason,
     })
   } catch (err) {
-    console.error("[admin/proof/reject] webhook failed", err)
+    log.error("[admin/proof/reject] webhook failed", err)
   }
   return res.status(200).json({ proof: updated })
 }

--- a/backend/src/api/v1/admin/marketplace/proofs/[id]/verify/route.ts
+++ b/backend/src/api/v1/admin/marketplace/proofs/[id]/verify/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/admin/marketplace/proofs/[id]/verify")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { WORK_VERIFICATION_MODULE } from "../../../../../../../modules/work-verification"
 import type WorkVerificationService from "../../../../../../../modules/work-verification/service"
@@ -31,7 +33,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       context_id: proof.context_id,
     })
   } catch (err) {
-    console.error("[admin/proof/verify] webhook failed", err)
+    log.error("[admin/proof/verify] webhook failed", err)
   }
   return res.status(200).json({ proof: updated })
 }

--- a/backend/src/api/v1/admin/marketplace/reward-pools/[id]/distribute/route.ts
+++ b/backend/src/api/v1/admin/marketplace/reward-pools/[id]/distribute/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/admin/marketplace/reward-pools/[id]/distribute")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { CREATOR_REWARDS_MODULE } from "../../../../../../../modules/creator-rewards"
 import type CreatorRewardsService from "../../../../../../../modules/creator-rewards/service"
@@ -63,7 +65,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       await rewards.markPayoutPaid(payout.id, entry.id)
       succeeded.push(payout.id)
     } catch (err) {
-      console.error(
+      log.error(
         `[admin/distribute] payout ${payout.id} failed`,
         err
       )
@@ -92,7 +94,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       }
     }
   } catch (err) {
-    console.error("[admin/distribute] webhook dispatch failed", err)
+    log.error("[admin/distribute] webhook dispatch failed", err)
   }
 
   return res.status(200).json({

--- a/backend/src/api/v1/admin/marketplace/subcontracts/[id]/resolve/route.ts
+++ b/backend/src/api/v1/admin/marketplace/subcontracts/[id]/resolve/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/admin/marketplace/subcontracts/[id]/resolve")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
@@ -121,7 +123,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     await webhooks.dispatch("subcontract.completed", sub.parent_seller_id, payload)
     await webhooks.dispatch("subcontract.completed", sub.subcontract_seller_id, payload)
   } catch (err) {
-    console.error("[admin/resolve] webhook dispatch failed", err)
+    log.error("[admin/resolve] webhook dispatch failed", err)
   }
 
   // §3 bridge: dispute resolution + ledger escrow disposition.

--- a/backend/src/api/v1/seller/creator/posts/route.ts
+++ b/backend/src/api/v1/seller/creator/posts/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/v1/seller/creator/posts")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
@@ -88,7 +90,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       }
     }
   } catch (err) {
-    console.error("[posts/register] verifyPostOwnership failed", err)
+    log.error("[posts/register] verifyPostOwnership failed", err)
   }
 
   // Best-effort webhook
@@ -109,7 +111,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       })
     }
   } catch (err) {
-    console.error("[posts/register] webhook dispatch failed", err)
+    log.error("[posts/register] webhook dispatch failed", err)
   }
 
   return res.status(201).json({ post })

--- a/backend/src/api/v1/seller/creator/programs/[id]/apply/route.ts
+++ b/backend/src/api/v1/seller/creator/programs/[id]/apply/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/creator/programs/[id]/apply")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
@@ -62,7 +64,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
             creator_seller_id: sellerId,
           })
         } catch (err) {
-          console.error("[apply] webhook dispatch failed", err)
+          log.error("[apply] webhook dispatch failed", err)
         }
       }
     }

--- a/backend/src/api/v1/seller/programs/[id]/applications/[appId]/decide/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/applications/[appId]/decide/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/programs/[id]/applications/[appId]/decide")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../../../middlewares/seller-context-v1"
@@ -95,7 +97,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         })
       }
     } catch (err) {
-      console.error("[program/decide] KYC check failed", err)
+      log.error("[program/decide] KYC check failed", err)
       return res.status(500).json({
         message: "KYC verification check failed",
         type: "kyc_check_failed",
@@ -135,7 +137,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       })) as any
       deal = await programService.attachDefaultLinkToDeal(deal.id, link.id)
     } catch (err) {
-      console.error("[program/decide] auto-link generation failed", err)
+      log.error("[program/decide] auto-link generation failed", err)
     }
 
     try {
@@ -157,7 +159,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         deal_id: deal.id,
       })
     } catch (err) {
-      console.error("[program/decide] webhook dispatch failed", err)
+      log.error("[program/decide] webhook dispatch failed", err)
     }
   } else {
     try {
@@ -168,7 +170,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         reason: parsed.data.reason ?? null,
       })
     } catch (err) {
-      console.error("[program/decide] reject webhook dispatch failed", err)
+      log.error("[program/decide] reject webhook dispatch failed", err)
     }
   }
 

--- a/backend/src/api/v1/seller/programs/[id]/deals/[dealId]/violate/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/deals/[dealId]/violate/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/programs/[id]/deals/[dealId]/violate")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../../../middlewares/seller-context-v1"
@@ -69,7 +71,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         })
       }
     } catch (err) {
-      console.error("[deal/violate] failed to pause links", err)
+      log.error("[deal/violate] failed to pause links", err)
     }
   }
 
@@ -86,7 +88,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     await webhooks.dispatch("creator.deal.violated", sellerId, payload)
     await webhooks.dispatch("creator.deal.violated", deal.creator_seller_id, payload)
   } catch (err) {
-    console.error("[deal/violate] webhook dispatch failed", err)
+    log.error("[deal/violate] webhook dispatch failed", err)
   }
 
   return res.status(200).json({ deal: updated })

--- a/backend/src/api/v1/seller/programs/[id]/publish/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/publish/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/programs/[id]/publish")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
 import { CREATOR_PROGRAM_MODULE } from "../../../../../../modules/creator-program"
@@ -33,7 +35,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       program_type: program.program_type,
     })
   } catch (err) {
-    console.error("[program/publish] webhook dispatch failed", err)
+    log.error("[program/publish] webhook dispatch failed", err)
   }
 
   return res.status(200).json({ program: updated })

--- a/backend/src/api/v1/seller/programs/[id]/reward-pools/route.ts
+++ b/backend/src/api/v1/seller/programs/[id]/reward-pools/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/programs/[id]/reward-pools")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../middlewares/seller-context-v1"
@@ -110,7 +112,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       currencyCode: (parsed.data.currency_code ?? program.currency_code).toUpperCase(),
     })
   } catch (err) {
-    console.error("[reward-pools] funding failed", err)
+    log.error("[reward-pools] funding failed", err)
     return res.status(402).json({
       message: `Pool created but funding failed: ${(err as Error).message}`,
       type: "funding_failed",
@@ -132,7 +134,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     await webhooks.dispatch("creator.reward.pool_opened", sellerId, payload)
     await webhooks.dispatch("creator.reward.pool_funded", sellerId, payload)
   } catch (err) {
-    console.error("[reward-pools] webhook dispatch failed", err)
+    log.error("[reward-pools] webhook dispatch failed", err)
   }
 
   return res.status(201).json({ pool })

--- a/backend/src/api/v1/seller/services/applications/route.ts
+++ b/backend/src/api/v1/seller/services/applications/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/applications")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
@@ -69,7 +71,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         })
       }
     } catch (err) {
-      console.error("[service-applications] webhook dispatch failed", err)
+      log.error("[service-applications] webhook dispatch failed", err)
     }
 
     return res.status(201).json({ application })

--- a/backend/src/api/v1/seller/services/programs/[id]/applications/[appId]/decide/route.ts
+++ b/backend/src/api/v1/seller/services/programs/[id]/applications/[appId]/decide/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/programs/[id]/applications/[appId]/decide")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../../../../middlewares/seller-context-v1"
@@ -90,7 +92,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         })
       }
     } catch (err) {
-      console.error("[service-decide] KYC check failed", err)
+      log.error("[service-decide] KYC check failed", err)
       return res.status(500).json({
         message: "KYC verification check failed",
         type: "kyc_check_failed",
@@ -135,7 +137,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         }
       )
     } catch (err) {
-      console.error("[service-decide] webhook dispatch failed", err)
+      log.error("[service-decide] webhook dispatch failed", err)
     }
   } else {
     try {
@@ -150,7 +152,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         }
       )
     } catch (err) {
-      console.error("[service-decide] reject webhook dispatch failed", err)
+      log.error("[service-decide] reject webhook dispatch failed", err)
     }
   }
 

--- a/backend/src/api/v1/seller/services/programs/[id]/publish/route.ts
+++ b/backend/src/api/v1/seller/services/programs/[id]/publish/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/programs/[id]/publish")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
 import { SERVICE_PROGRAM_MODULE } from "../../../../../../../modules/service-program"
@@ -33,7 +35,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       program_type: program.program_type,
     })
   } catch (err) {
-    console.error("[service-program/publish] webhook dispatch failed", err)
+    log.error("[service-program/publish] webhook dispatch failed", err)
   }
   return res.status(200).json({ program: updated })
 }

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/accept-delivery/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/accept-delivery/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/subcontracts/[id]/accept-delivery")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
 import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
@@ -73,7 +75,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     )
     await programSvc.incrementContractPayout(sub.contract_id, Number(sub.total_cents))
   } catch (err) {
-    console.error("[accept-delivery] contract payout update failed", err)
+    log.error("[accept-delivery] contract payout update failed", err)
   }
 
   try {
@@ -88,7 +90,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     await webhooks.dispatch("subcontract.completed", sellerId, payload)
     await webhooks.dispatch("subcontract.completed", sub.subcontract_seller_id, payload)
   } catch (err) {
-    console.error("[accept-delivery] webhook dispatch failed", err)
+    log.error("[accept-delivery] webhook dispatch failed", err)
   }
 
   return res.status(200).json({

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/accept/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/accept/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/subcontracts/[id]/accept")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
 import { ORDER_SUBCONTRACT_MODULE } from "../../../../../../../modules/order-subcontract"
@@ -33,7 +35,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         accepted_by: sellerId,
       })
     } catch (err) {
-      console.error("[subcontract/accept] webhook dispatch failed", err)
+      log.error("[subcontract/accept] webhook dispatch failed", err)
     }
     return res.status(200).json({ subcontract: sub })
   } catch (err) {

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/deliver/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/deliver/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/subcontracts/[id]/deliver")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
@@ -133,7 +135,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         if (!firstProofId) firstProofId = proof.id
       }
     } catch (err) {
-      console.error("[subcontract/deliver] proof submission failed", err)
+      log.error("[subcontract/deliver] proof submission failed", err)
     }
   }
 
@@ -161,7 +163,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       })
     }
   } catch (err) {
-    console.error("[subcontract/deliver] webhook dispatch failed", err)
+    log.error("[subcontract/deliver] webhook dispatch failed", err)
   }
 
   return res.status(200).json({ subcontract: updated, proof_ids: proofIds })

--- a/backend/src/api/v1/seller/services/subcontracts/[id]/dispute/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/[id]/dispute/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/subcontracts/[id]/dispute")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../../../middlewares/seller-context-v1"
@@ -78,7 +80,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     await webhooks.dispatch("subcontract.disputed", sub.parent_seller_id, payload)
     await webhooks.dispatch("subcontract.disputed", sub.subcontract_seller_id, payload)
   } catch (err) {
-    console.error("[subcontract/dispute] webhook dispatch failed", err)
+    log.error("[subcontract/dispute] webhook dispatch failed", err)
   }
 
   // §3 bridge: open the three-party dispute room. vendorId is the counterparty

--- a/backend/src/api/v1/seller/services/subcontracts/route.ts
+++ b/backend/src/api/v1/seller/services/subcontracts/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/v1/seller/services/subcontracts")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { z } from "zod"
 import type { SellerAuthRequest } from "../../../../middlewares/seller-context-v1"
@@ -103,7 +105,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       escrowLedgerEntryId: entry.id,
     })
   } catch (err) {
-    console.error("[subcontracts] escrow open failed", err)
+    log.error("[subcontracts] escrow open failed", err)
     return res.status(402).json({
       message: `Subcontract proposed but escrow failed: ${(err as Error).message}`,
       type: "escrow_failed",
@@ -124,7 +126,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     await webhooks.dispatch("subcontract.proposed", sellerId, payload)
     await webhooks.dispatch("subcontract.proposed", contract.service_seller_id, payload)
   } catch (err) {
-    console.error("[subcontracts] webhook dispatch failed", err)
+    log.error("[subcontracts] webhook dispatch failed", err)
   }
 
   return res.status(201).json({ subcontract: sub })

--- a/backend/src/api/v1/webhooks/content-platform/[platform]/route.ts
+++ b/backend/src/api/v1/webhooks/content-platform/[platform]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/v1/webhooks/content-platform/[platform]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { CONTENT_PLATFORM_MODULE } from "../../../../../modules/content-platform"
 import type ContentPlatformService from "../../../../../modules/content-platform/service"
@@ -91,7 +93,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       snapshotsCreated++
     }
   } catch (err) {
-    console.error("[content-platform-webhook] snapshot ingest failed", err)
+    log.error("[content-platform-webhook] snapshot ingest failed", err)
   }
 
   return res.status(200).json({

--- a/backend/src/api/vendor/_middlewares.ts
+++ b/backend/src/api/vendor/_middlewares.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("api/vendor/_middlewares")
 import { defineMiddlewares } from "@medusajs/framework/http"
 import type { MedusaRequest, MedusaResponse, MedusaNextFunction } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
@@ -75,7 +77,7 @@ async function vendorCorsMiddleware(
     res.setHeader("Access-Control-Max-Age", "86400")
     res.setHeader("Vary", "Origin")
   } else if (origin) {
-    console.warn(`[VENDOR CORS] Origin not allowed: "${origin}"`)
+    log.warn(`[VENDOR CORS] Origin not allowed: "${origin}"`)
   }
 
   // Handle preflight
@@ -271,7 +273,7 @@ export async function ensureSellerContext(
     const seller = sellers[0]
     ;(req as MedusaRequest & { seller?: unknown }).seller = seller
   } catch (error) {
-    console.error("[VENDOR AUTH] Failed to validate seller context:", error)
+    log.error("[VENDOR AUTH] Failed to validate seller context:", error)
     res.status(500).json({
       message: "Failed to validate seller context",
       type: "server_error",

--- a/backend/src/api/vendor/chat/route.ts
+++ b/backend/src/api/vendor/chat/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/chat")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { SELLER_MODULE } from "@mercurjs/b2c-core/modules/seller"
 import { requireSellerId } from "../../../shared/auth-helpers"
@@ -79,7 +81,7 @@ export async function GET(
 
       login = await matrixService.mintLoginToken(mxid)
     } catch (error: any) {
-      console.error("[GET /vendor/chat] Provisioning failed:", error.message)
+      log.error("[GET /vendor/chat] Provisioning failed:", error.message)
     }
 
     const response: Record<string, unknown> = {
@@ -98,7 +100,7 @@ export async function GET(
 
     res.json(response)
   } catch (error: any) {
-    console.error("[GET /vendor/chat] Error:", error)
+    log.error("[GET /vendor/chat] Error:", error)
     res.status(500).json({
       message: error.message || "Failed to retrieve chat configuration",
     })

--- a/backend/src/api/vendor/chat/unread/route.ts
+++ b/backend/src/api/vendor/chat/unread/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/chat/unread")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { SELLER_MODULE } from "@mercurjs/b2c-core/modules/seller"
 import { requireSellerId } from "../../../../shared/auth-helpers"
@@ -48,7 +50,7 @@ export async function GET(
     const unreadCount = await matrixService.getUnreadCount(mxid)
     res.json({ unread_count: unreadCount })
   } catch (error: any) {
-    console.warn(
+    log.warn(
       "[GET /vendor/chat/unread] Matrix unavailable, returning degraded count:",
       error?.message
     )

--- a/backend/src/api/vendor/collective/demand-pools/[id]/proposals/route.ts
+++ b/backend/src/api/vendor/collective/demand-pools/[id]/proposals/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/vendor/collective/demand-pools/[id]/proposals")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../../../modules/demand-pool"
@@ -66,7 +68,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     res.json({ proposals })
   } catch (error: unknown) {
     const message = getErrorMessage(error)
-    console.error("[GET vendor proposals] Error:", message)
+    log.error("[GET vendor proposals] Error:", message)
     res.status(500).json({ error: "Failed to retrieve proposals", details: message })
   }
 }
@@ -141,7 +143,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       return res.status(400).json({ error: "Validation failed", details: error.issues })
     }
     const message = getErrorMessage(error)
-    console.error("[POST vendor proposal] Error:", message)
+    log.error("[POST vendor proposal] Error:", message)
     res.status(400).json({ error: message })
   }
 }

--- a/backend/src/api/vendor/collective/demand-pools/route.ts
+++ b/backend/src/api/vendor/collective/demand-pools/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/collective/demand-pools")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { DEMAND_POOL_MODULE } from "../../../../modules/demand-pool"
 import DemandPoolModuleService from "../../../../modules/demand-pool/service"
@@ -45,7 +47,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     })
   } catch (error: unknown) {
     const message = getErrorMessage(error)
-    console.error("[GET /vendor/collective/demand-pools] Error:", message)
+    log.error("[GET /vendor/collective/demand-pools] Error:", message)
     res.status(500).json({ error: "Failed to retrieve demand pools", details: message })
   }
 }

--- a/backend/src/api/vendor/economic-standing/route.ts
+++ b/backend/src/api/vendor/economic-standing/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/economic-standing")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { requireSellerId } from "../../../shared/auth-helpers"
@@ -84,7 +86,7 @@ export async function GET(
       evaluated_at: new Date().toISOString(),
     })
   } catch (error: any) {
-    console.error("[GET /vendor/economic-standing] Error:", error.message)
+    log.error("[GET /vendor/economic-standing] Error:", error.message)
     res.json(zeroedStanding(null))
   }
 }

--- a/backend/src/api/vendor/hawala/advances/route.ts
+++ b/backend/src/api/vendor/hawala/advances/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/advances")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -42,7 +44,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       })),
     })
   } catch (error: any) {
-    console.error("Error getting advance info:", error)
+    log.error("Error getting advance info:", error)
     res.status(400).json({ error: "Failed to retrieve advance information" })
   }
 }
@@ -89,7 +91,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     })
   } catch (error: any) {
-    console.error("Error requesting advance:", error)
+    log.error("Error requesting advance:", error)
     res.status(400).json({ error: "Failed to request advance" })
   }
 }

--- a/backend/src/api/vendor/hawala/dashboard/route.ts
+++ b/backend/src/api/vendor/hawala/dashboard/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/dashboard")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -38,7 +40,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     
     res.json({ dashboard })
   } catch (error: any) {
-    console.error("Error getting vendor dashboard:", error)
+    log.error("Error getting vendor dashboard:", error)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/vendor/hawala/payments/route.ts
+++ b/backend/src/api/vendor/hawala/payments/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/payments")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -50,7 +52,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       })),
     })
   } catch (error: any) {
-    console.error("Error getting vendor payments:", error)
+    log.error("Error getting vendor payments:", error)
     res.status(400).json({ error: "Failed to retrieve payment history" })
   }
 }
@@ -110,7 +112,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       message: "Payment completed successfully. Funds transferred instantly with zero fees.",
     })
   } catch (error: any) {
-    console.error("Error creating vendor payment:", error)
+    log.error("Error creating vendor payment:", error)
     res.status(400).json({ error: "Failed to process payment" })
   }
 }

--- a/backend/src/api/vendor/hawala/payouts/config/route.ts
+++ b/backend/src/api/vendor/hawala/payouts/config/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/payouts/config")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../../modules/hawala-ledger/service"
@@ -54,7 +56,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       })),
     })
   } catch (error: any) {
-    console.error("Error getting payout config:", error)
+    log.error("Error getting payout config:", error)
     res.status(400).json({ error: error.message })
   }
 }
@@ -94,7 +96,7 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
 
     res.json({ config: updated })
   } catch (error: any) {
-    console.error("Error updating payout config:", error)
+    log.error("Error updating payout config:", error)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/vendor/hawala/payouts/config/splits/route.ts
+++ b/backend/src/api/vendor/hawala/payouts/config/splits/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/payouts/config/splits")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../../../modules/hawala-ledger/service"
@@ -59,7 +61,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
     res.status(201).json({ split_rule: rule })
   } catch (error: any) {
-    console.error("Error creating split rule:", error)
+    log.error("Error creating split rule:", error)
     res.status(400).json({ error: error.message })
   }
 }
@@ -102,7 +104,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       })),
     })
   } catch (error: any) {
-    console.error("Error getting split rules:", error)
+    log.error("Error getting split rules:", error)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/vendor/hawala/payouts/route.ts
+++ b/backend/src/api/vendor/hawala/payouts/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/payouts")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -20,7 +22,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     
     res.json({ payout_options: options })
   } catch (error: any) {
-    console.error("Error getting payout options:", error)
+    log.error("Error getting payout options:", error)
     res.status(400).json({ error: error.message })
   }
 }
@@ -58,7 +60,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
     res.status(201).json({ payout_request: payoutRequest })
   } catch (error: any) {
-    console.error("Error requesting payout:", error)
+    log.error("Error requesting payout:", error)
     res.status(400).json({ error: error.message })
   }
 }

--- a/backend/src/api/vendor/hawala/pools/[id]/withdraw/route.ts
+++ b/backend/src/api/vendor/hawala/pools/[id]/withdraw/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/pools/[id]/withdraw")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { randomUUID } from "crypto"
 import { HAWALA_LEDGER_MODULE } from "../../../../../../modules/hawala-ledger"
@@ -75,7 +77,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       message: `$${amount.toFixed(2)} transferred to earnings account`,
     })
   } catch (error) {
-    console.error("Error withdrawing from pool:", error)
+    log.error("Error withdrawing from pool:", error)
     res.status(400).json({ error: "Failed to process withdrawal" })
   }
 }

--- a/backend/src/api/vendor/hawala/pools/route.ts
+++ b/backend/src/api/vendor/hawala/pools/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/hawala/pools")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -26,7 +28,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     res.json({ pools: poolsWithDetails })
   } catch (error) {
-    console.error("Error listing pools:", error)
+    log.error("Error listing pools:", error)
     res.status(500).json({ error: "Failed to retrieve pools" })
   }
 }
@@ -91,7 +93,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     res.status(201).json({ pool, account: poolAccount })
   } catch (error) {
-    console.error("Error creating pool:", error)
+    log.error("Error creating pool:", error)
     res.status(400).json({ error: "Failed to create investment pool" })
   }
 }

--- a/backend/src/api/vendor/inventory-sync/events/route.ts
+++ b/backend/src/api/vendor/inventory-sync/events/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/inventory-sync/events")
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { inventoryLedgerEventSchema } from "../../../../shared/phase0-contracts"
 import { runQueueConsumer } from "../../../../shared/queue-runtime"
@@ -19,7 +21,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     idempotencyKey: payload.idempotency_key,
     handler: async () => undefined,
     publishToDlq: async (message) => {
-      console.error("[POST /vendor/inventory-sync/events][DLQ]", JSON.stringify(message))
+      log.error("[POST /vendor/inventory-sync/events][DLQ]", JSON.stringify(message))
     },
     requeue: async (message, delaySeconds) => {
       await requeueWithBackoff(message, delaySeconds)

--- a/backend/src/api/vendor/invoices/route.ts
+++ b/backend/src/api/vendor/invoices/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/invoices")
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ulid } from "ulid"
 import { invoiceSchema } from "../../../shared/phase0-contracts"
@@ -98,7 +100,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       idempotencyKey: payload.invoice_id,
       handler: async () => undefined,
       publishToDlq: async (message) => {
-        console.error("[POST /vendor/invoices][DLQ]", JSON.stringify(message))
+        log.error("[POST /vendor/invoices][DLQ]", JSON.stringify(message))
       },
       requeue: async (message, delaySeconds) => {
         await requeueWithBackoff(message, delaySeconds)

--- a/backend/src/api/vendor/me/onboarding/referral-capture/route.ts
+++ b/backend/src/api/vendor/me/onboarding/referral-capture/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/vendor/me/onboarding/referral-capture")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { TENANCY_MODULE } from "../../../../../modules/tenancy"
@@ -100,7 +102,7 @@ export async function POST(req: MedusaRequest<Body>, res: MedusaResponse) {
       onboardingUpdated = true
     }
   } catch (err) {
-    console.error("[vendor/me/onboarding/referral-capture] tenancy update failed:", err)
+    log.error("[vendor/me/onboarding/referral-capture] tenancy update failed:", err)
   }
 
   // Seed a primary AffiliateLink for the new seller pointing back at
@@ -139,7 +141,7 @@ export async function POST(req: MedusaRequest<Body>, res: MedusaResponse) {
       }
     }
   } catch (err) {
-    console.error("[vendor/me/onboarding/referral-capture] link seed failed:", err)
+    log.error("[vendor/me/onboarding/referral-capture] link seed failed:", err)
   }
 
   return res.status(200).json({

--- a/backend/src/api/vendor/me/route.ts
+++ b/backend/src/api/vendor/me/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/me")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 
@@ -93,7 +95,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     return res.json({ member })
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error"
-    console.error("[GET /vendor/me] Error:", errorMessage)
+    log.error("[GET /vendor/me] Error:", errorMessage)
     return res.status(500).json({
       message: "Failed to fetch vendor member profile",
       type: "server_error",

--- a/backend/src/api/vendor/order-cycles/route.ts
+++ b/backend/src/api/vendor/order-cycles/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/order-cycles")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ORDER_CYCLE_MODULE } from "../../../modules/order-cycle"
 import type OrderCycleModuleService from "../../../modules/order-cycle/service"
@@ -38,7 +40,7 @@ export async function GET(
       offset: offsetNum,
     })
   } catch (error) {
-    console.error("Error fetching order cycles:", error)
+    log.error("Error fetching order cycles:", error)
     res.status(500).json({ message: "Failed to fetch order cycles", error: String(error) })
   }
 }
@@ -111,7 +113,7 @@ export async function POST(
 
     res.status(201).json({ order_cycle: orderCycle })
   } catch (error) {
-    console.error("Error creating order cycle:", error)
+    log.error("Error creating order cycle:", error)
     res.status(500).json({ message: "Failed to create order cycle", error: String(error) })
   }
 }

--- a/backend/src/api/vendor/playbook/assign/route.ts
+++ b/backend/src/api/vendor/playbook/assign/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/playbook/assign")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { requireSellerId } from "../../../../shared"
 import {
@@ -87,7 +89,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     return res.json({ playbook_assignment: assignment ?? null })
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Unknown error"
-    console.error("[GET /vendor/playbook/assign] Error:", message)
+    log.error("[GET /vendor/playbook/assign] Error:", message)
     return res.status(500).json({
       type: "server_error",
       message: "Failed to fetch playbook assignment",
@@ -162,7 +164,7 @@ export async function POST(
     return res.json({ playbook_assignment: result.playbook_assignment })
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Unknown error"
-    console.error("[POST /vendor/playbook/assign] Error:", message)
+    log.error("[POST /vendor/playbook/assign] Error:", message)
     return res.status(500).json({
       type: "server_error",
       message: `Failed to assign playbook: ${message}`,

--- a/backend/src/api/vendor/product-types/[id]/route.ts
+++ b/backend/src/api/vendor/product-types/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/product-types/[id]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 
@@ -42,7 +44,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       })
     }
 
-    console.error("[VENDOR] Failed to fetch product type:", error)
+    log.error("[VENDOR] Failed to fetch product type:", error)
     res.status(500).json({
       message: "Failed to fetch product type",
       error: error.message,

--- a/backend/src/api/vendor/product-types/route.ts
+++ b/backend/src/api/vendor/product-types/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/product-types")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 
@@ -62,7 +64,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       limit: parseInt(limit as string, 10) || 20,
     })
   } catch (error: any) {
-    console.error("[VENDOR] Failed to fetch product types:", error)
+    log.error("[VENDOR] Failed to fetch product types:", error)
     res.status(500).json({
       message: "Failed to fetch product types",
       error: error.message,

--- a/backend/src/api/vendor/products/[id]/route.ts
+++ b/backend/src/api/vendor/products/[id]/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/products/[id]")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { updateProductsWorkflow } from "@medusajs/medusa/core-flows"
@@ -100,7 +102,7 @@ export async function GET(
 
     return res.status(404).json({ message: "Product not found" })
   } catch (error: any) {
-    console.error(`Error fetching product ${id} for seller ${sellerId}:`, error)
+    log.error(`Error fetching product ${id} for seller ${sellerId}:`, error)
     res.status(500).json({
       message: "Failed to fetch product"
     })
@@ -165,7 +167,7 @@ export async function POST(
 
     return res.status(404).json({ message: "Product not found after update" })
   } catch (error: any) {
-    console.error(`Error updating product ${id} for seller ${sellerId}:`, error)
+    log.error(`Error updating product ${id} for seller ${sellerId}:`, error)
     res.status(500).json({
       message: "Failed to update product"
     })
@@ -217,7 +219,7 @@ export async function DELETE(
       deleted: true
     })
   } catch (error: any) {
-    console.error(`Error deleting product ${id} for seller ${sellerId}:`, error)
+    log.error(`Error deleting product ${id} for seller ${sellerId}:`, error)
     res.status(500).json({
       message: "Failed to delete product"
     })

--- a/backend/src/api/vendor/products/[id]/status/route.ts
+++ b/backend/src/api/vendor/products/[id]/status/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/vendor/products/[id]/status")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { updateProductsWorkflow } from "@medusajs/medusa/core-flows"
@@ -61,7 +63,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     return res.json({ product: products?.[0] })
   } catch (error: any) {
-    console.error(`Error updating product status ${id}:`, error)
+    log.error(`Error updating product status ${id}:`, error)
     res.status(500).json({ message: "Failed to update product status" })
   }
 }

--- a/backend/src/api/vendor/products/route.ts
+++ b/backend/src/api/vendor/products/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/products")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
@@ -118,7 +120,7 @@ export async function POST(
 
       await linkSellerInventoryItems(req, resolvedSellerId, createdProduct.id)
     } catch (linkError: any) {
-      console.warn(
+      log.warn(
         `Could not create seller-product link for ${createdProduct.id}: ${linkError.message}`
       )
     }
@@ -138,7 +140,7 @@ export async function POST(
       product: products?.[0] || createdProduct,
     })
   } catch (error: any) {
-    console.error(`Error creating product for seller ${resolvedSellerId}:`, error)
+    log.error(`Error creating product for seller ${resolvedSellerId}:`, error)
     res.status(500).json({
       message: "Failed to create product",
       error: error.message,

--- a/backend/src/api/vendor/registration-status/route.ts
+++ b/backend/src/api/vendor/registration-status/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/registration-status")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 
 // Allow this endpoint to be accessed without seller authentication
@@ -13,7 +15,7 @@ export const AUTHENTICATE = false
  * This endpoint now redirects to the new location.
  */
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
-  console.log("[GET /vendor/registration-status] DEPRECATED - redirecting to /auth/seller/registration-status")
+  log.info("[GET /vendor/registration-status] DEPRECATED - redirecting to /auth/seller/registration-status")
 
   // Get the base URL from the request
   const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https'

--- a/backend/src/api/vendor/requests/route.ts
+++ b/backend/src/api/vendor/requests/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/requests")
 import { z } from "zod"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { REQUEST_MODULE } from "../../../modules/request"
@@ -60,7 +62,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       res.status(400).json({ message: "Validation failed", errors: error.issues })
       return
     }
-    console.error("[GET /vendor/requests] Error:", error.message)
+    log.error("[GET /vendor/requests] Error:", error.message)
     res.status(500).json({ message: "Failed to retrieve requests" })
   }
 }
@@ -86,7 +88,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       requester_id: sellerId,
     })
 
-    console.log(`[POST /vendor/requests] Request ${request.id} created by seller ${sellerId}. Type: ${body.request.type}`)
+    log.info(`[POST /vendor/requests] Request ${request.id} created by seller ${sellerId}. Type: ${body.request.type}`)
 
     res.status(201).json({
       request,
@@ -97,7 +99,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       res.status(400).json({ message: "Validation failed", errors: error.issues })
       return
     }
-    console.error("[POST /vendor/requests] Error:", error.message)
+    log.error("[POST /vendor/requests] Error:", error.message)
     res.status(500).json({ message: "Failed to create request" })
   }
 }

--- a/backend/src/api/vendor/sales-report/route.ts
+++ b/backend/src/api/vendor/sales-report/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/sales-report")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
@@ -156,7 +158,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       },
     })
   } catch (error: any) {
-    console.error(`Error fetching sales report for seller ${sellerId}:`, error)
+    log.error(`Error fetching sales report for seller ${sellerId}:`, error)
     res.status(500).json({ message: "Failed to fetch sales report", error: error.message })
   }
 }

--- a/backend/src/api/vendor/seller-products/route.ts
+++ b/backend/src/api/vendor/seller-products/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/seller-products")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
@@ -169,7 +171,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
       await linkSellerInventoryItems(req, resolvedSellerId, createdProduct.id)
     } catch (linkError: any) {
-      console.warn(
+      log.warn(
         `Could not create seller-product link for ${createdProduct.id}: ${linkError.message}`
       )
     }
@@ -200,7 +202,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
   } catch (error: any) {
     const status = getErrorStatus(error)
 
-    console.error("Error creating product for seller", {
+    log.error("Error creating product for seller", {
       sellerId: resolvedSellerId,
       status,
       message: error?.message,

--- a/backend/src/api/vendor/sellers/me/extensions/route.ts
+++ b/backend/src/api/vendor/sellers/me/extensions/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../../shared/logger"
+const log = createLogger("api/vendor/sellers/me/extensions")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { requireSellerId } from "../../../../../shared"
@@ -57,7 +59,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     return res.json({ seller })
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error"
-    console.error("[POST /vendor/sellers/me/extensions] Error:", errorMessage)
+    log.error("[POST /vendor/sellers/me/extensions] Error:", errorMessage)
     return res.status(500).json({
       type: "server_error",
       message: "Failed to update seller extensions",

--- a/backend/src/api/vendor/sellers/me/route.ts
+++ b/backend/src/api/vendor/sellers/me/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/vendor/sellers/me")
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { requireSellerId } from "../../../../shared"
@@ -38,7 +40,7 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     return res.json({ seller })
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error"
-    console.error("[GET /vendor/sellers/me] Error:", errorMessage)
+    log.error("[GET /vendor/sellers/me] Error:", errorMessage)
     return res.status(500).json({
       message: "Failed to fetch seller profile",
       type: "server_error",
@@ -134,7 +136,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
     return res.json({ seller })
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error"
-    console.error("[POST /vendor/sellers/me] Error:", errorMessage)
+    log.error("[POST /vendor/sellers/me] Error:", errorMessage)
     return res.status(500).json({
       message: "Failed to update seller profile",
       type: "server_error",

--- a/backend/src/api/vendor/sellers/route.ts
+++ b/backend/src/api/vendor/sellers/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("api/vendor/sellers")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { REQUEST_MODULE } from "../../../modules/request"
@@ -28,7 +30,7 @@ export const POST = async (
   try {
     body = createSellerSchema.parse(req.body)
   } catch (validationError: any) {
-    console.error("[POST /vendor/sellers] Validation error")
+    log.error("[POST /vendor/sellers] Validation error")
     return res.status(400).json({
       type: "invalid_data",
       message: validationError.errors?.[0]?.message || "Invalid request data",
@@ -36,7 +38,7 @@ export const POST = async (
     })
   }
 
-  console.log(`[POST /vendor/sellers] Creating seller request: "${body.name}" (email: ${maskEmail(body.member.email)})`)
+  log.info(`[POST /vendor/sellers] Creating seller request: "${body.name}" (email: ${maskEmail(body.member.email)})`)
 
   try {
     // Look up the auth identity by email (created during auth registration)
@@ -48,14 +50,14 @@ export const POST = async (
     })
 
     if (!authIdentity) {
-      console.error(`[POST /vendor/sellers] Auth identity not found for email: ${maskEmail(body.member.email)}`)
+      log.error(`[POST /vendor/sellers] Auth identity not found for email: ${maskEmail(body.member.email)}`)
       return res.status(400).json({
         type: "invalid_data",
         message: "Please complete authentication registration first",
       })
     }
 
-    console.log(`[POST /vendor/sellers] Found auth identity: ${authIdentity.id}`)
+    log.info(`[POST /vendor/sellers] Found auth identity: ${authIdentity.id}`)
 
     // Create a seller creation REQUEST using the custom Request module
     // This will appear in the admin panel for approval
@@ -79,7 +81,7 @@ export const POST = async (
       reviewer_note: `Seller registration request for "${body.name}"`,
     })
 
-    console.log(`[POST /vendor/sellers] Created seller request: ${sellerRequest.id}`)
+    log.info(`[POST /vendor/sellers] Created seller request: ${sellerRequest.id}`)
 
     return res.status(201).json({
       request: {
@@ -89,7 +91,7 @@ export const POST = async (
       },
     })
   } catch (error: any) {
-    console.error("[POST /vendor/sellers] Failed to create seller request:", error.message)
+    log.error("[POST /vendor/sellers] Failed to create seller request:", error.message)
 
     // Return proper error response
     return res.status(400).json({

--- a/backend/src/api/webhooks/hawala/stripe/route.ts
+++ b/backend/src/api/webhooks/hawala/stripe/route.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/webhooks/hawala/stripe")
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { HAWALA_LEDGER_MODULE } from "../../../../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../../../../modules/hawala-ledger/service"
@@ -21,13 +23,13 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
     // SECURITY: Require raw body buffer for proper signature verification
     if (!rawBody || !Buffer.isBuffer(rawBody)) {
-      console.error("Webhook raw body missing or not a buffer - signature verification would be invalid")
+      log.error("Webhook raw body missing or not a buffer - signature verification would be invalid")
       return res.status(400).json({ error: "Invalid request body format" })
     }
 
     const event = await achService.handleWebhook(rawBody, signature)
 
-    console.log(`Stripe webhook received: ${event.type}`)
+    log.info(`Stripe webhook received: ${event.type}`)
 
     switch (event.type) {
       case "payment_intent.succeeded": {
@@ -162,12 +164,12 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
       }
 
       default:
-        console.log(`Unhandled Stripe event type: ${event.type}`)
+        log.info(`Unhandled Stripe event type: ${event.type}`)
     }
 
     res.json({ received: true })
   } catch (error) {
-    console.error("Stripe webhook error:", error)
+    log.error("Stripe webhook error:", error)
     res.status(400).json({ error: (error as Error).message })
   }
 }

--- a/backend/src/jobs/asset-graph-settlement-reconciler.ts
+++ b/backend/src/jobs/asset-graph-settlement-reconciler.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/asset-graph-settlement-reconciler")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
 import { ASSET_GRAPH_MODULE } from "../modules/asset-graph"
@@ -40,7 +42,7 @@ export default async function assetGraphSettlementReconcilerJob(
   const hawala: any = container.resolve(HAWALA_LEDGER_MODULE)
   const assetGraph: any = container.resolve(ASSET_GRAPH_MODULE)
 
-  console.log("[asset-graph-reconciler] Starting unsettled-record sweep")
+  log.info("[asset-graph-reconciler] Starting unsettled-record sweep")
 
   const results = await reconcileAllUnsettled(hawala, assetGraph)
 
@@ -49,7 +51,7 @@ export default async function assetGraphSettlementReconcilerJob(
     return acc
   }, {})
 
-  console.log(
+  log.info(
     `[asset-graph-reconciler] Processed ${results.length} records: ` +
       Object.entries(counts)
         .map(([k, v]) => `${k}=${v}`)
@@ -58,7 +60,7 @@ export default async function assetGraphSettlementReconcilerJob(
 
   const failures = results.filter((r) => r.status === "failed")
   for (const f of failures) {
-    console.error(
+    log.error(
       `[asset-graph-reconciler] FAILED ${f.record_id}: ${
         (f as { error: string }).error
       }`

--- a/backend/src/jobs/attribution-fraud-sweep.ts
+++ b/backend/src/jobs/attribution-fraud-sweep.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/attribution-fraud-sweep")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
 import type CreatorAttributionService from "../modules/creator-attribution/service"
@@ -72,7 +74,7 @@ export default async function attributionFraudSweepJob(
         })
         flagged++
       } catch (err) {
-        console.error("[attribution-fraud-sweep] click update failed", err)
+        log.error("[attribution-fraud-sweep] click update failed", err)
       }
     }
   }
@@ -105,16 +107,16 @@ export default async function attributionFraudSweepJob(
             }
           )
         } catch (err) {
-          console.error("[attribution-fraud-sweep] webhook dispatch failed", err)
+          log.error("[attribution-fraud-sweep] webhook dispatch failed", err)
         }
       }
     } catch (err) {
-      console.error("[attribution-fraud-sweep] disqualify failed", err)
+      log.error("[attribution-fraud-sweep] disqualify failed", err)
     }
   }
 
   if (flagged > 0) {
-    console.log(`[attribution-fraud-sweep] flagged ${flagged} clicks`)
+    log.info(`[attribution-fraud-sweep] flagged ${flagged} clicks`)
   }
 }
 

--- a/backend/src/jobs/content-platform-metrics-poll.ts
+++ b/backend/src/jobs/content-platform-metrics-poll.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/content-platform-metrics-poll")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { CREATOR_REWARDS_MODULE } from "../modules/creator-rewards"
 import type CreatorRewardsService from "../modules/creator-rewards/service"
@@ -61,7 +63,7 @@ export default async function contentPlatformMetricsPollJob(
       if (msg.includes("not support")) {
         skipped++
       } else {
-        console.error(
+        log.error(
           `[content-platform-metrics-poll] post ${post.id} failed`,
           err
         )
@@ -70,7 +72,7 @@ export default async function contentPlatformMetricsPollJob(
   }
 
   if (attempted > 0 || updated > 0) {
-    console.log(
+    log.info(
       `[content-platform-metrics-poll] attempted=${attempted} updated=${updated} skipped=${skipped}`
     )
   }

--- a/backend/src/jobs/creator-attribution-approve-held.ts
+++ b/backend/src/jobs/creator-attribution-approve-held.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/creator-attribution-approve-held")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
 import CreatorAttributionService from "../modules/creator-attribution/service"
@@ -36,7 +38,7 @@ export default async function approveHeldCreatorAttributionsJob(
   const due = await attributionService.listHeldAttributionsDue()
   if (due.length === 0) return
 
-  console.log(`[creator-approve-held] processing ${due.length} due attributions`)
+  log.info(`[creator-approve-held] processing ${due.length} due attributions`)
 
   for (const a of due) {
     const amountCents = Number(a.commission_amount_cents)
@@ -45,7 +47,7 @@ export default async function approveHeldCreatorAttributionsJob(
       try {
         await attributionService.approveCommission(a.id, "")
       } catch (err) {
-        console.error(`[creator-approve-held] zero-cent approve failed for ${a.id}`, err)
+        log.error(`[creator-approve-held] zero-cent approve failed for ${a.id}`, err)
       }
       continue
     }
@@ -56,7 +58,7 @@ export default async function approveHeldCreatorAttributionsJob(
       try {
         await attributionService.disqualifyAttribution(a.id, "missing_vendor_id")
       } catch (err) {
-        console.error(`[creator-approve-held] disqualify failed for ${a.id}`, err)
+        log.error(`[creator-approve-held] disqualify failed for ${a.id}`, err)
       }
       continue
     }
@@ -94,11 +96,11 @@ export default async function approveHeldCreatorAttributionsJob(
             payload
           )
         } catch (err) {
-          console.error(`[creator-approve-held] webhook dispatch failed for ${a.id}`, err)
+          log.error(`[creator-approve-held] webhook dispatch failed for ${a.id}`, err)
         }
       }
     } catch (err) {
-      console.error(`[creator-approve-held] approval failed for ${a.id}`, err)
+      log.error(`[creator-approve-held] approval failed for ${a.id}`, err)
     }
   }
 }

--- a/backend/src/jobs/creator-rewards-pool-close.ts
+++ b/backend/src/jobs/creator-rewards-pool-close.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/creator-rewards-pool-close")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { CREATOR_REWARDS_MODULE } from "../modules/creator-rewards"
 import type CreatorRewardsService from "../modules/creator-rewards/service"
@@ -24,13 +26,13 @@ export default async function creatorRewardsPoolCloseJob(container: MedusaContai
 
   const due = await rewards.listPoolsDueForDistribution()
   if (due.length === 0) return
-  console.log(`[creator-rewards-pool-close] processing ${due.length} due pools`)
+  log.info(`[creator-rewards-pool-close] processing ${due.length} due pools`)
 
   for (const pool of due) {
     try {
       const result = await rewards.calculatePoolDistribution(pool.id)
       if (result.total_distributed_cents === 0) {
-        console.log(`[creator-rewards-pool-close] no eligible creators in pool ${pool.id}`)
+        log.info(`[creator-rewards-pool-close] no eligible creators in pool ${pool.id}`)
         await rewards.markPoolDistributed(pool.id)
         continue
       }
@@ -61,14 +63,14 @@ export default async function creatorRewardsPoolCloseJob(container: MedusaContai
                 }
               )
             } catch (err) {
-              console.error(
+              log.error(
                 `[creator-rewards-pool-close] webhook failed for ${payout.id}`,
                 err
               )
             }
           }
         } catch (err) {
-          console.error(
+          log.error(
             `[creator-rewards-pool-close] payout ${payout.id} failed`,
             err
           )
@@ -89,14 +91,14 @@ export default async function creatorRewardsPoolCloseJob(container: MedusaContai
             }
           )
         } catch (err) {
-          console.error(
+          log.error(
             `[creator-rewards-pool-close] funder webhook failed`,
             err
           )
         }
       }
     } catch (err) {
-      console.error(`[creator-rewards-pool-close] pool ${pool.id} failed`, err)
+      log.error(`[creator-rewards-pool-close] pool ${pool.id} failed`, err)
     }
   }
 }

--- a/backend/src/jobs/demand-pool-expiry.ts
+++ b/backend/src/jobs/demand-pool-expiry.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/demand-pool-expiry")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { DEMAND_POOL_MODULE } from "../modules/demand-pool"
 import { DemandPostStatus } from "../modules/demand-pool/models/demand-post"
@@ -75,7 +77,7 @@ export default async function demandPoolExpiryJob(
     container.resolve<DemandPoolModuleService>(DEMAND_POOL_MODULE)
   const collectiveHawala = getCollectiveHawalaService(container)
 
-  console.log("[demand-pool-expiry] Starting overdue-pool sweep")
+  log.info("[demand-pool-expiry] Starting overdue-pool sweep")
 
   const results = await expireOverduePools(
     demandPoolService,
@@ -86,13 +88,13 @@ export default async function demandPoolExpiryJob(
   const expired = results.filter((r) => r.status === "expired").length
   const failed = results.filter((r) => r.status === "failed")
 
-  console.log(
+  log.info(
     `[demand-pool-expiry] Processed ${results.length} overdue pools: ` +
       `expired=${expired}, failed=${failed.length}`
   )
 
   for (const f of failed) {
-    console.error(
+    log.error(
       `[demand-pool-expiry] FAILED ${f.demand_post_id}: ${f.error}`
     )
   }

--- a/backend/src/jobs/donation-batch-disbursement.ts
+++ b/backend/src/jobs/donation-batch-disbursement.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/donation-batch-disbursement")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { DONATION_MODULE } from "../modules/donation"
 import DonationModuleService from "../modules/donation/service"
@@ -9,9 +11,9 @@ export default async function donationBatchDisbursementJob(container: MedusaCont
 
   const result = await service.queueBatchDisbursement(start, now)
   if ((result as any).skipped) {
-    console.log("[DonationBatch] skipped:", (result as any).reason)
+    log.info("[DonationBatch] skipped:", (result as any).reason)
   } else {
-    console.log("[DonationBatch] queued disbursements:", (result as any).count)
+    log.info("[DonationBatch] queued disbursements:", (result as any).count)
   }
 }
 

--- a/backend/src/jobs/drain-webhook-deliveries.ts
+++ b/backend/src/jobs/drain-webhook-deliveries.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/drain-webhook-deliveries")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
 import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
@@ -22,11 +24,11 @@ export default async function drainWebhookDeliveriesJob(
   try {
     const attempted = await webhooks.drainDueDeliveries(50)
     if (attempted > 0) {
-      console.log(`[Webhook Drain] Attempted ${attempted} delivery(ies)`)
+      log.info(`[Webhook Drain] Attempted ${attempted} delivery(ies)`)
     }
     return { attempted }
   } catch (error) {
-    console.error("[Webhook Drain] Error draining deliveries:", error)
+    log.error("[Webhook Drain] Error draining deliveries:", error)
     throw error
   }
 }

--- a/backend/src/jobs/hawala-balance-reconciler.ts
+++ b/backend/src/jobs/hawala-balance-reconciler.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/hawala-balance-reconciler")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
@@ -21,27 +23,27 @@ export default async function hawalaBalanceReconcilerJob(
   const hawala: any = container.resolve(HAWALA_LEDGER_MODULE)
   const pgConnection: any = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
 
-  console.log("[hawala-balance-reconciler] Starting balance drift sweep")
+  log.info("[hawala-balance-reconciler] Starting balance drift sweep")
 
   let drifts
   try {
     drifts = await reconcileLedgerBalances(hawala, pgConnection)
   } catch (error) {
-    console.error("[hawala-balance-reconciler] Sweep failed:", error)
+    log.error("[hawala-balance-reconciler] Sweep failed:", error)
     return
   }
 
   if (drifts.length === 0) {
-    console.log("[hawala-balance-reconciler] No balance drift detected")
+    log.info("[hawala-balance-reconciler] No balance drift detected")
     return
   }
 
-  console.warn(
+  log.warn(
     `[hawala-balance-reconciler] Detected ${drifts.length} account(s) with balance drift; ` +
       `manual investigation required (NOT auto-corrected)`
   )
   for (const d of drifts) {
-    console.warn(
+    log.warn(
       `[hawala-balance-reconciler]   account=${d.account_id} ` +
         `cached=${d.cached} computed=${d.computed} drift=${d.drift}`
     )

--- a/backend/src/jobs/hawala-settlement.ts
+++ b/backend/src/jobs/hawala-settlement.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/hawala-settlement")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
@@ -17,10 +19,10 @@ import { requeueWithBackoff } from "../shared/queue-requeue-adapter"
 export default async function hawalaSettlementJob(container: MedusaContainer) {
   const hawalaService = container.resolve<HawalaLedgerModuleService>(HAWALA_LEDGER_MODULE)
 
-  console.log("[Hawala Settlement] Starting daily settlement batch...")
+  log.info("[Hawala Settlement] Starting daily settlement batch...")
 
   const publishToDlq = async (message: any) => {
-    console.error("[Hawala Settlement][DLQ]", JSON.stringify(message))
+    log.error("[Hawala Settlement][DLQ]", JSON.stringify(message))
   }
   const requeue = async (message: any, delaySeconds: number) => {
     await requeueWithBackoff(message, delaySeconds)
@@ -37,11 +39,11 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
     const unsettledEntries = entries.filter(e => !e.settlement_batch_id)
 
     if (unsettledEntries.length === 0) {
-      console.log("[Hawala Settlement] No unsettled entries found")
+      log.info("[Hawala Settlement] No unsettled entries found")
       return
     }
 
-    console.log(`[Hawala Settlement] Found ${unsettledEntries.length} unsettled entries`)
+    log.info(`[Hawala Settlement] Found ${unsettledEntries.length} unsettled entries`)
 
     // Calculate totals
     const totalVolume = unsettledEntries.reduce((sum, e) => sum + Number(e.amount), 0)
@@ -63,7 +65,7 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
       status: "PENDING",
     })
 
-    console.log(`[Hawala Settlement] Created batch #${batchNumber}`)
+    log.info(`[Hawala Settlement] Created batch #${batchNumber}`)
 
     const invoiceEvent = {
       invoice_id: `settlement-${batch.id}`,
@@ -105,7 +107,7 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
           rail: decision.rail,
           batch_id: batch.id,
         })
-        console.log(
+        log.info(
           `[Hawala Settlement] Dual-rail decision: ${decision.rail} (` +
             decision.reasons.map((r) => `${r.check}=${r.outcome}`).join(", ") +
             `)`
@@ -117,7 +119,7 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
           stellarMetrics.inc("hawala.settlement_pending_manual", {
             batch_id: batch.id,
           })
-          console.warn(
+          log.warn(
             "[Hawala Settlement] Batch left PENDING for manual Stripe-ACH action",
             JSON.stringify({
               batch_id: batch.id,
@@ -160,7 +162,7 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
           const errorMessage =
             submitError instanceof Error ? submitError.message : String(submitError)
           stellarMetrics.inc("hawala.settlement_failed", { batch_id: batch.id })
-          console.error(
+          log.error(
             `[Hawala Settlement] Stellar submission failed for batch #${batchNumber}:`,
             errorMessage
           )
@@ -200,11 +202,11 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
           })
         }
 
-        console.log(`[Hawala Settlement] Batch #${batchNumber} anchored to Stellar:`)
-        console.log(`  - TX Hash: ${stellarResult.txHash}`)
-        console.log(`  - Merkle Root: ${stellarResult.merkleRoot}`)
-        console.log(`  - Entries: ${unsettledEntries.length}`)
-        console.log(`  - Volume: $${totalVolume.toFixed(2)}`)
+        log.info(`[Hawala Settlement] Batch #${batchNumber} anchored to Stellar:`)
+        log.info(`  - TX Hash: ${stellarResult.txHash}`)
+        log.info(`  - Merkle Root: ${stellarResult.merkleRoot}`)
+        log.info(`  - Entries: ${unsettledEntries.length}`)
+        log.info(`  - Volume: $${totalVolume.toFixed(2)}`)
       },
       publishToDlq,
       requeue,
@@ -222,7 +224,7 @@ export default async function hawalaSettlementJob(container: MedusaContainer) {
       })
     }
   } catch (error) {
-    console.error("[Hawala Settlement] Settlement job failed:", error)
+    log.error("[Hawala Settlement] Settlement job failed:", error)
   }
 }
 

--- a/backend/src/jobs/order-cycle-status-update.ts
+++ b/backend/src/jobs/order-cycle-status-update.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/order-cycle-status-update")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { ORDER_CYCLE_MODULE } from "../modules/order-cycle"
 import type OrderCycleModuleService from "../modules/order-cycle/service"
@@ -17,20 +19,20 @@ export default async function orderCycleStatusUpdateJob(
 ) {
   const orderCycleService = container.resolve<OrderCycleModuleService>(ORDER_CYCLE_MODULE)
   
-  console.log("[Order Cycle Job] Checking for status updates...")
+  log.info("[Order Cycle Job] Checking for status updates...")
   
   try {
     const results = await orderCycleService.updateOrderCycleStatuses()
     
     if (results.opened > 0 || results.closed > 0) {
-      console.log(
+      log.info(
         `[Order Cycle Job] Updated ${results.opened} cycles to open, ${results.closed} cycles to closed`
       )
     }
     
     return results
   } catch (error) {
-    console.error("[Order Cycle Job] Error updating statuses:", error)
+    log.error("[Order Cycle Job] Error updating statuses:", error)
     throw error
   }
 }

--- a/backend/src/jobs/process-subscription-renewals.ts
+++ b/backend/src/jobs/process-subscription-renewals.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("jobs/process-subscription-renewals")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { SUBSCRIPTION_MODULE } from "../modules/subscription"
 import SubscriptionModuleService from "../modules/subscription/service"
@@ -62,14 +64,14 @@ export default async function processSubscriptionRenewals(
 
   const liveMode = process.env.FBM_SUBSCRIPTION_RENEWAL_LIVE === "1"
 
-  console.log(
+  log.info(
     `[Subscription Job] Starting subscription renewal check (live_mode=${liveMode})...`
   )
 
   try {
     const dueSubscriptions = await subscriptionService.getDueSubscriptions()
 
-    console.log(
+    log.info(
       `[Subscription Job] Found ${dueSubscriptions.length} subscriptions due for renewal`
     )
 
@@ -83,7 +85,7 @@ export default async function processSubscriptionRenewals(
           subscription.expiration_date &&
           new Date() > new Date(subscription.expiration_date)
         ) {
-          console.log(
+          log.info(
             `[Subscription Job] Expiring subscription ${subscription.id}`
           )
           await subscriptionService.expireSubscription(subscription.id)
@@ -95,7 +97,7 @@ export default async function processSubscriptionRenewals(
           // Legacy path — preserved for environments that haven't been
           // cut over to the workflow-driven loop yet.
           await subscriptionService.recordNewSubscriptionOrder(subscription.id)
-          console.log(
+          log.info(
             `[Subscription Job] (legacy) advanced dates for ${subscription.id}`
           )
           continue
@@ -109,13 +111,13 @@ export default async function processSubscriptionRenewals(
         await subscriptionService.clearDunningAttempts(subscription.id)
         await emitSubscriptionState(container, subscription, "activated")
 
-        console.log(
+        log.info(
           `[Subscription Job] Renewed subscription ${subscription.id}`
         )
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Unknown error"
-        console.error(
+        log.error(
           `[Subscription Job] Renewal failed for ${subscription.id}: ${message}`
         )
 
@@ -134,7 +136,7 @@ export default async function processSubscriptionRenewals(
             },
           })
         } catch (dunningError) {
-          console.error(
+          log.error(
             `[Subscription Job] Dunning workflow failed for ${subscription.id}:`,
             dunningError
           )
@@ -155,7 +157,7 @@ export default async function processSubscriptionRenewals(
       .map((s) => s.id)
 
     if (expiredIds.length > 0) {
-      console.log(
+      log.info(
         `[Subscription Job] Expiring ${expiredIds.length} past-due subscriptions`
       )
       await subscriptionService.expireSubscription(expiredIds)
@@ -164,9 +166,9 @@ export default async function processSubscriptionRenewals(
       }
     }
 
-    console.log("[Subscription Job] Completed subscription renewal check")
+    log.info("[Subscription Job] Completed subscription renewal check")
   } catch (error) {
-    console.error(
+    log.error(
       "[Subscription Job] Error in subscription renewal job:",
       error
     )

--- a/backend/src/lib/blackout-emit.ts
+++ b/backend/src/lib/blackout-emit.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("lib/blackout-emit")
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
 import type MarketplaceWebhooksService from "../modules/marketplace-webhooks/service"
@@ -23,7 +25,7 @@ export async function emitBlackoutEvent(
     const result = await webhooks.emitBlackout(type, fields, opts)
     return result ? opts.eventId ?? null : null
   } catch (err) {
-    console.error(
+    log.error(
       `[blackout-emit] failed to enqueue ${type}:`,
       err instanceof Error ? err.message : err
     )

--- a/backend/src/lib/instrumentation.ts
+++ b/backend/src/lib/instrumentation.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("lib/instrumentation")
 /**
  * Lightweight instrumentation surface for FBM modules.
  *
@@ -28,7 +30,7 @@ export function emitMetric(
     ts: new Date().toISOString(),
   }
   // eslint-disable-next-line no-console -- structured-metric sink
-  console.warn(JSON.stringify(payload))
+  log.warn(JSON.stringify(payload))
 }
 
 export function snapshotMetrics(): Array<{

--- a/backend/src/links/listing-type-product.ts
+++ b/backend/src/links/listing-type-product.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/listing-type-product")
 import { defineLink } from "@medusajs/framework/utils"
 import ProductModule from "@medusajs/medusa/product"
 import ListingTypeModule from "../modules/listing-type"
@@ -35,9 +37,9 @@ try {
       isList: false,
     }
   )
-  console.log(`${LOG_PREFIX} Link defined successfully: product ↔ listing_type`)
+  log.info(`${LOG_PREFIX} Link defined successfully: product ↔ listing_type`)
 } catch (linkError: any) {
-  console.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
+  log.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
   listingTypeProductLink = null
 }
 

--- a/backend/src/links/order-cycle-seller.ts
+++ b/backend/src/links/order-cycle-seller.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/order-cycle-seller")
 import { defineLink } from "@medusajs/framework/utils"
 import OrderCycleModule from "../modules/order-cycle"
 
@@ -23,7 +25,7 @@ try {
   try {
     SellerModule = require("../modules/marketplace").default
   } catch {
-    console.warn("No seller module found - order cycle links will not be created")
+    log.warn("No seller module found - order cycle links will not be created")
     SellerModule = null
   }
 }

--- a/backend/src/links/playbook-seller.ts
+++ b/backend/src/links/playbook-seller.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/playbook-seller")
 import { defineLink } from "@medusajs/framework/utils"
 import PlaybookModule from "../modules/playbook"
 
@@ -19,16 +21,16 @@ let SellerModule: any = null
 
 try {
   SellerModule = require("@mercurjs/framework").SellerModule
-  console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
+  log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
 } catch (frameworkError: any) {
   try {
     SellerModule = require("@mercurjs/b2c-core/modules/seller").default
-    console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
+    log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
   } catch (b2cError: any) {
-    console.error(`${LOG_PREFIX} Failed to load SellerModule:`)
-    console.error(`${LOG_PREFIX}   @mercurjs/framework: ${frameworkError.message}`)
-    console.error(`${LOG_PREFIX}   @mercurjs/b2c-core/modules/seller: ${b2cError.message}`)
-    console.error(`${LOG_PREFIX} playbook link will NOT be created`)
+    log.error(`${LOG_PREFIX} Failed to load SellerModule:`)
+    log.error(`${LOG_PREFIX}   @mercurjs/framework: ${frameworkError.message}`)
+    log.error(`${LOG_PREFIX}   @mercurjs/b2c-core/modules/seller: ${b2cError.message}`)
+    log.error(`${LOG_PREFIX} playbook link will NOT be created`)
   }
 }
 
@@ -53,9 +55,9 @@ if (SellerModule) {
         isList: false,
       }
     )
-    console.log(`${LOG_PREFIX} Link defined successfully: seller ↔ playbook_assignment`)
+    log.info(`${LOG_PREFIX} Link defined successfully: seller ↔ playbook_assignment`)
   } catch (linkError: any) {
-    console.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
+    log.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
     playbookSellerLink = null
   }
 }

--- a/backend/src/links/producer-seller.ts
+++ b/backend/src/links/producer-seller.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/producer-seller")
 import { defineLink } from "@medusajs/framework/utils"
 import ProducerModule from "../modules/producer"
 
@@ -25,16 +27,16 @@ let SellerModule: any = null
 
 try {
   SellerModule = require("@mercurjs/framework").SellerModule
-  console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
+  log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
 } catch (frameworkError: any) {
   try {
     SellerModule = require("@mercurjs/b2c-core/modules/seller").default
-    console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
+    log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
   } catch (b2cError: any) {
-    console.error(`${LOG_PREFIX} Failed to load SellerModule:`)
-    console.error(`${LOG_PREFIX}   @mercurjs/framework: ${frameworkError.message}`)
-    console.error(`${LOG_PREFIX}   @mercurjs/b2c-core/modules/seller: ${b2cError.message}`)
-    console.error(`${LOG_PREFIX} producer link will NOT be created`)
+    log.error(`${LOG_PREFIX} Failed to load SellerModule:`)
+    log.error(`${LOG_PREFIX}   @mercurjs/framework: ${frameworkError.message}`)
+    log.error(`${LOG_PREFIX}   @mercurjs/b2c-core/modules/seller: ${b2cError.message}`)
+    log.error(`${LOG_PREFIX} producer link will NOT be created`)
   }
 }
 
@@ -60,9 +62,9 @@ if (SellerModule) {
         isList: false,
       }
     )
-    console.log(`${LOG_PREFIX} Link defined successfully: seller ↔ producer`)
+    log.info(`${LOG_PREFIX} Link defined successfully: seller ↔ producer`)
   } catch (linkError: any) {
-    console.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
+    log.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
     producerSellerLink = null
   }
 }

--- a/backend/src/links/seller-metadata.ts
+++ b/backend/src/links/seller-metadata.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/seller-metadata")
 import { defineLink } from "@medusajs/framework/utils"
 import SellerExtensionModule from "../modules/seller-extension"
 
@@ -30,21 +32,21 @@ let loadError: string | null = null
 try {
   // Try the newer @mercurjs/framework export first
   SellerModule = require("@mercurjs/framework").SellerModule
-  console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
+  log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
 } catch (frameworkError: any) {
   try {
     // Fallback to @mercurjs/b2c-core direct import
     SellerModule = require("@mercurjs/b2c-core/modules/seller").default
-    console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
+    log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
   } catch (b2cError: any) {
     loadError = `
       Failed to load SellerModule:
       - @mercurjs/framework: ${frameworkError.message}
       - @mercurjs/b2c-core/modules/seller: ${b2cError.message}
     `.trim()
-    console.error(`${LOG_PREFIX} ${loadError}`)
-    console.error(`${LOG_PREFIX} seller_metadata link will NOT be created`)
-    console.error(`${LOG_PREFIX} Queries like "seller.seller_metadata.*" will fail`)
+    log.error(`${LOG_PREFIX} ${loadError}`)
+    log.error(`${LOG_PREFIX} seller_metadata link will NOT be created`)
+    log.error(`${LOG_PREFIX} Queries like "seller.seller_metadata.*" will fail`)
   }
 }
 
@@ -71,9 +73,9 @@ if (SellerModule) {
         isList: false,
       }
     )
-    console.log(`${LOG_PREFIX} Link defined successfully: seller ↔ seller_metadata`)
+    log.info(`${LOG_PREFIX} Link defined successfully: seller ↔ seller_metadata`)
   } catch (linkError: any) {
-    console.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
+    log.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
     sellerMetadataLink = null
   }
 }

--- a/backend/src/links/subscription-seller.ts
+++ b/backend/src/links/subscription-seller.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/subscription-seller")
 import { defineLink } from "@medusajs/framework/utils"
 import SubscriptionModule from "../modules/subscription"
 
@@ -13,7 +15,7 @@ try {
   try {
     SellerModule = require("@mercurjs/b2c-core/modules/seller").default
   } catch {
-    console.warn("No seller module found - subscription-seller links will not be created")
+    log.warn("No seller module found - subscription-seller links will not be created")
     SellerModule = null
   }
 }

--- a/backend/src/links/utils/load-seller-module.ts
+++ b/backend/src/links/utils/load-seller-module.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("links/utils/load-seller-module")
 /**
  * Utility to load the MercurJS SellerModule
  *
@@ -27,7 +29,7 @@ export function loadSellerModule(linkName: string): LoadResult {
   try {
     const SellerModule = require("@mercurjs/framework").SellerModule
     if (SellerModule) {
-      console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
+      log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
       return { SellerModule, error: null, source: "@mercurjs/framework" }
     }
   } catch (e: any) {
@@ -38,7 +40,7 @@ export function loadSellerModule(linkName: string): LoadResult {
   try {
     const SellerModule = require("@mercurjs/b2c-core/modules/seller").default
     if (SellerModule) {
-      console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
+      log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core/modules/seller`)
       return { SellerModule, error: null, source: "@mercurjs/b2c-core/modules/seller" }
     }
   } catch (e: any) {
@@ -49,7 +51,7 @@ export function loadSellerModule(linkName: string): LoadResult {
   try {
     const b2cCore = require("@mercurjs/b2c-core")
     if (b2cCore.SellerModule) {
-      console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core`)
+      log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core`)
       return { SellerModule: b2cCore.SellerModule, error: null, source: "@mercurjs/b2c-core" }
     }
   } catch (e: any) {
@@ -68,7 +70,7 @@ export function loadSellerModule(linkName: string): LoadResult {
     Links requiring SellerModule will not be created.
   `.trim()
 
-  console.error(error)
+  log.error(error)
   return { SellerModule: null, error, source: null }
 }
 

--- a/backend/src/links/woocommerce-connection-seller.ts
+++ b/backend/src/links/woocommerce-connection-seller.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("links/woocommerce-connection-seller")
 import { defineLink } from "@medusajs/framework/utils"
 import WooCommerceImportModule from "../modules/woocommerce-import"
 
@@ -21,14 +23,14 @@ let SellerModule: any = null
 
 try {
   SellerModule = require("@mercurjs/framework").SellerModule
-  console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
+  log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/framework`)
 } catch (frameworkError: any) {
   try {
     SellerModule = require("@mercurjs/b2c-core/modules/seller").default
-    console.log(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core`)
+    log.info(`${LOG_PREFIX} Loaded SellerModule from @mercurjs/b2c-core`)
   } catch (b2cError: any) {
-    console.error(`${LOG_PREFIX} Failed to load SellerModule`)
-    console.error(`${LOG_PREFIX} woocommerce_connection link will NOT be created`)
+    log.error(`${LOG_PREFIX} Failed to load SellerModule`)
+    log.error(`${LOG_PREFIX} woocommerce_connection link will NOT be created`)
   }
 }
 
@@ -53,9 +55,9 @@ if (SellerModule) {
         isList: false,
       }
     )
-    console.log(`${LOG_PREFIX} Link defined successfully`)
+    log.info(`${LOG_PREFIX} Link defined successfully`)
   } catch (linkError: any) {
-    console.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
+    log.error(`${LOG_PREFIX} Failed to define link: ${linkError.message}`)
     wooConnectionSellerLink = null
   }
 }

--- a/backend/src/modules/blackstar-fulfillment-provider/service.ts
+++ b/backend/src/modules/blackstar-fulfillment-provider/service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/blackstar-fulfillment-provider/service")
 import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
 import {
   CreateFulfillmentResult,
@@ -76,7 +78,7 @@ class BlackstarFulfillmentProviderService extends AbstractFulfillmentProviderSer
           metadata: (data.metadata as Record<string, unknown> | undefined) ?? null,
         })
       } catch (err) {
-        console.error("[blackstar-fulfillment] failed to persist BlackstarShipment", err)
+        log.error("[blackstar-fulfillment] failed to persist BlackstarShipment", err)
       }
     }
 

--- a/backend/src/modules/hawala-ledger/__tests__/posture-a-invariants.unit.spec.ts
+++ b/backend/src/modules/hawala-ledger/__tests__/posture-a-invariants.unit.spec.ts
@@ -124,11 +124,12 @@ describe("posture-a-guard: warn / off modes", () => {
   }
 
   it("warn mode logs but does not throw", () => {
+    // Routed through the structured logger, which formats message + context into a
+    // single string before handing it to console.warn.
     const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
     expect(() => assertPurchaseContext(base, "warn")).not.toThrow()
     expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining("Posture A closed-loop violation"),
-      expect.any(Object)
+      expect.stringContaining("Posture A closed-loop violation")
     )
     spy.mockRestore()
   })

--- a/backend/src/modules/hawala-ledger/audit-logger.ts
+++ b/backend/src/modules/hawala-ledger/audit-logger.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/hawala-ledger/audit-logger")
 /**
  * Hawala Financial Audit Logger
  * 
@@ -56,7 +58,7 @@ export function logAuditEvent(event: Omit<AuditEvent, "timestamp">) {
   }
 
   // Structured logging for production systems
-  console.log(JSON.stringify({
+  log.info(JSON.stringify({
     level: "audit",
     ...fullEvent,
   }))

--- a/backend/src/modules/hawala-ledger/posture-a-guard.ts
+++ b/backend/src/modules/hawala-ledger/posture-a-guard.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/hawala-ledger/posture-a-guard")
 /**
  * Coalition Credits closed-loop guard (Posture A).
  *
@@ -146,7 +148,7 @@ export const assertPurchaseContext = (
   }
 
   if (mode === "warn") {
-    console.warn(
+    log.warn(
       "[hawala-ledger] Posture A closed-loop violation (warn mode): " +
         "CCR transfer outside a goods/services purchase context. " +
         "See docs/POSTURE_A_COMPLIANCE.md.",
@@ -284,7 +286,7 @@ const raiseOrWarn = (
 ): void => {
   if (mode === "off") return
   if (mode === "warn") {
-    console.warn(`[hawala-ledger] ${message}`, details)
+    log.warn(`[hawala-ledger] ${message}`, details)
     return
   }
   throw new ClosedLoopViolationError(message, details)

--- a/backend/src/modules/hawala-ledger/service.ts
+++ b/backend/src/modules/hawala-ledger/service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/hawala-ledger/service")
 import { MedusaService, ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { auditFinancialTransaction, logAuditEvent } from "./audit-logger"
 import { assertRailInvariants } from "./posture-a-guard"
@@ -973,7 +975,7 @@ class HawalaLedgerModuleService extends MedusaService({
       idempotency_key: `${idempotencyKey}-customer`,
     })
     if (existingRefunds.length > 0) {
-      console.log(`[Hawala] Refund already processed for order ${data.order_id}`)
+      log.info(`[Hawala] Refund already processed for order ${data.order_id}`)
       return existingRefunds
     }
 
@@ -1097,7 +1099,7 @@ class HawalaLedgerModuleService extends MedusaService({
       }
     )
 
-    console.log(
+    log.info(
       `[Hawala] Refund processed for order ${data.order_id}: ` +
       `$${refundAmount} total ($${sellerRefund} from seller, $${feeRefund} fee reversal)`
     )
@@ -2205,7 +2207,7 @@ class HawalaLedgerModuleService extends MedusaService({
     // Validate rules sum to 100%
     const totalPercentage = rules.reduce((sum, r) => sum + Number(r.percentage), 0)
     if (Math.abs(totalPercentage - 100) > 0.01) {
-      console.warn(`Split rules for vendor ${vendorId} do not sum to 100%: ${totalPercentage}`)
+      log.warn(`Split rules for vendor ${vendorId} do not sum to 100%: ${totalPercentage}`)
     }
 
     const splits: Array<{ destination: string; amount: number; ledger_entry_id?: string }> = []

--- a/backend/src/modules/hawala-ledger/stellar-settlement.ts
+++ b/backend/src/modules/hawala-ledger/stellar-settlement.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/hawala-ledger/stellar-settlement")
 import {
   Keypair,
   Horizon,
@@ -35,7 +37,7 @@ export const stellarMetrics = {
   inc(name: string, labels: Record<string, string | number> = {}) {
     const payload = { metric: name, labels, ts: new Date().toISOString() }
     // eslint-disable-next-line no-console -- structured-metric sink
-    console.warn(JSON.stringify(payload))
+    log.warn(JSON.stringify(payload))
   },
 }
 
@@ -385,7 +387,7 @@ export function createStellarSettlementService(): StellarSettlementService {
   }
 
   if (!config.signerSecretKey) {
-    console.warn("STELLAR_SIGNER_SECRET not configured - settlement features disabled")
+    log.warn("STELLAR_SIGNER_SECRET not configured - settlement features disabled")
   }
 
   return new StellarSettlementService(config)

--- a/backend/src/modules/hawala-ledger/stripe-ach.ts
+++ b/backend/src/modules/hawala-ledger/stripe-ach.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/hawala-ledger/stripe-ach")
 import Stripe from "stripe"
 
 export interface AchConfig {
@@ -401,7 +403,7 @@ export function createStripeAchService(): StripeAchService {
   }
 
   if (!config.stripeSecretKey) {
-    console.warn("STRIPE_SECRET_KEY not configured - ACH features disabled")
+    log.warn("STRIPE_SECRET_KEY not configured - ACH features disabled")
   }
 
   return new StripeAchService(config)

--- a/backend/src/modules/request/service.ts
+++ b/backend/src/modules/request/service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("modules/request/service")
 import { MedusaService } from "@medusajs/framework/utils"
 import Request, { RequestStatus } from "./models/request"
 
@@ -227,16 +229,16 @@ class RequestModuleService extends MedusaService({
     reviewerId: string,
     reviewerNote?: string
   ) {
-    console.log(`[RequestService] acceptRequestWithReview called for id: ${id}`)
+    log.info(`[RequestService] acceptRequestWithReview called for id: ${id}`)
 
     const existingRequest = await this.getRequestForStatusChange(id)
-    console.log(`[RequestService] Found request with status: ${existingRequest.status}`)
+    log.info(`[RequestService] Found request with status: ${existingRequest.status}`)
 
     this.validateStatusTransition(
       existingRequest.status as RequestStatus,
       RequestStatus.ACCEPTED
     )
-    console.log(`[RequestService] Status transition validated`)
+    log.info(`[RequestService] Status transition validated`)
 
     // Build update data
     const updateData: Record<string, unknown> = {
@@ -248,7 +250,7 @@ class RequestModuleService extends MedusaService({
       updateData.reviewer_note = reviewerNote
     }
 
-    console.log(`[RequestService] Updating request with data:`, JSON.stringify(updateData))
+    log.info(`[RequestService] Updating request with data:`, JSON.stringify(updateData))
 
     // Use retrieveRequest + update pattern for more reliable single-record update
     try {
@@ -266,11 +268,11 @@ class RequestModuleService extends MedusaService({
         throw new Error("Request status update did not persist")
       }
 
-      console.log(`[RequestService] Request updated successfully, new status: ${updatedRequest.status}`)
+      log.info(`[RequestService] Request updated successfully, new status: ${updatedRequest.status}`)
       return updatedRequest
     } catch (error: any) {
-      console.error(`[RequestService] Failed to update request:`, error.message)
-      console.error(`[RequestService] Error stack:`, error.stack)
+      log.error(`[RequestService] Failed to update request:`, error.message)
+      log.error(`[RequestService] Error stack:`, error.stack)
       throw error
     }
   }
@@ -285,7 +287,7 @@ class RequestModuleService extends MedusaService({
     reviewerId: string,
     reason?: string
   ) {
-    console.log(`[RequestService] rejectRequestWithReview called for id: ${id}`)
+    log.info(`[RequestService] rejectRequestWithReview called for id: ${id}`)
 
     const existingRequest = await this.getRequestForStatusChange(id)
 
@@ -323,7 +325,7 @@ class RequestModuleService extends MedusaService({
       throw new Error("Request status update did not persist")
     }
 
-    console.log(`[RequestService] Request rejected successfully`)
+    log.info(`[RequestService] Request rejected successfully`)
     return updatedRequest
   }
 }

--- a/backend/src/services/apprise/apprise.service.ts
+++ b/backend/src/services/apprise/apprise.service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("services/apprise/apprise.service")
 /**
  * Apprise Notification Service
  * 
@@ -145,13 +147,13 @@ export class AppriseService {
 
       if (!response.ok) {
         const errorText = await response.text()
-        console.error("[Apprise] Notification failed:", errorText)
+        log.error("[Apprise] Notification failed:", errorText)
         return { success: false, error: errorText }
       }
 
       return { success: true }
     } catch (error) {
-      console.error("[Apprise] Error sending notification:", error)
+      log.error("[Apprise] Error sending notification:", error)
       return { 
         success: false, 
         error: error instanceof Error ? error.message : "Unknown error" 
@@ -174,7 +176,7 @@ export class AppriseService {
 
       return response.ok
     } catch (error) {
-      console.error("[Apprise] Error adding config:", error)
+      log.error("[Apprise] Error adding config:", error)
       return false
     }
   }
@@ -192,7 +194,7 @@ export class AppriseService {
 
       return await response.json()
     } catch (error) {
-      console.error("[Apprise] Error getting config:", error)
+      log.error("[Apprise] Error getting config:", error)
       return null
     }
   }
@@ -208,7 +210,7 @@ export class AppriseService {
 
       return response.ok
     } catch (error) {
-      console.error("[Apprise] Error deleting config:", error)
+      log.error("[Apprise] Error deleting config:", error)
       return false
     }
   }

--- a/backend/src/services/apprise/resend.service.ts
+++ b/backend/src/services/apprise/resend.service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("services/apprise/resend.service")
 /**
  * Resend Email Service
  * 
@@ -65,7 +67,7 @@ export class ResendService {
    */
   async sendEmail(params: SendEmailParams): Promise<ResendResponse> {
     if (!this.apiKey) {
-      console.warn("[Resend] No API key configured, email not sent")
+      log.warn("[Resend] No API key configured, email not sent")
       return { success: false, error: "No API key configured" }
     }
 
@@ -112,7 +114,7 @@ export class ResendService {
       const data = await response.json()
 
       if (!response.ok) {
-        console.error("[Resend] API error:", data)
+        log.error("[Resend] API error:", data)
         return { 
           success: false, 
           error: data.message || data.error || "Failed to send email" 
@@ -121,7 +123,7 @@ export class ResendService {
 
       return { success: true, id: data.id }
     } catch (error) {
-      console.error("[Resend] Error sending email:", error)
+      log.error("[Resend] Error sending email:", error)
       return { 
         success: false, 
         error: error instanceof Error ? error.message : "Unknown error" 

--- a/backend/src/shared/access-control.ts
+++ b/backend/src/shared/access-control.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "./logger"
+const log = createLogger("shared/access-control")
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { ENTITLEMENT_MODULE } from "../modules/entitlement"
 import type EntitlementModuleService from "../modules/entitlement/service"
@@ -53,7 +55,7 @@ export async function evaluateFbmAccess(
     const service = scope.resolve(ENTITLEMENT_MODULE) as EntitlementModuleService
     return await service.evaluateAccess(input)
   } catch (error: any) {
-    console.error("[AccessControl] evaluateFbmAccess failed:", error.message)
+    log.error("[AccessControl] evaluateFbmAccess failed:", error.message)
     return {
       allowed: false,
       reasons: [

--- a/backend/src/shared/auth-helpers.ts
+++ b/backend/src/shared/auth-helpers.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "./logger"
+const log = createLogger("shared/auth-helpers")
 import type { MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import jwt from "jsonwebtoken"
@@ -246,7 +248,7 @@ export function decodeAuthToken(token: string): AuthTokenInfo | null {
 
 export function decodeAuthTokenWithError(token: string): TokenDecodeResult {
   if (!config.JWT_SECRET) {
-    console.error("[Auth] JWT_SECRET not configured")
+    log.error("[Auth] JWT_SECRET not configured")
     return {
       success: false,
       error: "no_secret",
@@ -304,7 +306,7 @@ export function decodeAuthTokenWithError(token: string): TokenDecodeResult {
         message: "Invalid authentication token format. Please log in again.",
       }
     }
-    console.error("[Auth] Unknown JWT verification error:", err)
+    log.error("[Auth] Unknown JWT verification error:", err)
     return {
       success: false,
       error: "unknown_error",

--- a/backend/src/shared/config.ts
+++ b/backend/src/shared/config.ts
@@ -121,9 +121,9 @@ function loadConfig(): Config {
     
     // In development, log helpful hints
     if (process.env.NODE_ENV !== "production") {
-      console.error("\n❌ Environment configuration errors found:")
-      errors.forEach(e => console.error(e))
-      console.error("\nCheck your .env file and ensure all required variables are set.\n")
+      logger.error("\n❌ Environment configuration errors found:")
+      errors.forEach(e => logger.error(e))
+      logger.error("\nCheck your .env file and ensure all required variables are set.\n")
     }
     
     // Don't throw in development to allow partial startup

--- a/backend/src/shared/logger.ts
+++ b/backend/src/shared/logger.ts
@@ -64,6 +64,48 @@ function getLogLevelFromEnv(): LogLevel {
   return process.env.NODE_ENV === "production" ? "info" : "debug"
 }
 
+/**
+ * Coerce an arbitrary first argument (this logger accepts a console-compatible
+ * variadic signature) into a human-readable message string.
+ */
+function coerceMessage(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value instanceof Error) return value.message
+  if (value === undefined) return ""
+  try {
+    return typeof value === "object" ? JSON.stringify(value) : String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+/**
+ * Fold the trailing console-style arguments into a structured context object and,
+ * for error logging, surface the first Error. Plain objects are merged; primitives
+ * and arrays are collected under `args`.
+ */
+function collectArgs(rest: unknown[]): { context?: LogContext; error?: Error } {
+  let error: Error | undefined
+  const extras: unknown[] = []
+  const merged: LogContext = {}
+  for (const item of rest) {
+    if (item instanceof Error && !error) {
+      error = item
+      continue
+    }
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      Object.assign(merged, item as LogContext)
+    } else {
+      extras.push(item)
+    }
+  }
+  if (extras.length > 0) {
+    merged.args = extras.length === 1 ? extras[0] : extras
+  }
+  const context = Object.keys(merged).length > 0 ? merged : undefined
+  return { context, error }
+}
+
 class Logger {
   private prefix: string
   private minLevel: LogLevel
@@ -126,29 +168,36 @@ class Logger {
     }
   }
 
-  debug(message: string, context?: LogContext): void {
+  debug(message?: unknown, ...rest: unknown[]): void {
     if (this.shouldLog("debug")) {
-      this.output("debug", this.formatEntry("debug", message, context))
+      const { context } = collectArgs(rest)
+      this.output("debug", this.formatEntry("debug", coerceMessage(message), context))
     }
   }
 
-  info(message: string, context?: LogContext): void {
+  info(message?: unknown, ...rest: unknown[]): void {
     if (this.shouldLog("info")) {
-      this.output("info", this.formatEntry("info", message, context))
+      const { context } = collectArgs(rest)
+      this.output("info", this.formatEntry("info", coerceMessage(message), context))
     }
   }
 
-  warn(message: string, context?: LogContext): void {
+  warn(message?: unknown, ...rest: unknown[]): void {
     if (this.shouldLog("warn")) {
-      this.output("warn", this.formatEntry("warn", message, context))
+      const { context } = collectArgs(rest)
+      this.output("warn", this.formatEntry("warn", coerceMessage(message), context))
     }
   }
 
-  error(message: string, error?: unknown, context?: LogContext): void {
+  error(message?: unknown, ...rest: unknown[]): void {
     if (this.shouldLog("error")) {
-      const err = error instanceof Error ? error : undefined
-      const ctx = error && !(error instanceof Error) ? { ...context, error } : context
-      this.output("error", this.formatEntry("error", message, ctx, err))
+      // A leading Error (e.g. `log.error(err)`) is promoted to the structured error field.
+      const leadError = message instanceof Error ? message : undefined
+      const { context, error } = collectArgs(rest)
+      this.output(
+        "error",
+        this.formatEntry("error", coerceMessage(message), context, error ?? leadError)
+      )
     }
   }
 

--- a/backend/src/shared/matrix-service.ts
+++ b/backend/src/shared/matrix-service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "./logger"
+const log = createLogger("shared/matrix-service")
 import axios, { AxiosInstance } from "axios"
 
 /**
@@ -143,10 +145,10 @@ export class MatrixService {
         `/_synapse/admin/v2/users/${encodeURIComponent(mxid)}`,
         body
       )
-      console.log(`[Matrix] Ensured user ${mxid}`)
+      log.info(`[Matrix] Ensured user ${mxid}`)
       return { mxid, localpart }
     } catch (error: any) {
-      console.error(
+      log.error(
         "[Matrix] ensureUser failed:",
         error.response?.data || error.message
       )
@@ -187,7 +189,7 @@ export class MatrixService {
       }
       return userAccessToken
     } catch (error: any) {
-      console.error(
+      log.error(
         "[Matrix] admin user login failed:",
         error.response?.data || error.message
       )
@@ -226,7 +228,7 @@ export class MatrixService {
             : 120000,
       }
     } catch (error: any) {
-      console.error(
+      log.error(
         "[Matrix] login token mint failed:",
         error.response?.data || error.message
       )
@@ -270,7 +272,7 @@ export class MatrixService {
       }
       return total
     } catch (error: any) {
-      console.error(
+      log.error(
         "[Matrix] getUnreadCount failed:",
         error.response?.data || error.message
       )
@@ -292,7 +294,7 @@ export class MatrixService {
       if (error.response?.status === 404) {
         return null
       }
-      console.error(
+      log.error(
         "[Matrix] resolveRoomId failed:",
         error.response?.data || error.message
       )
@@ -329,14 +331,14 @@ export class MatrixService {
 
     try {
       const res = await this.client.post("/_matrix/client/v3/createRoom", body)
-      console.log(`[Matrix] Created room ${fullAlias}`)
+      log.info(`[Matrix] Created room ${fullAlias}`)
       return res.data.room_id || null
     } catch (error: any) {
       // Lost a create race — the alias now exists, so resolve it.
       if (error.response?.data?.errcode === "M_ROOM_IN_USE") {
         return this.resolveRoomId(fullAlias)
       }
-      console.error(
+      log.error(
         "[Matrix] ensureRoom failed:",
         error.response?.data || error.message
       )
@@ -353,7 +355,7 @@ export class MatrixService {
     if (roomIdOrAlias.startsWith("#")) {
       const resolved = await this.resolveRoomId(roomIdOrAlias)
       if (!resolved) {
-        console.warn(`[Matrix] invite skipped, alias not found: ${roomIdOrAlias}`)
+        log.warn(`[Matrix] invite skipped, alias not found: ${roomIdOrAlias}`)
         return
       }
       roomId = resolved
@@ -364,7 +366,7 @@ export class MatrixService {
         `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/invite`,
         { user_id: mxid }
       )
-      console.log(`[Matrix] Invited ${mxid} to ${roomId}`)
+      log.info(`[Matrix] Invited ${mxid} to ${roomId}`)
     } catch (error: any) {
       const errcode = error.response?.data?.errcode
       const message: string = error.response?.data?.error || ""
@@ -375,7 +377,7 @@ export class MatrixService {
       ) {
         return
       }
-      console.error(
+      log.error(
         "[Matrix] invite failed:",
         error.response?.data || error.message
       )
@@ -404,7 +406,7 @@ export function getMatrixService(): MatrixService | null {
     !process.env.MATRIX_SERVER_NAME ||
     !process.env.MATRIX_ADMIN_TOKEN
   ) {
-    console.log("[Matrix] Service not configured, skipping")
+    log.info("[Matrix] Service not configured, skipping")
     return null
   }
 
@@ -412,7 +414,7 @@ export function getMatrixService(): MatrixService | null {
     try {
       matrixService = new MatrixService()
     } catch (error: any) {
-      console.error("[Matrix] Failed to initialize service:", error.message)
+      log.error("[Matrix] Failed to initialize service:", error.message)
       return null
     }
   }

--- a/backend/src/shared/seller-approval-service.ts
+++ b/backend/src/shared/seller-approval-service.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "./logger"
+const log = createLogger("shared/seller-approval-service")
 import { MedusaContainer } from "@medusajs/framework/types"
 import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createSellerWorkflow } from "@mercurjs/b2c-core/workflows"
@@ -249,29 +251,29 @@ export class SellerApprovalService {
     try {
       data = validateSellerRequestData(request.data)
     } catch (validationError: any) {
-      console.error(`[SellerApproval] Request data validation failed:`, validationError.message)
-      console.error(`[SellerApproval] Request data was:`, JSON.stringify(request.data, null, 2))
+      log.error(`[SellerApproval] Request data validation failed:`, validationError.message)
+      log.error(`[SellerApproval] Request data was:`, JSON.stringify(request.data, null, 2))
       throw new Error(`Invalid request data: ${validationError.message}`)
     }
     const vendorType = data.vendor_type || "producer"
 
-    console.log(`[SellerApproval] Processing approval for seller "${data.seller.name}" (email: ${maskEmail(data.member.email)})`)
+    log.info(`[SellerApproval] Processing approval for seller "${data.seller.name}" (email: ${maskEmail(data.member.email)})`)
 
     // Step 2.5: Verify auth identity exists before proceeding
     const authModule = this.container.resolve(Modules.AUTH)
     const authIdentities = await authModule.listAuthIdentities({ id: [data.auth_identity_id] })
     if (!authIdentities || authIdentities.length === 0) {
-      console.error(`[SellerApproval] Auth identity not found: ${data.auth_identity_id}`)
+      log.error(`[SellerApproval] Auth identity not found: ${data.auth_identity_id}`)
       throw new Error(`Auth identity not found. The user may need to re-register.`)
     }
-    console.log(`[SellerApproval] Auth identity verified: ${data.auth_identity_id}`)
+    log.info(`[SellerApproval] Auth identity verified: ${data.auth_identity_id}`)
 
     let createdSeller: { id: string; name: string; handle?: string } | null = null
     let authUpdated = false
 
     try {
       // Step 3: Create the seller using MercurJS workflow
-      console.log(`[SellerApproval] Starting seller workflow with auth_identity_id: ${data.auth_identity_id}`)
+      log.info(`[SellerApproval] Starting seller workflow with auth_identity_id: ${data.auth_identity_id}`)
 
       const workflowInput = {
         auth_identity_id: data.auth_identity_id,
@@ -283,7 +285,7 @@ export class SellerApprovalService {
           name: data.seller.name,
         },
       }
-      console.log(`[SellerApproval] Workflow input:`, JSON.stringify(workflowInput, null, 2))
+      log.info(`[SellerApproval] Workflow input:`, JSON.stringify(workflowInput, null, 2))
 
       let seller: { id: string; name: string; handle?: string }
 
@@ -299,11 +301,11 @@ export class SellerApprovalService {
         }
         seller = result
         createdSeller = seller
-        console.log(`[SellerApproval] Seller created with ID: ${seller.id}`)
+        log.info(`[SellerApproval] Seller created with ID: ${seller.id}`)
       } catch (workflowError: any) {
         // Check if it's a duplicate handle error - if so, try to find and link existing seller
         if (workflowError.message?.includes("already exists")) {
-          console.log(`[SellerApproval] Seller already exists, attempting to find and link existing seller...`)
+          log.info(`[SellerApproval] Seller already exists, attempting to find and link existing seller...`)
 
           const query = this.container.resolve(ContainerRegistrationKeys.QUERY)
           const pgConnection = this.container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
@@ -333,7 +335,7 @@ export class SellerApprovalService {
 
           // If not found by email, try to find by handle (derived from seller name)
           if (!existingSeller) {
-            console.log(`[SellerApproval] Seller not found by email, trying by handle...`)
+            log.info(`[SellerApproval] Seller not found by email, trying by handle...`)
 
             // Generate expected handle from seller name (MercurJS uses kebab-case)
             const expectedHandle = data.seller.name
@@ -362,21 +364,21 @@ export class SellerApprovalService {
             }
 
             if (existingSeller) {
-              console.log(`[SellerApproval] Found seller by handle: ${existingSeller.handle}`)
+              log.info(`[SellerApproval] Found seller by handle: ${existingSeller.handle}`)
             }
           }
 
           if (existingSeller) {
-            console.log(`[SellerApproval] Found existing seller: ${existingSeller.id} (${existingSeller.name})`)
+            log.info(`[SellerApproval] Found existing seller: ${existingSeller.id} (${existingSeller.name})`)
             seller = { id: existingSeller.id, name: existingSeller.name, handle: existingSeller.handle }
             createdSeller = seller
           } else {
-            console.error(`[SellerApproval] Could not find existing seller to link. Email: ${data.member.email}, Name: ${data.seller.name}`)
+            log.error(`[SellerApproval] Could not find existing seller to link. Email: ${data.member.email}, Name: ${data.seller.name}`)
             throw new Error(`Seller creation workflow failed: ${workflowError.message}`)
           }
         } else {
-          console.error(`[SellerApproval] Workflow execution failed:`, workflowError.message)
-          console.error(`[SellerApproval] Workflow error details:`, workflowError)
+          log.error(`[SellerApproval] Workflow execution failed:`, workflowError.message)
+          log.error(`[SellerApproval] Workflow error details:`, workflowError)
           throw new Error(`Seller creation workflow failed: ${workflowError.message}`)
         }
       }
@@ -390,7 +392,7 @@ export class SellerApprovalService {
         },
       }])
       authUpdated = true
-      console.log(`[SellerApproval] Auth identity linked successfully`)
+      log.info(`[SellerApproval] Auth identity linked successfully`)
 
       // Step 5: Create seller metadata with vendor_type
       try {
@@ -403,10 +405,10 @@ export class SellerApprovalService {
             vendor_type: vendorTypeEnum,
           },
         })
-        console.log(`[SellerApproval] Metadata created with vendor_type: ${vendorTypeEnum}`)
+        log.info(`[SellerApproval] Metadata created with vendor_type: ${vendorTypeEnum}`)
       } catch (metadataError: any) {
         // Non-critical: subscriber will create with default type
-        console.warn(`[SellerApproval] Metadata creation failed (will use fallback): ${metadataError.message}`)
+        log.warn(`[SellerApproval] Metadata creation failed (will use fallback): ${metadataError.message}`)
       }
 
       // Step 6: Provision Matrix (Blackout) user + vendor room (non-blocking)
@@ -435,14 +437,14 @@ export class SellerApprovalService {
           )
 
           matrixCreated = true
-          console.log(`[SellerApproval] Matrix account provisioned: ${mxid}`)
+          log.info(`[SellerApproval] Matrix account provisioned: ${mxid}`)
         } catch (matrixError: any) {
-          console.warn(`[SellerApproval] Matrix provisioning failed (non-blocking): ${matrixError.message}`)
+          log.warn(`[SellerApproval] Matrix provisioning failed (non-blocking): ${matrixError.message}`)
         }
       }
 
       // Step 7: Update request status and reviewer info using dedicated service method
-      console.log(`[SellerApproval] Step 7: Updating request status to ACCEPTED...`)
+      log.info(`[SellerApproval] Step 7: Updating request status to ACCEPTED...`)
       const sanitizedNote = sanitizeInput(reviewerNote)
       const updatedNote = request.reviewer_note
         ? `${request.reviewer_note}\n${sanitizedNote}`.trim()
@@ -456,14 +458,14 @@ export class SellerApprovalService {
           reviewerId,
           updatedNote || undefined
         )
-        console.log(`[SellerApproval] Request ${requestId} status updated to ACCEPTED`)
+        log.info(`[SellerApproval] Request ${requestId} status updated to ACCEPTED`)
       } catch (updateError: any) {
-        console.error(`[SellerApproval] Failed to update request status:`, updateError.message)
-        console.error(`[SellerApproval] Update error details:`, updateError.stack || updateError)
+        log.error(`[SellerApproval] Failed to update request status:`, updateError.message)
+        log.error(`[SellerApproval] Update error details:`, updateError.stack || updateError)
         throw updateError
       }
 
-      console.log(`[SellerApproval] Request ${requestId} approved by reviewer ${reviewerId}`)
+      log.info(`[SellerApproval] Request ${requestId} approved by reviewer ${reviewerId}`)
 
       try {
         const vendorPanelUrl = process.env.VENDOR_PANEL_URL || process.env.VENDOR_URL || ""
@@ -484,9 +486,9 @@ export class SellerApprovalService {
             login_url: loginUrl || undefined,
           },
         })
-        console.log(`[SellerApproval] Vendor acceptance notification sent to ${maskEmail(data.member.email)}`)
+        log.info(`[SellerApproval] Vendor acceptance notification sent to ${maskEmail(data.member.email)}`)
       } catch (notificationError: any) {
-        console.warn(`[SellerApproval] Failed to send vendor acceptance notification: ${notificationError.message}`)
+        log.warn(`[SellerApproval] Failed to send vendor acceptance notification: ${notificationError.message}`)
       }
 
       return {
@@ -503,12 +505,12 @@ export class SellerApprovalService {
       }
     } catch (error: any) {
       // Compensating actions for critical failures
-      console.error(`[SellerApproval] Error during approval: ${error.message}`)
+      log.error(`[SellerApproval] Error during approval: ${error.message}`)
 
       // If seller was created but auth wasn't updated, we have an orphaned seller
       // Log this for manual intervention as we can't easily delete the seller
       if (createdSeller && !authUpdated) {
-        console.error(`[SellerApproval] CRITICAL: Seller ${createdSeller.id} created but auth not linked. Manual intervention required.`)
+        log.error(`[SellerApproval] CRITICAL: Seller ${createdSeller.id} created but auth not linked. Manual intervention required.`)
       }
 
       throw error
@@ -543,7 +545,7 @@ export class SellerApprovalService {
       sanitizedReason || undefined
     )
 
-    console.log(`[SellerApproval] Request ${requestId} rejected by reviewer ${reviewerId}${sanitizedReason ? `: ${sanitizedReason}` : ""}`)
+    log.info(`[SellerApproval] Request ${requestId} rejected by reviewer ${reviewerId}${sanitizedReason ? `: ${sanitizedReason}` : ""}`)
 
     return {
       id: updatedRequest.id,
@@ -584,7 +586,7 @@ export class SellerApprovalService {
       updatedNote || undefined
     )
 
-    console.log(`[SellerApproval] Generic request ${requestId} approved by reviewer ${reviewerId}`)
+    log.info(`[SellerApproval] Generic request ${requestId} approved by reviewer ${reviewerId}`)
 
     try {
       const customerContact = await this.resolveCustomerContact({
@@ -593,7 +595,7 @@ export class SellerApprovalService {
       })
 
       if (!customerContact?.email) {
-        console.warn(`[SellerApproval] No customer contact found for request ${requestId}`)
+        log.warn(`[SellerApproval] No customer contact found for request ${requestId}`)
       } else {
         const storefrontUrl = process.env.STOREFRONT_URL || process.env.NEXT_PUBLIC_BASE_URL || ""
         const loginUrl = storefrontUrl ? `${storefrontUrl}/account` : ""
@@ -607,10 +609,10 @@ export class SellerApprovalService {
             login_url: loginUrl || undefined,
           },
         })
-        console.log(`[SellerApproval] Customer acceptance notification sent to ${maskEmail(customerContact.email)}`)
+        log.info(`[SellerApproval] Customer acceptance notification sent to ${maskEmail(customerContact.email)}`)
       }
     } catch (notificationError: any) {
-      console.warn(`[SellerApproval] Failed to send customer acceptance notification: ${notificationError.message}`)
+      log.warn(`[SellerApproval] Failed to send customer acceptance notification: ${notificationError.message}`)
     }
 
     return {

--- a/backend/src/shared/seller-profile.ts
+++ b/backend/src/shared/seller-profile.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "./logger"
+const log = createLogger("shared/seller-profile")
 import { MedusaRequest } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
@@ -125,7 +127,7 @@ export const fetchSellerProfile = async ({
         response[field] = sellerMetadata[field]
       }
     } catch (error) {
-      console.warn("[fetchSellerProfile] Failed to load seller metadata:", error)
+      log.warn("[fetchSellerProfile] Failed to load seller metadata:", error)
     }
   }
 

--- a/backend/src/shared/seller-registration.ts
+++ b/backend/src/shared/seller-registration.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "./logger"
+const log = createLogger("shared/seller-registration")
 import { MedusaRequest } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { REQUEST_MODULE } from "../modules/request"
@@ -34,13 +36,13 @@ async function resolveToSellerId(req: MedusaRequest, id: string | null | undefin
       )
       const sellerId = result.rows?.[0]?.seller_id
       if (sellerId) {
-        console.log(`[SellerRegistration] Resolved member ${id} to seller ${sellerId}`)
+        log.info(`[SellerRegistration] Resolved member ${id} to seller ${sellerId}`)
         return sellerId
       }
-      console.warn(`[SellerRegistration] Member ${id} has no associated seller_id`)
+      log.warn(`[SellerRegistration] Member ${id} has no associated seller_id`)
       return null
     } catch (err) {
-      console.error(`[SellerRegistration] Error resolving member to seller:`, err)
+      log.error(`[SellerRegistration] Error resolving member to seller:`, err)
       return null
     }
   }
@@ -162,7 +164,7 @@ export const getSellerRegistrationStatus = async (
         }
       }
 
-      console.warn(
+      log.warn(
         "[GET /auth/seller/registration-status] Seller ID present in token but not found:",
         sellerId
       )
@@ -203,7 +205,7 @@ export const getSellerRegistrationStatus = async (
     if (appMetadata?.seller_id) {
       const seller = await findSellerById(req, String(appMetadata.seller_id))
       if (!seller) {
-        console.warn(
+        log.warn(
           "[GET /auth/seller/registration-status] Seller ID present in auth metadata but not found:",
           appMetadata.seller_id
         )
@@ -222,7 +224,7 @@ export const getSellerRegistrationStatus = async (
     return await checkRequests(req, authIdentityId, authModule)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Unknown error"
-    console.error("[GET /auth/seller/registration-status] Error:", message)
+    log.error("[GET /auth/seller/registration-status] Error:", message)
     return {
       statusCode: 500,
       status: {
@@ -246,7 +248,7 @@ async function findSellerById(req: MedusaRequest, sellerId: string) {
 async function getAuthIdentity(authModule: any, authIdentityId: string) {
   const identities = await authModule.listAuthIdentities({ id: [authIdentityId] })
   if (!identities || identities.length === 0) return null
-  console.log("[Auth identity] Found:", authIdentityId)
+  log.info("[Auth identity] Found:", authIdentityId)
   return identities[0]
 }
 
@@ -265,7 +267,7 @@ async function checkRequests(
       order: { created_at: "DESC" },
     }
   )
-  console.log(
+  log.info(
     `[Requests] Found ${userRequests.length} requests for authIdentityId: ${authIdentityId}`
   )
 
@@ -281,7 +283,7 @@ async function checkRequests(
 
   const latestRequest = userRequests[0]
 
-  console.log(
+  log.info(
     `[Requests] Latest request status: ${latestRequest.status}, id: ${latestRequest.id}`
   )
 
@@ -362,7 +364,7 @@ async function handleAcceptedRequest(
       if (sellerId) {
         const seller = await findSellerById(req, sellerId)
         if (seller) {
-          console.log("[Accepted request] Found seller, updating auth_identity")
+          log.info("[Accepted request] Found seller, updating auth_identity")
           await authModule.updateAuthIdentities([
             { id: authIdentityId, app_metadata: { seller_id: sellerId } },
           ])
@@ -389,7 +391,7 @@ async function handleAcceptedRequest(
       },
     }
   } catch (err: any) {
-    console.error("[Accepted request] Error:", err.message)
+    log.error("[Accepted request] Error:", err.message)
     return {
       statusCode: 200,
       status: {

--- a/backend/src/subscribers/attribute-order-on-placed.ts
+++ b/backend/src/subscribers/attribute-order-on-placed.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/attribute-order-on-placed")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
 import CreatorAttributionService from "../modules/creator-attribution/service"
@@ -115,12 +117,12 @@ export default async function attributeOrderOnPlacedSubscriber({
           )
         }
       } catch (err) {
-        console.error("[attribute-order-on-placed] webhook dispatch failed", err)
+        log.error("[attribute-order-on-placed] webhook dispatch failed", err)
       }
     }
   } catch (err) {
     // Never fail the order placement because attribution failed.
-    console.error(`[attribute-order-on-placed] failed for order ${orderId}:`, err)
+    log.error(`[attribute-order-on-placed] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/customer-created-matrix.ts
+++ b/backend/src/subscribers/customer-created-matrix.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/customer-created-matrix")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { getMatrixService } from "../shared/matrix-service"
@@ -15,17 +17,17 @@ export default async function customerCreatedMatrixHandler({
   const customerId = event.data.id
 
   if (!customerId) {
-    console.warn("[customerCreated Matrix] Event received without customer ID")
+    log.warn("[customerCreated Matrix] Event received without customer ID")
     return
   }
 
-  console.log(`[customerCreated Matrix] Processing customer ${customerId}`)
+  log.info(`[customerCreated Matrix] Processing customer ${customerId}`)
 
   try {
     const matrixService = getMatrixService()
 
     if (!matrixService) {
-      console.log("[customerCreated Matrix] Matrix not configured, skipping")
+      log.info("[customerCreated Matrix] Matrix not configured, skipping")
       return
     }
 
@@ -37,7 +39,7 @@ export default async function customerCreatedMatrixHandler({
     })
 
     if (!customer || !customer.email) {
-      console.warn(`[customerCreated Matrix] Customer ${customerId} not found or has no email`)
+      log.warn(`[customerCreated Matrix] Customer ${customerId} not found or has no email`)
       return
     }
 
@@ -65,13 +67,13 @@ export default async function customerCreatedMatrixHandler({
           metadata: { ...(customer.metadata || {}), mxid },
         })
       } catch (persistError: any) {
-        console.warn(`[customerCreated Matrix] Failed to persist mxid: ${persistError.message}`)
+        log.warn(`[customerCreated Matrix] Failed to persist mxid: ${persistError.message}`)
       }
     }
 
-    console.log(`[customerCreated Matrix] Provisioned Matrix account for customer: ${mxid}`)
+    log.info(`[customerCreated Matrix] Provisioned Matrix account for customer: ${mxid}`)
   } catch (error: any) {
-    console.error(`[customerCreated Matrix] Failed for customer ${customerId}:`, error.message)
+    log.error(`[customerCreated Matrix] Failed for customer ${customerId}:`, error.message)
     // Don't throw - this is a non-critical enhancement
   }
 }

--- a/backend/src/subscribers/emit-blackout-order-placed.ts
+++ b/backend/src/subscribers/emit-blackout-order-placed.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/emit-blackout-order-placed")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { emitBlackoutEvent } from "../lib/blackout-emit"
 import {
@@ -113,7 +115,7 @@ export default async function emitBlackoutOrderPlaced({
       { eventId: `order.created:${orderId}` }
     )
   } catch (err) {
-    console.error(`[emit-blackout-order-placed] failed for order ${orderId}:`, err)
+    log.error(`[emit-blackout-order-placed] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/emit-blackout-order-refund-cancel.ts
+++ b/backend/src/subscribers/emit-blackout-order-refund-cancel.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/emit-blackout-order-refund-cancel")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { emitBlackoutEvent } from "../lib/blackout-emit"
 import {
@@ -98,7 +100,7 @@ export default async function emitBlackoutOrderRefundCancel({
       }
     }
   } catch (err) {
-    console.error(`[emit-blackout-order-refund-cancel] failed for order ${orderId}:`, err)
+    log.error(`[emit-blackout-order-refund-cancel] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/emit-blackout-order-updated.ts
+++ b/backend/src/subscribers/emit-blackout-order-updated.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/emit-blackout-order-updated")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { emitBlackoutEvent } from "../lib/blackout-emit"
 import { resolveBlackoutUserId } from "../lib/blackout-identity"
@@ -48,7 +50,7 @@ export default async function emitBlackoutOrderUpdated({
       { eventId: `order.updated:${orderId}:${status}` }
     )
   } catch (err) {
-    console.error(`[emit-blackout-order-updated] failed for order ${orderId}:`, err)
+    log.error(`[emit-blackout-order-updated] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/fan-out-digital-delivery.ts
+++ b/backend/src/subscribers/fan-out-digital-delivery.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/fan-out-digital-delivery")
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { MARKETPLACE_WEBHOOKS_MODULE } from "../modules/marketplace-webhooks"
@@ -88,7 +90,7 @@ export default async function fanOutDigitalDelivery({
     // the order's seller (or a wildcard) receives the event.
     await webhooks.dispatch("digital_delivery.ready", orderId, payload)
   } catch (err) {
-    console.error(
+    log.error(
       `[fan-out-digital-delivery] failed for digital_product_order ${digitalOrderId}:`,
       err
     )

--- a/backend/src/subscribers/grant-entitlements-on-order-placed.ts
+++ b/backend/src/subscribers/grant-entitlements-on-order-placed.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/grant-entitlements-on-order-placed")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { ENTITLEMENT_MODULE } from "../modules/entitlement"
 import type EntitlementModuleService from "../modules/entitlement/service"
@@ -58,7 +60,7 @@ export default async function grantEntitlementsOnOrderPlaced({
       source_subscription_id: sourceSubscriptionId,
     })
   } catch (err) {
-    console.error(`[grant-entitlements-on-order-placed] failed for order ${orderId}:`, err)
+    log.error(`[grant-entitlements-on-order-placed] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/handle-digital-order.ts
+++ b/backend/src/subscribers/handle-digital-order.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/handle-digital-order")
 import type {
   SubscriberArgs,
   SubscriberConfig,
@@ -15,7 +17,7 @@ async function digitalProductOrderCreatedHandler({
       }
     })
   } catch (error) {
-    console.error(`[digital-order] Failed to fulfill digital order ${data.id}:`, error)
+    log.error(`[digital-order] Failed to fulfill digital order ${data.id}:`, error)
     // Don't throw - subscriber failure shouldn't crash the event bus
   }
 }

--- a/backend/src/subscribers/hawala-order-payment.ts
+++ b/backend/src/subscribers/hawala-order-payment.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/hawala-order-payment")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
@@ -20,10 +22,10 @@ import { emitBlackoutEvent } from "../lib/blackout-emit"
 function centsToDollars(cents: number): number {
   // Sanity check: if value looks like dollars already (has decimals or > $10000), warn
   if (cents !== Math.floor(cents)) {
-    console.warn(`[Hawala] Warning: centsToDollars received non-integer value: ${cents}`)
+    log.warn(`[Hawala] Warning: centsToDollars received non-integer value: ${cents}`)
   }
   if (cents > 0 && cents < 1) {
-    console.warn(`[Hawala] Warning: centsToDollars received value < 1, likely already in dollars: ${cents}`)
+    log.warn(`[Hawala] Warning: centsToDollars received value < 1, likely already in dollars: ${cents}`)
     return cents // Return as-is to avoid double conversion
   }
   return cents / 100
@@ -48,7 +50,7 @@ export default async function hawalaOrderPaymentSubscriber({
   const orderModuleService = container.resolve("order")
 
   const orderId = event.data.id
-  console.log(`[Hawala] Processing payment for order: ${orderId}`)
+  log.info(`[Hawala] Processing payment for order: ${orderId}`)
 
   try {
     // Get order details
@@ -57,14 +59,14 @@ export default async function hawalaOrderPaymentSubscriber({
     })
 
     if (!order) {
-      console.log(`[Hawala] Order not found: ${orderId}`)
+      log.info(`[Hawala] Order not found: ${orderId}`)
       return
     }
 
     // Get or create customer wallet
     const customerId = order.customer_id
     if (!customerId) {
-      console.log(`[Hawala] No customer ID for order: ${orderId}`)
+      log.info(`[Hawala] No customer ID for order: ${orderId}`)
       return
     }
 
@@ -129,7 +131,7 @@ export default async function hawalaOrderPaymentSubscriber({
         creatorSellerId = attribution.creator_seller_id
       }
     } catch (attributionError) {
-      console.warn(`[Hawala] Could not look up creator attribution for order ${orderId}:`, attributionError)
+      log.warn(`[Hawala] Could not look up creator attribution for order ${orderId}:`, attributionError)
     }
 
     // Store the breakdown for this order (for transparency reporting)
@@ -149,7 +151,7 @@ export default async function hawalaOrderPaymentSubscriber({
         order.currency_code
       )
     } catch (breakdownError) {
-      console.warn(`[Hawala] Could not store breakdown for order ${orderId}:`, breakdownError)
+      log.warn(`[Hawala] Could not store breakdown for order ${orderId}:`, breakdownError)
     }
 
     // Check for auto-invest settings
@@ -168,7 +170,7 @@ export default async function hawalaOrderPaymentSubscriber({
       idempotency_key: `order-payment-${orderId}`,
     })
 
-    console.log(`[Hawala] Order ${orderId} processed: ${entries.length} ledger entries created`)
+    log.info(`[Hawala] Order ${orderId} processed: ${entries.length} ledger entries created`)
 
     // §3 bridge: post to the vendor's private ledger room. order.total is in
     // CENTS already, which is exactly the minor-units the contract wants.
@@ -187,7 +189,7 @@ export default async function hawalaOrderPaymentSubscriber({
       { eventId: `ledger.payment_received:${orderId}` }
     )
   } catch (error) {
-    console.error(`[Hawala] Error processing order ${orderId}:`, error)
+    log.error(`[Hawala] Error processing order ${orderId}:`, error)
     // Don't throw - order completion should not fail due to ledger issues
   }
 }

--- a/backend/src/subscribers/hawala-order-refund.ts
+++ b/backend/src/subscribers/hawala-order-refund.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/hawala-order-refund")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { HAWALA_LEDGER_MODULE } from "../modules/hawala-ledger"
 import HawalaLedgerModuleService from "../modules/hawala-ledger/service"
@@ -29,7 +31,7 @@ export default async function hawalaOrderRefundSubscriber({
   const refundAmount = event.data.refund_amount
   const reason = event.data.reason || "Order cancelled"
 
-  console.log(`[Hawala] Processing refund for order: ${orderId}`)
+  log.info(`[Hawala] Processing refund for order: ${orderId}`)
 
   try {
     const refundEntries = await hawalaService.processRefund({
@@ -39,18 +41,18 @@ export default async function hawalaOrderRefundSubscriber({
       idempotency_key: `order-refund-${orderId}`,
     })
 
-    console.log(
+    log.info(
       `[Hawala] Refund for order ${orderId} processed: ` +
       `${refundEntries.length} ledger entries created`
     )
   } catch (error) {
     // Log but don't throw - we don't want to fail the cancellation
     // if the ledger processing has issues
-    console.error(`[Hawala] Error processing refund for order ${orderId}:`, error)
+    log.error(`[Hawala] Error processing refund for order ${orderId}:`, error)
     
     // If no payments found, this order may not have been processed yet
     if ((error as Error).message?.includes("No completed payments found")) {
-      console.log(`[Hawala] Order ${orderId} has no payments to refund - skipping`)
+      log.info(`[Hawala] Order ${orderId} has no payments to refund - skipping`)
       return
     }
   }

--- a/backend/src/subscribers/onboarding-48h-followup.ts
+++ b/backend/src/subscribers/onboarding-48h-followup.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/onboarding-48h-followup")
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { Modules } from "@medusajs/framework/utils"
 import type { IEventBusModuleService } from "@medusajs/framework/types"
@@ -57,7 +59,7 @@ export default async function onboardingFollowup({
   try {
     await webhooks.dispatch("vendor.onboarding.followup_scheduled", seller_id, payload)
   } catch (err) {
-    console.error("[onboarding-48h-followup] webhook dispatch failed", err)
+    log.error("[onboarding-48h-followup] webhook dispatch failed", err)
   }
 }
 

--- a/backend/src/subscribers/order-cycle-order-placed.ts
+++ b/backend/src/subscribers/order-cycle-order-placed.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/order-cycle-order-placed")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { ORDER_CYCLE_MODULE } from "../modules/order-cycle"
@@ -20,7 +22,7 @@ export default async function orderPlacedHandler({
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
   const remoteLink = container.resolve(ContainerRegistrationKeys.REMOTE_LINK)
   
-  console.log(`[Order Cycle Subscriber] Processing order ${orderId}`)
+  log.info(`[Order Cycle Subscriber] Processing order ${orderId}`)
   
   try {
     // Get order with line items
@@ -39,7 +41,7 @@ export default async function orderPlacedHandler({
     const order = orders[0]
     
     if (!order) {
-      console.log(`[Order Cycle Subscriber] Order ${orderId} not found`)
+      log.info(`[Order Cycle Subscriber] Order ${orderId} not found`)
       return
     }
     
@@ -52,14 +54,14 @@ export default async function orderPlacedHandler({
       return
     }
     
-    console.log(`[Order Cycle Subscriber] Order ${orderId} placed in cycle ${orderCycleId}`)
+    log.info(`[Order Cycle Subscriber] Order ${orderId} placed in cycle ${orderCycleId}`)
     
     // Verify the order cycle exists and is valid
     let orderCycle
     try {
       orderCycle = await orderCycleService.retrieveOrderCycle(orderCycleId)
     } catch {
-      console.log(`[Order Cycle Subscriber] Order cycle ${orderCycleId} not found`)
+      log.info(`[Order Cycle Subscriber] Order cycle ${orderCycleId} not found`)
       return
     }
     
@@ -72,10 +74,10 @@ export default async function orderPlacedHandler({
       
       try {
         await orderCycleService.recordSale(orderCycleId, variantId, quantity)
-        console.log(`[Order Cycle Subscriber] Recorded sale: ${quantity}x ${variantId}`)
+        log.info(`[Order Cycle Subscriber] Recorded sale: ${quantity}x ${variantId}`)
       } catch (error) {
         // Product might not be in the cycle - that's okay
-        console.log(`[Order Cycle Subscriber] Could not record sale for ${variantId}:`, error)
+        log.info(`[Order Cycle Subscriber] Could not record sale for ${variantId}:`, error)
       }
     }
     
@@ -89,13 +91,13 @@ export default async function orderPlacedHandler({
           order_cycle_id: orderCycleId,
         },
       })
-      console.log(`[Order Cycle Subscriber] Linked order ${orderId} to cycle ${orderCycleId}`)
+      log.info(`[Order Cycle Subscriber] Linked order ${orderId} to cycle ${orderCycleId}`)
     } catch (error) {
-      console.log(`[Order Cycle Subscriber] Could not link order:`, error)
+      log.info(`[Order Cycle Subscriber] Could not link order:`, error)
     }
     
   } catch (error) {
-    console.error(`[Order Cycle Subscriber] Error processing order ${orderId}:`, error)
+    log.error(`[Order Cycle Subscriber] Error processing order ${orderId}:`, error)
   }
 }
 

--- a/backend/src/subscribers/order-placed.ts
+++ b/backend/src/subscribers/order-placed.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/order-placed")
 ﻿import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { TICKET_BOOKING_MODULE } from "../modules/ticket-booking"
 import TicketBookingModuleService from "../modules/ticket-booking/service"
@@ -69,7 +71,7 @@ export default async function handleOrderPlaced({
     },
   })
   } catch (error) {
-    console.error(`[order-placed] Failed to process order ${data.id}:`, error)
+    log.error(`[order-placed] Failed to process order ${data.id}:`, error)
     // Don't throw - notification failure shouldn't break the order flow
   }
 }

--- a/backend/src/subscribers/password-reset.ts
+++ b/backend/src/subscribers/password-reset.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/password-reset")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { appendPath } from "../shared/url"
 
@@ -14,11 +16,11 @@ export default async function passwordResetHandler({
   const { entity_id: email, token, actor_type } = event.data
 
   if (!email || !token) {
-    console.warn("Password reset event received without email or token")
+    log.warn("Password reset event received without email or token")
     return
   }
 
-  console.log(`[passwordReset subscriber] Processing password reset for ${actor_type}: ${email}`)
+  log.info(`[passwordReset subscriber] Processing password reset for ${actor_type}: ${email}`)
 
   try {
     const notificationModuleService = container.resolve("notification") as any
@@ -51,7 +53,7 @@ export default async function passwordResetHandler({
         baseUrl = getEnvVar("VENDOR_URL") || getEnvVar("VENDOR_PANEL_URL")
         break
       default:
-        console.warn(`Unknown actor_type: ${actorType}, defaulting to storefront`)
+        log.warn(`Unknown actor_type: ${actorType}, defaulting to storefront`)
         baseUrl = getEnvVar("STOREFRONT_URL") || getEnvVar("NEXT_PUBLIC_BASE_URL")
     }
 
@@ -60,9 +62,9 @@ export default async function passwordResetHandler({
 
     // Validate that base URL is set and looks like a valid URL
     if (!baseUrl || !baseUrl.startsWith("http")) {
-      console.error(`[passwordReset subscriber] Missing or invalid base URL for actor_type: ${actorType}.`)
-      console.error(`[passwordReset subscriber] STOREFRONT_URL="${process.env.STOREFRONT_URL}", NEXT_PUBLIC_BASE_URL="${process.env.NEXT_PUBLIC_BASE_URL}"`)
-      console.error(`[passwordReset subscriber] Please set the appropriate environment variable (VENDOR_URL, STOREFRONT_URL, or ADMIN_URL) with a valid URL starting with http:// or https://`)
+      log.error(`[passwordReset subscriber] Missing or invalid base URL for actor_type: ${actorType}.`)
+      log.error(`[passwordReset subscriber] STOREFRONT_URL="${process.env.STOREFRONT_URL}", NEXT_PUBLIC_BASE_URL="${process.env.NEXT_PUBLIC_BASE_URL}"`)
+      log.error(`[passwordReset subscriber] Please set the appropriate environment variable (VENDOR_URL, STOREFRONT_URL, or ADMIN_URL) with a valid URL starting with http:// or https://`)
       return
     }
 
@@ -80,9 +82,9 @@ export default async function passwordResetHandler({
       },
     })
 
-    console.log(`[passwordReset subscriber] Password reset email sent successfully to ${email}`)
+    log.info(`[passwordReset subscriber] Password reset email sent successfully to ${email}`)
   } catch (error) {
-    console.error(`[passwordReset subscriber] Failed to send password reset email to ${email}:`, error)
+    log.error(`[passwordReset subscriber] Failed to send password reset email to ${email}:`, error)
     // Don't throw - notification failure shouldn't break the password reset flow
   }
 }

--- a/backend/src/subscribers/process-refund-reverses-commission.ts
+++ b/backend/src/subscribers/process-refund-reverses-commission.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/process-refund-reverses-commission")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { CREATOR_ATTRIBUTION_MODULE } from "../modules/creator-attribution"
 import CreatorAttributionService from "../modules/creator-attribution/service"
@@ -71,7 +73,7 @@ export default async function processRefundReversesCommission({
           currencyCode: attribution.currency_code,
         })
       } catch (err) {
-        console.error(`[refund-reverses-commission] ledger reversal failed for ${attribution.id}:`, err)
+        log.error(`[refund-reverses-commission] ledger reversal failed for ${attribution.id}:`, err)
       }
     }
 
@@ -101,11 +103,11 @@ export default async function processRefundReversesCommission({
           )
         }
       } catch (err) {
-        console.error("[refund-reverses-commission] webhook dispatch failed", err)
+        log.error("[refund-reverses-commission] webhook dispatch failed", err)
       }
     }
   } catch (err) {
-    console.error(`[refund-reverses-commission] failed for order ${orderId}:`, err)
+    log.error(`[refund-reverses-commission] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/product-created-sales-channel.ts
+++ b/backend/src/subscribers/product-created-sales-channel.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/product-created-sales-channel")
 import {
   SubscriberArgs,
   SubscriberConfig,
@@ -36,7 +38,7 @@ export default async function productCreatedSalesChannelHandler({
     const defaultSalesChannelId = store?.default_sales_channel_id
 
     if (!defaultSalesChannelId) {
-      console.warn(
+      log.warn(
         `[productCreatedSalesChannel] No default sales channel configured for the store`
       )
       return
@@ -67,7 +69,7 @@ export default async function productCreatedSalesChannelHandler({
       },
     })
   } catch (error) {
-    console.error(
+    log.error(
       `[productCreatedSalesChannel] Failed to link product ${productId} to default sales channel:`,
       error
     )

--- a/backend/src/subscribers/progression-order-canceled.ts
+++ b/backend/src/subscribers/progression-order-canceled.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/progression-order-canceled")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PROGRESSION_MODULE } from "../modules/progression"
@@ -42,7 +44,7 @@ export default async function progressionOrderCanceled({
 
     await progression.recomputeAggregates(customerId, query as never)
   } catch (error) {
-    console.error(
+    log.error(
       `[progression-order-canceled] Failed to claw back XP for order ${data.id}:`,
       error
     )

--- a/backend/src/subscribers/progression-order-placed.ts
+++ b/backend/src/subscribers/progression-order-placed.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/progression-order-placed")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PROGRESSION_MODULE } from "../modules/progression"
@@ -44,7 +46,7 @@ export default async function progressionOrderPlaced({
 
     await progression.recomputeAggregates(customerId, query as never)
   } catch (error) {
-    console.error(
+    log.error(
       `[progression-order-placed] Failed to award XP for order ${data.id}:`,
       error
     )

--- a/backend/src/subscribers/progression-vendor-verified.ts
+++ b/backend/src/subscribers/progression-vendor-verified.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/progression-vendor-verified")
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PROGRESSION_MODULE } from "../modules/progression"
@@ -50,7 +52,7 @@ export default async function progressionVendorVerified({
     // Mirror the seller's trust score onto the sheet snapshot.
     await progression.recomputeAggregates(memberId, query as never, sellerId)
   } catch (error) {
-    console.error(
+    log.error(
       `[progression-vendor-verified] Failed for seller ${data.seller_id}:`,
       error
     )

--- a/backend/src/subscribers/revoke-entitlements-on-refund.ts
+++ b/backend/src/subscribers/revoke-entitlements-on-refund.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/revoke-entitlements-on-refund")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { ENTITLEMENT_MODULE } from "../modules/entitlement"
 import type EntitlementModuleService from "../modules/entitlement/service"
@@ -16,7 +18,7 @@ export default async function revokeEntitlementsOnRefund({
   try {
     await service.revokeByOrderId(orderId, "order_refund_or_cancel")
   } catch (err) {
-    console.error(`[revoke-entitlements-on-refund] failed for order ${orderId}:`, err)
+    log.error(`[revoke-entitlements-on-refund] failed for order ${orderId}:`, err)
   }
 }
 

--- a/backend/src/subscribers/seller-created-matrix.ts
+++ b/backend/src/subscribers/seller-created-matrix.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/seller-created-matrix")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { SELLER_MODULE } from "@mercurjs/b2c-core/modules/seller"
 import {
@@ -29,17 +31,17 @@ export default async function sellerCreatedMatrixHandler({
   const sellerId = event.data.id
 
   if (!sellerId) {
-    console.warn("[sellerCreated Matrix] Event received without seller ID")
+    log.warn("[sellerCreated Matrix] Event received without seller ID")
     return
   }
 
-  console.log(`[sellerCreated Matrix] Processing seller ${sellerId}`)
+  log.info(`[sellerCreated Matrix] Processing seller ${sellerId}`)
 
   try {
     const matrixService = getMatrixService()
 
     if (!matrixService) {
-      console.log("[sellerCreated Matrix] Matrix not configured, skipping")
+      log.info("[sellerCreated Matrix] Matrix not configured, skipping")
       return
     }
 
@@ -49,13 +51,13 @@ export default async function sellerCreatedMatrixHandler({
     })
 
     if (!seller || !seller.members || seller.members.length === 0) {
-      console.warn(`[sellerCreated Matrix] Seller ${sellerId} not found or has no members`)
+      log.warn(`[sellerCreated Matrix] Seller ${sellerId} not found or has no members`)
       return
     }
 
     const member = seller.members[0]
     if (!member.email) {
-      console.warn(`[sellerCreated Matrix] Seller member has no email`)
+      log.warn(`[sellerCreated Matrix] Seller member has no email`)
       return
     }
 
@@ -79,9 +81,9 @@ export default async function sellerCreatedMatrixHandler({
       mxid
     )
 
-    console.log(`[sellerCreated Matrix] Provisioned Matrix account and room for vendor: ${mxid}`)
+    log.info(`[sellerCreated Matrix] Provisioned Matrix account and room for vendor: ${mxid}`)
   } catch (error: any) {
-    console.error(`[sellerCreated Matrix] Failed for seller ${sellerId}:`, error.message)
+    log.error(`[sellerCreated Matrix] Failed for seller ${sellerId}:`, error.message)
     // Don't throw - this is a non-critical enhancement
   }
 }

--- a/backend/src/subscribers/seller-created.ts
+++ b/backend/src/subscribers/seller-created.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/seller-created")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { createSellerMetadataWorkflow } from "../workflows/create-seller-metadata"
 import { VendorType } from "../modules/seller-extension/models/seller-metadata"
@@ -19,11 +21,11 @@ export default async function sellerCreatedHandler({
   const sellerId = event.data.id
 
   if (!sellerId) {
-    console.warn("sellerCreated event received without seller ID")
+    log.warn("sellerCreated event received without seller ID")
     return
   }
 
-  console.log(`[sellerCreated subscriber] Checking metadata for seller ${sellerId}`)
+  log.info(`[sellerCreated subscriber] Checking metadata for seller ${sellerId}`)
 
   try {
     // Check if metadata already exists
@@ -36,12 +38,12 @@ export default async function sellerCreatedHandler({
     })
 
     if (existingMetadata && existingMetadata.length > 0) {
-      console.log(`[sellerCreated subscriber] Metadata already exists for seller ${sellerId}, skipping creation`)
+      log.info(`[sellerCreated subscriber] Metadata already exists for seller ${sellerId}, skipping creation`)
       return
     }
 
     // Create metadata if it doesn't exist
-    console.log(`[sellerCreated subscriber] Creating metadata for seller ${sellerId}`)
+    log.info(`[sellerCreated subscriber] Creating metadata for seller ${sellerId}`)
 
     const { result } = await createSellerMetadataWorkflow.run({
       container,
@@ -51,9 +53,9 @@ export default async function sellerCreatedHandler({
       },
     })
 
-    console.log(`[sellerCreated subscriber] Seller metadata created: ${result.seller_metadata.id}`)
+    log.info(`[sellerCreated subscriber] Seller metadata created: ${result.seller_metadata.id}`)
   } catch (error) {
-    console.error(`[sellerCreated subscriber] Failed to create seller metadata for ${sellerId}:`, error)
+    log.error(`[sellerCreated subscriber] Failed to create seller metadata for ${sellerId}:`, error)
     throw error
   }
 }

--- a/backend/src/subscribers/user-created-matrix.ts
+++ b/backend/src/subscribers/user-created-matrix.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/user-created-matrix")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { Modules } from "@medusajs/framework/utils"
 import { getMatrixService } from "../shared/matrix-service"
@@ -15,17 +17,17 @@ export default async function userCreatedMatrixHandler({
   const userId = event.data.id
 
   if (!userId) {
-    console.warn("[userCreated Matrix] Event received without user ID")
+    log.warn("[userCreated Matrix] Event received without user ID")
     return
   }
 
-  console.log(`[userCreated Matrix] Processing user ${userId}`)
+  log.info(`[userCreated Matrix] Processing user ${userId}`)
 
   try {
     const matrixService = getMatrixService()
 
     if (!matrixService) {
-      console.log("[userCreated Matrix] Matrix not configured, skipping")
+      log.info("[userCreated Matrix] Matrix not configured, skipping")
       return
     }
 
@@ -33,7 +35,7 @@ export default async function userCreatedMatrixHandler({
     const user = await userModule.retrieveUser(userId)
 
     if (!user || !user.email) {
-      console.warn(`[userCreated Matrix] User ${userId} not found or has no email`)
+      log.warn(`[userCreated Matrix] User ${userId} not found or has no email`)
       return
     }
 
@@ -53,9 +55,9 @@ export default async function userCreatedMatrixHandler({
       mxid
     )
 
-    console.log(`[userCreated Matrix] Provisioned Matrix account for admin user: ${mxid}`)
+    log.info(`[userCreated Matrix] Provisioned Matrix account for admin user: ${mxid}`)
   } catch (error: any) {
-    console.error(`[userCreated Matrix] Failed for user ${userId}:`, error.message)
+    log.error(`[userCreated Matrix] Failed for user ${userId}:`, error.message)
     // Don't throw - this is a non-critical enhancement
   }
 }

--- a/backend/src/subscribers/vendor-verified.ts
+++ b/backend/src/subscribers/vendor-verified.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../shared/logger"
+const log = createLogger("subscribers/vendor-verified")
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { sendVendorAcceptedNotificationWorkflow } from "../workflows/send-vendor-accepted-notification"
@@ -23,11 +25,11 @@ export default async function vendorVerifiedHandler({
   const sellerId = event.data.seller_id
 
   if (!sellerId) {
-    console.warn("vendor.verified event received without seller_id")
+    log.warn("vendor.verified event received without seller_id")
     return
   }
 
-  console.log(`Processing vendor verification notification for seller ${sellerId}`)
+  log.info(`Processing vendor verification notification for seller ${sellerId}`)
 
   try {
     const query = container.resolve(ContainerRegistrationKeys.QUERY)
@@ -48,7 +50,7 @@ export default async function vendorVerifiedHandler({
     })
 
     if (!sellers || sellers.length === 0) {
-      console.error(`Seller ${sellerId} not found for verification notification`)
+      log.error(`Seller ${sellerId} not found for verification notification`)
       return
     }
 
@@ -58,7 +60,7 @@ export default async function vendorVerifiedHandler({
     const primaryMember = seller.members?.[0]
     
     if (!primaryMember?.email) {
-      console.error(`No member with email found for seller ${sellerId}`)
+      log.error(`No member with email found for seller ${sellerId}`)
       return
     }
 
@@ -73,9 +75,9 @@ export default async function vendorVerifiedHandler({
       },
     })
 
-    console.log(`Vendor acceptance notification sent to ${primaryMember.email}`)
+    log.info(`Vendor acceptance notification sent to ${primaryMember.email}`)
   } catch (error) {
-    console.error(`Failed to send vendor verification notification for ${sellerId}:`, error)
+    log.error(`Failed to send vendor verification notification for ${sellerId}:`, error)
     // Don't throw - notification failure shouldn't break the verification flow
   }
 }

--- a/backend/src/workflows/collective-purchase/process-group-purchase.ts
+++ b/backend/src/workflows/collective-purchase/process-group-purchase.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../shared/logger"
+const log = createLogger("workflows/collective-purchase/process-group-purchase")
 import {
   createWorkflow,
   WorkflowResponse,
@@ -30,7 +32,7 @@ const processGroupPurchaseStep = createStep(
   async (demandPostId, { container }) => {
     if (!demandPostId) return
     // Note: Financial reversals should be handled via refund process
-    console.log(
+    log.info(
       `[process-group-purchase] Compensation triggered for demand post ${demandPostId}. Manual review required for financial reversal.`
     )
   }

--- a/backend/src/workflows/food-distribution/steps/notify-drivers.ts
+++ b/backend/src/workflows/food-distribution/steps/notify-drivers.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("workflows/food-distribution/steps/notify-drivers")
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 import { FOOD_DISTRIBUTION_MODULE } from "../../../modules/food-distribution"
 import type FoodDistributionService from "../../../modules/food-distribution/service"
@@ -62,9 +64,9 @@ export const notifyDriversStep = createStep(
           await deliveryNotifications.notifyNewDeliveryAvailable(notificationData)
         }
 
-        console.log(`[NotifyDrivers] Sent notification for delivery ${input.delivery_id}`)
+        log.info(`[NotifyDrivers] Sent notification for delivery ${input.delivery_id}`)
       } catch (error) {
-        console.error("[NotifyDrivers] Apprise notification failed:", error)
+        log.error("[NotifyDrivers] Apprise notification failed:", error)
         // Don't fail the step if notification fails
       }
     }

--- a/backend/src/workflows/food-distribution/steps/notify-producer.ts
+++ b/backend/src/workflows/food-distribution/steps/notify-producer.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("workflows/food-distribution/steps/notify-producer")
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 import { FOOD_DISTRIBUTION_MODULE } from "../../../modules/food-distribution"
 import type FoodDistributionService from "../../../modules/food-distribution/service"
@@ -56,7 +58,7 @@ export const notifyProducerStep = createStep(
           }, notificationUrls.length > 0 ? notificationUrls : undefined)
         }
       } catch (error) {
-        console.error("[NotifyProducer] Apprise notification failed:", error)
+        log.error("[NotifyProducer] Apprise notification failed:", error)
         // Don't fail the step if notification fails
       }
     }

--- a/backend/src/workflows/launch-product/steps/emit-launch-events.ts
+++ b/backend/src/workflows/launch-product/steps/emit-launch-events.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("workflows/launch-product/steps/emit-launch-events")
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 import MarketplaceWebhooksService from "../../../modules/marketplace-webhooks/service"
 import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../modules/marketplace-webhooks"
@@ -61,7 +63,7 @@ const emitLaunchEventsStep = createStep(
       }
     } catch (err) {
       // Never fail a launch because the outbound channel hiccuped.
-      console.error("[launch] emit-launch-events failed:", (err as Error).message)
+      log.error("[launch] emit-launch-events failed:", (err as Error).message)
     }
 
     return new StepResponse({ emitted: true })

--- a/backend/src/workflows/launch-sponsorship/steps/emit-sponsorship-events.ts
+++ b/backend/src/workflows/launch-sponsorship/steps/emit-sponsorship-events.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("workflows/launch-sponsorship/steps/emit-sponsorship-events")
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 import MarketplaceWebhooksService from "../../../modules/marketplace-webhooks/service"
 import { MARKETPLACE_WEBHOOKS_MODULE } from "../../../modules/marketplace-webhooks"
@@ -49,7 +51,7 @@ const emitSponsorshipEventsStep = createStep(
         { eventId: `sponsorship.created:${data.launch_id}` }
       )
     } catch (err) {
-      console.error(
+      log.error(
         "[sponsorship] emit-sponsorship-events failed:",
         (err as Error).message
       )

--- a/backend/src/workflows/woocommerce-import/steps/fetch-woo-products.ts
+++ b/backend/src/workflows/woocommerce-import/steps/fetch-woo-products.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "../../../shared/logger"
+const log = createLogger("workflows/woocommerce-import/steps/fetch-woo-products")
 import {
   createStep,
   StepResponse,
@@ -30,7 +32,7 @@ const fetchWooProductsStep = createStep(
           variationsMap[product.id] = await client.fetchProductVariations(product.id)
         } catch (error: any) {
           // Log but don't fail - product will be imported as simple
-          console.warn(
+          log.warn(
             `Failed to fetch variations for product ${product.id}: ${error.message}`
           )
         }

--- a/docs/AUDIT_DEBT.md
+++ b/docs/AUDIT_DEBT.md
@@ -25,9 +25,11 @@ Effort key: **S** ≤ 1 day · **M** 2–5 days · **L** > 1 week.
 
 | # | Item | Location | Count | Owner | Effort | Target milestone |
 |---|------|----------|------:|-------|:------:|------------------|
-| LG-1 | Replace `console.*` with structured logger in backend runtime | `backend/src/**` | ~172 | backend team | M | `v1.1.0` |
-| LG-2 | Replace `console.*` in storefront request wrappers and middleware | `storefront/src/lib/config.ts`, `storefront/src/lib/data/*`, `storefront/src/middleware.ts`, `storefront/src/app/[locale]/(main)/page.tsx`, `storefront/src/components/sections/*` | 54 | storefront team | S | `v1.1.0` |
-| LG-3 | Replace `console.*` in admin-panel runtime | `admin-panel/src/lib/query-client.ts`, `admin-panel/src/components/layout/pages/*`, `admin-panel/src/components/data-grid/*` | 27 | admin-panel team | S | `v1.1.0` |
+| ~~LG-1~~ | ~~Replace `console.*` with structured logger in backend runtime~~ — **resolved 2026-06-13**: 503 runtime `console.*` calls across 188 files migrated to the existing structured logger `backend/src/shared/logger.ts` (`createLogger`), whose methods were widened to a console-compatible variadic signature (`(message?, ...rest)`) so the migration was a clean level-mapped swap (`log/info`→`info`, `warn`→`warn`, `error`→`error`, `debug`→`debug`); trailing args fold into structured context and a leading `Error` is promoted to the structured `error` field. Excluded by design: `backend/src/scripts/**` (CLI/seed output) and tests. Backend typecheck 0 errors; unit suite green (733 tests; `posture-a-invariants` updated for the single-string log shape). | `backend/src/**` (excl. `scripts/**`, tests) | 0 | — | — | done |
+| ~~LG-2~~ | ~~Replace `console.*` in storefront request wrappers and middleware~~ — **resolved 2026-06-13**: 56 calls across 34 files routed through the **existing** gated `storefront/src/lib/logger.ts` (`import { logger } from "@/lib/logger"`); imports inserted after any `"use client"`/`"use server"` directive. `pnpm typecheck` + `pnpm lint` clean. | `storefront/src/**` | 0 | — | — | done |
+| ~~LG-3~~ | ~~Replace `console.*` in admin-panel runtime~~ — **resolved 2026-06-13**: new `admin-panel/src/lib/logger.ts` (gated, mirrors the storefront logger); 26 calls across 18 files migrated via `@lib/logger` (the `__tests__` translation spec's diagnostic `console.error` left intentionally). Typecheck 0 errors; ESLint 912 warnings (unchanged baseline, under the 1000 cap). | `admin-panel/src/**` (excl. tests) | 0 | — | — | done |
+
+A single repo-wide regression guard `scripts/check-no-console.mjs` (`pnpm check:no-console`, wired into the CI `lint` job) now fails on any bare `console.*` in runtime code, excluding each app's logger file, `backend/src/scripts/**`, and tests. Chosen over three separate ESLint `no-console` rules to keep one mechanism across all three apps and avoid disturbing admin-panel's `--max-warnings 1000` ratchet (LR-1).
 
 ## Lint/typecheck baseline ratchet
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "check:vendor-completeness": "node scripts/check-vendor-completeness.mjs",
+    "check:no-console": "node scripts/check-no-console.mjs",
     "validate:hermes-prompt": "node scripts/validate-hermes-prompt.mjs",
     "test:hermes-langgraph": "npx --yes -p tsx tsx --test services/ai-orchestrator/langgraph/supervisor-agent.entrypoint.test.ts",
     "test:hermes-vendor-runtime": "npx --yes -p tsx tsx --test services/ai-orchestrator/langgraph/vendor-runtime.contract.test.ts",

--- a/scripts/check-no-console.mjs
+++ b/scripts/check-no-console.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Guard against bare `console.*` creeping back into application runtime code.
+ *
+ * Logging hygiene (audit-debt LG-1/LG-2/LG-3) routes all runtime logging through
+ * each app's gated/structured logger:
+ *   - backend:      backend/src/shared/logger.ts   (`createLogger`)
+ *   - storefront:   storefront/src/lib/logger.ts   (`logger`)
+ *   - admin-panel:  admin-panel/src/lib/logger.ts  (`logger`)
+ *
+ * This check fails CI if a raw `console.<level>(` appears outside of:
+ *   - the sanctioned logger files themselves (the console sink lives there),
+ *   - `backend/src/scripts/**` (one-off CLI/seed scripts where console output IS the UX),
+ *   - test files (`**​/__tests__/**`, `*.spec.*`, `*.test.*`) — diagnostic output.
+ *
+ * Run: `node scripts/check-no-console.mjs`
+ */
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+const TARGETS = [
+  { dir: "backend/src", excludeDirs: ["scripts"], loggerFile: "backend/src/shared/logger.ts" },
+  { dir: "storefront/src", excludeDirs: [], loggerFile: "storefront/src/lib/logger.ts" },
+  { dir: "admin-panel/src", excludeDirs: [], loggerFile: "admin-panel/src/lib/logger.ts" },
+]
+
+const CONSOLE_RE = /\bconsole\.(log|info|warn|error|debug)\b/
+const SRC_EXT = /\.(tsx?|jsx?|mjs|cjs)$/
+const TEST_FILE = /\.(spec|test)\.(tsx?|jsx?)$/
+
+function walk(absDir, excludeTop, files = []) {
+  if (!fs.existsSync(absDir)) return files
+  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue
+    if (entry.name === "__tests__") continue
+    const full = path.join(absDir, entry.name)
+    if (entry.isDirectory()) {
+      if (excludeTop && excludeTop.includes(entry.name)) continue
+      walk(full, null, files) // excludeDirs only apply at the target root
+    } else if (SRC_EXT.test(entry.name) && !TEST_FILE.test(entry.name)) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+const violations = []
+for (const target of TARGETS) {
+  const absDir = path.join(ROOT, target.dir)
+  const loggerAbs = path.join(ROOT, target.loggerFile)
+  for (const file of walk(absDir, target.excludeDirs)) {
+    if (file === loggerAbs) continue
+    const lines = fs.readFileSync(file, "utf8").split("\n")
+    lines.forEach((line, i) => {
+      if (CONSOLE_RE.test(line)) {
+        violations.push(`${path.relative(ROOT, file)}:${i + 1}: ${line.trim()}`)
+      }
+    })
+  }
+}
+
+if (violations.length) {
+  console.error(
+    `Found ${violations.length} bare console.* call(s) in runtime code. ` +
+      `Use the app logger instead (see scripts/check-no-console.mjs header):`
+  )
+  for (const v of violations) console.error(` - ${v}`)
+  process.exit(1)
+}
+
+console.log("No bare console.* in runtime code — logging hygiene check passed.")

--- a/storefront/src/app/[locale]/(main)/collections/page.tsx
+++ b/storefront/src/app/[locale]/(main)/collections/page.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { CollectionsPage } from "@/components/sections/CollectionsPage/CollectionsPage"
 import { Breadcrumbs } from "@/components/atoms"
 import { listCollections } from "@/lib/data/categories"
@@ -17,7 +18,7 @@ export default async function Collections() {
   try {
     collections = await listCollections()
   } catch (error) {
-    console.error("Failed to fetch collections:", error)
+    logger.error("Failed to fetch collections:", error)
   }
 
   const breadcrumbsItems = [

--- a/storefront/src/app/[locale]/(main)/layout.tsx
+++ b/storefront/src/app/[locale]/(main)/layout.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { Footer, Header } from "@/components/organisms"
 import { BackToTop } from "@/components/atoms"
 import { MobileLauncher } from "@/components/molecules"
@@ -24,7 +25,7 @@ export default async function RootLayout({
   try {
     regionIsValid = await checkRegion(locale)
   } catch (error) {
-    console.error("[RootLayout] Region check failed:", error)
+    logger.error("[RootLayout] Region check failed:", error)
   }
 
   if (!regionIsValid) {

--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import {
   BannerSection,
   BlogSection,
@@ -61,7 +62,7 @@ export async function generateMetadata({
       return acc
     }, {})
   } catch (error) {
-    console.error("[generateMetadata] listRegions failed:", error)
+    logger.error("[generateMetadata] listRegions failed:", error)
   }
 
   const title = "Home"

--- a/storefront/src/app/api/gardens/[handle]/route.ts
+++ b/storefront/src/app/api/gardens/[handle]/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -28,7 +29,7 @@ export async function GET(
     const data = await response.json()
     return NextResponse.json({ garden: data.garden })
   } catch (error) {
-    console.error("Failed to fetch garden:", error)
+    logger.error("Failed to fetch garden:", error)
     return NextResponse.json(
       { error: "Failed to fetch garden" },
       { status: 500 }

--- a/storefront/src/app/api/gardens/route.ts
+++ b/storefront/src/app/api/gardens/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -21,7 +22,7 @@ export async function GET() {
     const data = await response.json()
     return NextResponse.json({ gardens: data.gardens || [] })
   } catch (error) {
-    console.error("Failed to fetch gardens:", error)
+    logger.error("Failed to fetch gardens:", error)
     // Return empty array on error
     return NextResponse.json({ gardens: [] })
   }

--- a/storefront/src/app/api/kitchens/route.ts
+++ b/storefront/src/app/api/kitchens/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -25,7 +26,7 @@ export async function GET() {
     const data = await response.json()
     return NextResponse.json({ kitchens: data.kitchens || [] })
   } catch (error) {
-    console.error("Failed to fetch kitchens:", error)
+    logger.error("Failed to fetch kitchens:", error)
     return NextResponse.json({ kitchens: [] })
   }
 }

--- a/storefront/src/app/api/producers/[handle]/route.ts
+++ b/storefront/src/app/api/producers/[handle]/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -29,7 +30,7 @@ export async function GET(
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
-    console.error("Error fetching producer:", error)
+    logger.error("Error fetching producer:", error)
     return NextResponse.json(
       { producer: null, message: "Internal error" },
       { status: 500 }

--- a/storefront/src/app/api/producers/route.ts
+++ b/storefront/src/app/api/producers/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest) {
         response.headers.get("x-correlation-id") ||
         null
 
-      console.error("[storefront/api/producers] Backend request failed", {
+      logger.error("[storefront/api/producers] Backend request failed", {
         status: response.status,
         statusText: response.statusText,
         requestId,
@@ -62,7 +63,7 @@ export async function GET(request: NextRequest) {
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
-    console.error("[storefront/api/producers] Unhandled error", {
+    logger.error("[storefront/api/producers] Unhandled error", {
       backendUrl: `${BACKEND_URL}/store/producers`,
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,

--- a/storefront/src/app/api/products/[id]/provenance/route.ts
+++ b/storefront/src/app/api/products/[id]/provenance/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -29,7 +30,7 @@ export async function GET(
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
-    console.error("Error fetching provenance:", error)
+    logger.error("Error fetching provenance:", error)
     return NextResponse.json(
       { provenance: null, message: "Internal error" },
       { status: 500 }

--- a/storefront/src/app/api/sell-signup/route.ts
+++ b/storefront/src/app/api/sell-signup/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextResponse } from "next/server"
 
 /**
@@ -54,7 +55,7 @@ export async function POST(request: Request) {
   }
 
   if (!BACKEND_URL || !PUBLISHABLE_KEY) {
-    console.warn(
+    logger.warn(
       "[sell-signup] backend not configured; capture not persisted",
       { email: payload.email, store_name: payload.store_name },
     )
@@ -86,7 +87,7 @@ export async function POST(request: Request) {
     }
 
     if (!backendRes.ok) {
-      console.warn("[sell-signup] backend rejected capture", {
+      logger.warn("[sell-signup] backend rejected capture", {
         status: backendRes.status,
         email: payload.email,
       })
@@ -98,7 +99,7 @@ export async function POST(request: Request) {
     const data = await backendRes.json().catch(() => ({ status: "accepted" }))
     return NextResponse.json(data, { status: 202 })
   } catch (err) {
-    console.warn("[sell-signup] backend forward failed", {
+    logger.warn("[sell-signup] backend forward failed", {
       email: payload.email,
       error: err instanceof Error ? err.message : String(err),
     })

--- a/storefront/src/app/api/vendors/route.ts
+++ b/storefront/src/app/api/vendors/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || "http://localhost:9000"
@@ -51,7 +52,7 @@ export async function GET(request: NextRequest) {
         response.headers.get("x-correlation-id") ||
         null
 
-      console.error("[storefront/api/vendors] Backend request failed", {
+      logger.error("[storefront/api/vendors] Backend request failed", {
         status: response.status,
         statusText: response.statusText,
         requestId,
@@ -74,7 +75,7 @@ export async function GET(request: NextRequest) {
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
-    console.error("[storefront/api/vendors] Unhandled error", {
+    logger.error("[storefront/api/vendors] Unhandled error", {
       backendUrl: `${BACKEND_URL}/store/vendors`,
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,

--- a/storefront/src/components/cells/OrderCancel/OrderCancel.tsx
+++ b/storefront/src/components/cells/OrderCancel/OrderCancel.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { Button, Checkbox, Divider } from "@/components/atoms"
 import { Modal } from "@/components/molecules"
@@ -12,7 +13,7 @@ export const OrderCancel = ({ order }: { order: any }) => {
   const [selectedItems, setSelectedItems] = useState<any[]>([])
 
   const handleCancel = () => {
-    console.log("cancel")
+    logger.info("cancel")
   }
 
   const handleSelectItem = (item: any) => {

--- a/storefront/src/components/cells/WishlistButton/WishlistButton.tsx
+++ b/storefront/src/components/cells/WishlistButton/WishlistButton.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { Button } from "@/components/atoms"
 import { HeartFilledIcon, HeartIcon } from "@/icons"
@@ -39,7 +40,7 @@ export const WishlistButton = ({
         reference: "product",
       })
     } catch (error) {
-      console.error(error)
+      logger.error(error)
     } finally {
       setIsWishlistAdding(false)
     }
@@ -48,7 +49,7 @@ export const WishlistButton = ({
   const handleRemoveFromWishlist = async () => {
     const wishlistId = wishlist?.[0]?.id
     if (!wishlistId) {
-      console.error("Cannot remove from wishlist: wishlist ID not found")
+      logger.error("Cannot remove from wishlist: wishlist ID not found")
       return
     }
 
@@ -60,7 +61,7 @@ export const WishlistButton = ({
         product_id: productId,
       })
     } catch (error) {
-      console.error(error)
+      logger.error(error)
     } finally {
       setIsWishlistAdding(false)
     }

--- a/storefront/src/components/molecules/DeliveryCheck/DeliveryCheck.tsx
+++ b/storefront/src/components/molecules/DeliveryCheck/DeliveryCheck.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { useState, useEffect, useCallback } from "react"
 
@@ -90,7 +91,7 @@ export function DeliveryCheck({
       setResult(data)
       onAvailabilityChange?.(data)
     } catch (err) {
-      console.error("Delivery check error:", err)
+      logger.error("Delivery check error:", err)
       setError("Unable to check delivery availability. Please try again.")
       onAvailabilityChange?.(null)
     } finally {

--- a/storefront/src/components/molecules/ProfilePasswordForm/ProfilePasswordForm.tsx
+++ b/storefront/src/components/molecules/ProfilePasswordForm/ProfilePasswordForm.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { Button, Card } from "@/components/atoms"
 import { LabeledInput } from "@/components/cells"
@@ -82,7 +83,7 @@ const Form = ({
           toast.error(res.error || "Something went wrong")
         }
       } catch (err) {
-        console.log(err)
+        logger.info(err)
         return
       }
     }

--- a/storefront/src/components/molecules/ReportListingForm/ReportListingForm.tsx
+++ b/storefront/src/components/molecules/ReportListingForm/ReportListingForm.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { logger } from "@/lib/logger"
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -41,7 +42,7 @@ export const ReportListingForm = ({
   });
 
   const onSubmit = (data: FormData) => {
-    console.log('Form Data:', data);
+    logger.info('Form Data:', data);
   };
 
   return (

--- a/storefront/src/components/molecules/ReportSellerForm/ReportSellerForm.tsx
+++ b/storefront/src/components/molecules/ReportSellerForm/ReportSellerForm.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { logger } from "@/lib/logger"
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -41,7 +42,7 @@ export const ReportSellerForm = ({
   });
 
   const onSubmit = (data: FormData) => {
-    console.log('Form Data:', data);
+    logger.info('Form Data:', data);
   };
 
   return (

--- a/storefront/src/components/sections/CartReview/CartPromotionCode.tsx
+++ b/storefront/src/components/sections/CartReview/CartPromotionCode.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 import { HttpTypes } from "@medusajs/types"
 import { Button, Input } from "@/components/atoms"
 import { Heading, Label } from "@medusajs/ui"
@@ -25,7 +26,7 @@ export default function CartPromotionCode({
       }
       setPromotionCode("")
     } catch (err) {
-      console.log(err)
+      logger.info(err)
     } finally {
       setIsLoading(false)
     }

--- a/storefront/src/components/sections/GardensPage/GardensLandingPage.tsx
+++ b/storefront/src/components/sections/GardensPage/GardensLandingPage.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
@@ -58,7 +59,7 @@ export function GardensLandingPage({ locale }: GardensLandingPageProps) {
           setGardens(data.gardens || [])
         }
       } catch (err) {
-        console.error("Failed to fetch gardens:", err)
+        logger.error("Failed to fetch gardens:", err)
       } finally {
         setLoading(false)
       }

--- a/storefront/src/components/sections/JustJoinedVendors/JustJoinedVendors.tsx
+++ b/storefront/src/components/sections/JustJoinedVendors/JustJoinedVendors.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
@@ -43,7 +44,7 @@ export function JustJoinedVendors() {
         const data = await response.json()
         setVendors(data.vendors || [])
       } catch (error) {
-        console.error("Error fetching recently joined vendors:", error)
+        logger.error("Error fetching recently joined vendors:", error)
       } finally {
         setLoading(false)
       }

--- a/storefront/src/components/sections/KitchensPage/KitchensLandingPage.tsx
+++ b/storefront/src/components/sections/KitchensPage/KitchensLandingPage.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
@@ -87,7 +88,7 @@ export function KitchensLandingPage({ locale }: KitchensLandingPageProps) {
           setKitchens(data.kitchens || [])
         }
       } catch (err) {
-        console.error("Failed to fetch kitchens:", err)
+        logger.error("Failed to fetch kitchens:", err)
       } finally {
         setLoading(false)
       }

--- a/storefront/src/components/sections/OrderReturnSection/OrderReturnSection.tsx
+++ b/storefront/src/components/sections/OrderReturnSection/OrderReturnSection.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { Button } from "@/components/atoms"
 import { UserNavigation } from "@/components/molecules"
@@ -72,7 +73,7 @@ export const OrderReturnSection = ({
     const { order_return_request } = await createReturnRequest(data)
 
     if (!order_return_request.id) {
-      return console.log("Error creating return request")
+      return logger.info("Error creating return request")
     }
 
     router.push(`/user/orders/${order_return_request.id}/request-success`)

--- a/storefront/src/components/sections/ProducersPage/ProducersPage.tsx
+++ b/storefront/src/components/sections/ProducersPage/ProducersPage.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { useState, useEffect, useCallback } from "react"
 import Link from "next/link"
@@ -82,7 +83,7 @@ export function ProducersPage({ locale }: ProducersPageProps) {
       const data = await response.json()
       setProducers(data.producers || [])
     } catch (error) {
-      console.error("Error fetching producers:", error)
+      logger.error("Error fetching producers:", error)
     } finally {
       setLoading(false)
     }

--- a/storefront/src/components/sections/VendorsPage/VendorsPage.tsx
+++ b/storefront/src/components/sections/VendorsPage/VendorsPage.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import { useState, useEffect, useCallback } from "react"
 import Link from "next/link"
@@ -116,7 +117,7 @@ export function VendorsPage({ locale }: VendorsPageProps) {
       const data = await response.json()
       setVendors(data.vendors || [])
     } catch (error) {
-      console.error("Error fetching vendors:", error)
+      logger.error("Error fetching vendors:", error)
     } finally {
       setLoading(false)
     }
@@ -147,7 +148,7 @@ export function VendorsPage({ locale }: VendorsPageProps) {
           setVendors(data.vendors || [])
           setDistanceActive(true)
         } catch (error) {
-          console.error("Error fetching vendors:", error)
+          logger.error("Error fetching vendors:", error)
         } finally {
           setGeolocating(false)
         }

--- a/storefront/src/lib/analytics/events.ts
+++ b/storefront/src/lib/analytics/events.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 export type AnalyticsPayload = Record<string, string | number | boolean | null | undefined>
 
 /**
@@ -220,6 +221,6 @@ export const emitWebsiteEvent = (
   }
 
   if (process.env.NODE_ENV !== "production") {
-    console.info("[analytics]", eventPayload)
+    logger.info("[analytics]", eventPayload)
   }
 }

--- a/storefront/src/lib/data/categories.ts
+++ b/storefront/src/lib/data/categories.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { sdk } from "@/lib/config"
 import { HttpTypes } from "@medusajs/types"
 
@@ -136,7 +137,7 @@ export const listFeaturedCategories = async (limit = 10) => {
     const { categories } = await listCategories({ query: { limit } })
     return categories
   } catch (error) {
-    console.error("Failed to fetch featured categories:", error)
+    logger.error("Failed to fetch featured categories:", error)
     return []
   }
 }

--- a/storefront/src/lib/data/cms-taxonomy.ts
+++ b/storefront/src/lib/data/cms-taxonomy.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { medusaFetch } from "@/lib/config"
 
 export interface CmsType {
@@ -68,7 +69,7 @@ export async function getCmsTaxonomy(): Promise<CmsTaxonomy> {
     )
     return response
   } catch (error) {
-    console.error("Failed to fetch CMS taxonomy:", error)
+    logger.error("Failed to fetch CMS taxonomy:", error)
     // Return empty taxonomy on error
     return {
       taxonomy: [],
@@ -92,7 +93,7 @@ export async function getCmsTypes(): Promise<CmsType[]> {
     )
     return response.types || []
   } catch (error) {
-    console.error("Failed to fetch CMS types:", error)
+    logger.error("Failed to fetch CMS types:", error)
     return []
   }
 }
@@ -111,7 +112,7 @@ export async function getCmsTypeByHandle(handle: string): Promise<CmsType | null
     )
     return response.type || null
   } catch (error) {
-    console.error(`Failed to fetch CMS type ${handle}:`, error)
+    logger.error(`Failed to fetch CMS type ${handle}:`, error)
     return null
   }
 }
@@ -130,7 +131,7 @@ export async function getCmsCategoryByHandle(handle: string): Promise<CmsCategor
     )
     return response.category || null
   } catch (error) {
-    console.error(`Failed to fetch CMS category ${handle}:`, error)
+    logger.error(`Failed to fetch CMS category ${handle}:`, error)
     return null
   }
 }
@@ -155,7 +156,7 @@ export async function getCmsTags(options?: {
     })
     return response.tags || []
   } catch (error) {
-    console.error("Failed to fetch CMS tags:", error)
+    logger.error("Failed to fetch CMS tags:", error)
     return []
   }
 }

--- a/storefront/src/lib/data/customer.ts
+++ b/storefront/src/lib/data/customer.ts
@@ -1,4 +1,5 @@
 "use server"
+import { logger } from "@/lib/logger"
 
 import { medusaFetch, sdk } from "../config"
 import { HttpTypes } from "@medusajs/types"
@@ -127,7 +128,7 @@ function getErrorMessage(error: any): string {
     return error.errors.map((e: any) => e.message || e).join(", ")
   }
   if (typeof error === "string") return error
-  console.error("Unhandled error:", error)
+  logger.error("Unhandled error:", error)
   return "An unexpected error occurred. Please try again."
 }
 
@@ -176,7 +177,7 @@ export async function signup(formData: FormData) {
 
     return customer
   } catch (error) {
-    console.error("Signup error:", error)
+    logger.error("Signup error:", error)
     return getErrorMessage(error)
   }
 }
@@ -202,24 +203,24 @@ export async function login(formData: FormData) {
       : (tokenResponse as any)?.token
 
     if (!token || typeof token !== "string") {
-      console.error("[login] Invalid token response:", tokenResponse)
+      logger.error("[login] Invalid token response:", tokenResponse)
       return "Login failed: Invalid authentication response"
     }
 
-    console.log("[login] Token received, length:", token.length)
+    logger.info("[login] Token received, length:", token.length)
     await setAuthToken(token)
 
     const customerCacheTag = await getCacheTag("customers")
     revalidateTag(customerCacheTag)
   } catch (error) {
-    console.error("Login error:", error)
+    logger.error("Login error:", error)
     return getErrorMessage(error)
   }
 
   try {
     await transferCart()
   } catch {
-    console.warn("Cart transfer failed — continuing login")
+    logger.warn("Cart transfer failed — continuing login")
   }
 }
 

--- a/storefront/src/lib/data/feed.ts
+++ b/storefront/src/lib/data/feed.ts
@@ -1,4 +1,5 @@
 "use server"
+import { logger } from "@/lib/logger"
 
 import { listProducts } from "./products"
 import { HttpTypes } from "@medusajs/types"
@@ -74,7 +75,7 @@ export async function getProductFeed({
       totalCount: response.count,
     }
   } catch (error) {
-    console.error("Error fetching product feed:", error)
+    logger.error("Error fetching product feed:", error)
     return {
       products: [],
       nextPage: null,

--- a/storefront/src/lib/data/matrix.ts
+++ b/storefront/src/lib/data/matrix.ts
@@ -1,4 +1,5 @@
 "use server"
+import { logger } from "@/lib/logger"
 
 import { medusaFetch } from "../config"
 import { getAuthHeaders } from "./cookies"
@@ -36,7 +37,7 @@ export async function getMatrixChatConfig(): Promise<MatrixChatConfig | null> {
 
     return config
   } catch (error) {
-    console.error("[getMatrixChatConfig] Error:", error)
+    logger.error("[getMatrixChatConfig] Error:", error)
     return null
   }
 }
@@ -60,7 +61,7 @@ export async function getMatrixUnread(): Promise<number> {
 
     return result?.unread_count ?? 0
   } catch (error) {
-    console.error("[getMatrixUnread] Error:", error)
+    logger.error("[getMatrixUnread] Error:", error)
     return 0
   }
 }

--- a/storefront/src/lib/data/orders.ts
+++ b/storefront/src/lib/data/orders.ts
@@ -1,4 +1,5 @@
 "use server"
+import { logger } from "@/lib/logger"
 
 import { SellerProps } from "@/types/seller"
 import { medusaFetch, sdk } from "../config"
@@ -74,7 +75,7 @@ export const getReturns = async () => {
   })
     .then((res) => res)
     .catch((err) => {
-      console.error("[getReturns] Failed to fetch returns:", err?.message || err)
+      logger.error("[getReturns] Failed to fetch returns:", err?.message || err)
       return { order_return_requests: [] }
     })
 }
@@ -194,7 +195,7 @@ export const retrieveReturnReasons = async () => {
   })
     .then(({ return_reasons }) => return_reasons)
     .catch((err) => {
-      console.error("[retrieveReturnReasons] Failed to fetch return reasons:", err?.message || err)
+      logger.error("[retrieveReturnReasons] Failed to fetch return reasons:", err?.message || err)
       return []
     })
 }

--- a/storefront/src/lib/helpers/medusa-error.ts
+++ b/storefront/src/lib/helpers/medusa-error.ts
@@ -1,12 +1,13 @@
+import { logger } from "@/lib/logger"
 export default function medusaError(error: any): never {
   if (error.response) {
     // The request was made and the server responded with a status code
     // that falls out of the range of 2xx
     const u = new URL(error.config.url, error.config.baseURL)
-    console.error("Resource:", u.toString())
-    console.error("Response data:", error.response.data)
-    console.error("Status code:", error.response.status)
-    console.error("Headers:", error.response.headers)
+    logger.error("Resource:", u.toString())
+    logger.error("Response data:", error.response.data)
+    logger.error("Status code:", error.response.status)
+    logger.error("Headers:", error.response.headers)
 
     // Extracting the error message from the response data
     const message = error.response.data.message || error.response.data

--- a/storefront/src/middleware.ts
+++ b/storefront/src/middleware.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger"
 import { HttpTypes } from "@medusajs/types"
 import { NextRequest, NextResponse } from "next/server"
 import { detectEmbedContext } from "./lib/runtime/embed-context"
@@ -16,7 +17,7 @@ async function getRegionMap(cacheId: string) {
 
   if (!BACKEND_URL || !PUBLISHABLE_API_KEY) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
+      logger.warn(
         "Middleware.ts: MEDUSA_BACKEND_URL/NEXT_PUBLIC_MEDUSA_BACKEND_URL or NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY missing; skipping dynamic region fetch."
       )
     }
@@ -92,7 +93,7 @@ async function getCountryCode(
     return countryCode
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
-      console.error(
+      logger.error(
         "Middleware.ts: Error getting the country code. Did you set up regions in your Medusa Admin and define a MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL."
       )
     }

--- a/storefront/src/providers/MatrixChatProvider.tsx
+++ b/storefront/src/providers/MatrixChatProvider.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { logger } from "@/lib/logger"
 
 import {
   createContext,
@@ -123,7 +124,7 @@ export const MatrixChatProvider = ({
         setConnectionState(fallbackUrl ? "connecting" : "idle")
       }
     } catch (error) {
-      console.error("[MatrixChatProvider] Failed to fetch config:", error)
+      logger.error("[MatrixChatProvider] Failed to fetch config:", error)
       const fallbackUrl = elementBaseUrl()
       setIsConfigured(Boolean(fallbackUrl))
       setElementUrl(fallbackUrl)


### PR DESCRIPTION
Closes audit-debt LG-1/LG-2/LG-3 — replace raw console.* in runtime code
with each app's structured/gated logger, and add a CI guard against regressions.

- backend (LG-1): 503 calls / 188 files → existing shared/logger.ts. Widened
  its methods to a console-compatible variadic signature so the swap is clean;
  trailing args fold into structured context and a leading Error is promoted to
  the error field. Excludes src/scripts/** (CLI output) and tests.
- storefront (LG-2): 56 calls / 34 files → existing @/lib/logger; imports placed
  after any "use client"/"use server" directive.
- admin-panel (LG-3): new gated @lib/logger; 26 calls / 18 files (test-spec
  diagnostics left intentionally).
- guard: scripts/check-no-console.mjs (pnpm check:no-console) wired into the CI
  lint job; fails on bare console.* outside logger files, backend scripts, tests.
- bookkeeping: strike LG-1/2/3 in docs/AUDIT_DEBT.md; mark the already-shipped
  static internal-link validation follow-up done in TODO_TRACKER.md.

Verified: backend tsc 0 errors + 733 unit tests green; storefront + admin-panel
typecheck clean; storefront lint clean; admin-panel lint 912 warnings (unchanged
baseline, under cap); guard passes.

https://claude.ai/code/session_01SZ9mz4gMaDL4ojWnz1dmKP