### PR TITLE
fix(modules): use underscore module keys so medusa build passes

### DIFF
--- a/backend/src/modules/knowledge-base/index.ts
+++ b/backend/src/modules/knowledge-base/index.ts
@@ -1,7 +1,7 @@
 import { Module } from "@medusajs/framework/utils"
 import KnowledgeBaseService from "./service"
 
-export const KNOWLEDGE_BASE_MODULE = "knowledge-base"
+export const KNOWLEDGE_BASE_MODULE = "knowledge_base"
 
 export default Module(KNOWLEDGE_BASE_MODULE, {
   service: KnowledgeBaseService,

--- a/backend/src/modules/opportunity-engine/index.ts
+++ b/backend/src/modules/opportunity-engine/index.ts
@@ -1,7 +1,7 @@
 import { Module } from "@medusajs/framework/utils"
 import OpportunityEngineService from "./service"
 
-export const OPPORTUNITY_ENGINE_MODULE = "opportunity-engine"
+export const OPPORTUNITY_ENGINE_MODULE = "opportunity_engine"
 
 export default Module(OPPORTUNITY_ENGINE_MODULE, {
   service: OpportunityEngineService,

--- a/backend/src/modules/plugin-registry/index.ts
+++ b/backend/src/modules/plugin-registry/index.ts
@@ -1,7 +1,7 @@
 import { Module } from "@medusajs/framework/utils"
 import PluginRegistryService from "./service"
 
-export const PLUGIN_REGISTRY_MODULE = "plugin-registry"
+export const PLUGIN_REGISTRY_MODULE = "plugin_registry"
 
 export default Module(PLUGIN_REGISTRY_MODULE, {
   service: PluginRegistryService,


### PR DESCRIPTION
## What & why

`medusa build` (and therefore the production Docker image build — the **Build backend** CI job) has been failing on `main` with:

```
Error generating types
Invalid module name "opportunity-engine". Module names must be alpha numeric and may contain an underscore
```

Three modules registered **hyphenated** keys, which Medusa's `validateModuleName` (run during build-time type generation) rejects:

| Module | Before | After |
|---|---|---|
| `modules/opportunity-engine` | `"opportunity-engine"` | `"opportunity_engine"` |
| `modules/knowledge-base` | `"knowledge-base"` | `"knowledge_base"` |
| `modules/plugin-registry` | `"plugin-registry"` | `"plugin_registry"` |

The hyphen was **tolerated at runtime** (the app boots — Playwright/compose CI is green), so only `medusa build` was affected. The build stopped at the first invalid key (`opportunity-engine`); the other two would have failed next.

## Why this is safe
- Only the `*_MODULE` constant **values** change (directory names are untouched).
- Every consumer resolves these modules via the exported constant, so registration and resolution stay consistent.
- No hardcoded string references to the old keys and no module-link files reference them (verified by grep).
- Snake_case matches the existing convention (`asset_graph`, `cms_blueprint`, `listing_type`, `sell_signup`).

## Verification
- `cd backend && pnpm build` → **Backend build completed successfully** (was failing)
- `cd backend && pnpm typecheck` → 0 errors
- `cd backend && pnpm test` (unit) → **733 passed**

This is one of the two pre-existing `main` CI failures; the Trivy FS gate failure is addressed separately.

https://claude.ai/code/session_01SZ9mz4gMaDL4ojWnz1dmKP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ9mz4gMaDL4ojWnz1dmKP)_