### PR TITLE
Reposition homepage around customer, vendor, financials, and mission

### DIFF
--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -192,8 +192,8 @@ export default async function Home({
       <Hero
         variant="mission"
         image="/images/hero/Image.jpg"
-        heading="Shop local vendors. Launch your storefront. Grow community programs."
-        paragraph="A community-commerce marketplace for products, services, subscriptions, events, and local initiatives. Buyers can discover trusted vendors quickly, and sellers get a clear path to launch and manage operations while keeping 97% of every sale."
+        heading="Buy direct from real people. Sell on your own terms. Build community wealth."
+        paragraph="Free Black Market is community-owned commerce for goods, services, local food and CSA, creators, and mutual aid. Shoppers buy directly from verified makers — no middlemen, no markups. Vendors launch fast and keep 97% of every sale, with a flat 3% coalition fee and no listing, monthly, or processing fees passed to you."
         buttons={[
           {
             label: "Explore the Marketplace",
@@ -278,7 +278,8 @@ export default async function Home({
       <section className="px-4 lg:px-8 w-full">
         <div className="rounded-2xl border border-green-200 bg-green-50 p-6 md:p-8">
           <p className="text-sm font-semibold uppercase tracking-wide text-green-700 mb-2">For vendors</p>
-          <h2 className="text-3xl font-semibold text-green-900 mb-4">Everything you can run through one storefront stack.</h2>
+          <h2 className="text-3xl font-semibold text-green-900 mb-2">Everything you can run through one storefront stack.</h2>
+          <p className="text-green-900/80 mb-4 max-w-2xl">Stop renting your business from extractive platforms. Own your customer relationship, sell across every model from one account, and keep 97% of what you earn — no listing, monthly, or processing fees.</p>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 text-sm">
             <div><span className="font-semibold">Products:</span> physical goods, local food, and digital downloads.</div>
             <div><span className="font-semibold">Services:</span> bookings, custom requests, and provider messaging.</div>
@@ -316,8 +317,8 @@ export default async function Home({
 
       <section className="px-4 lg:px-8 w-full">
         <div className="rounded-2xl border p-6 md:p-8 bg-neutral-50">
-          <h2 className="text-2xl md:text-3xl font-semibold mb-2">Vendor economics: simple, clear, predictable</h2>
-          <p className="text-gray-700 mb-4">Transparent Stripe Connect payouts, vendor-controlled fulfillment, and a flat coalition fee.</p>
+          <h2 className="text-2xl md:text-3xl font-semibold mb-2">The financials: you keep 97%</h2>
+          <p className="text-gray-700 mb-4">A flat 3% coalition fee — and that&apos;s it. No listing fees, no monthly subscription, and no payment processing fees passed to you. Transparent Stripe Connect payouts with vendor-controlled fulfillment.</p>
           <div className="grid sm:grid-cols-3 gap-3 mb-4">
             <div className="rounded-lg bg-white p-4 border"><p className="text-sm text-gray-500">Sale</p><p className="text-xl font-semibold">$100.00</p></div>
             <div className="rounded-lg bg-white p-4 border"><p className="text-sm text-gray-500">Coalition fee (3%)</p><p className="text-xl font-semibold">$3.00</p></div>
@@ -325,9 +326,35 @@ export default async function Home({
           </div>
           <details className="mb-4 rounded-lg border bg-white p-4" data-event="pricing_breakdown_expanded">
             <summary className="cursor-pointer font-medium text-gray-900">How this compares to typical channels</summary>
-            <p className="text-sm text-gray-700 mt-2">Many channels stack listing, subscription, and fulfillment charges. Our model stays simple: one transparent 3% coalition fee.</p>
+            <p className="text-sm text-gray-700 mt-2">Etsy, Shopify, Amazon, and delivery apps stack listing fees, monthly subscriptions, ad spend, and fulfillment charges — often 15–30% all-in. Our model stays simple: one transparent 3% coalition fee. Settle through our internal ledger (Coalition Credits) to move value between members with no card processing cost — an internal payment processor is coming soon.</p>
           </details>
           <Link href="/sell" className="text-green-700 font-medium underline">See this in the vendor onboarding guide</Link>
+        </div>
+      </section>
+
+      <section className="px-4 lg:px-8 w-full">
+        <div className="rounded-2xl border p-6 md:p-8">
+          <p className="text-sm font-semibold uppercase tracking-wide text-green-700 mb-2">Our goals</p>
+          <h2 className="text-2xl md:text-3xl font-semibold mb-2">Building community wealth, not extracting it</h2>
+          <p className="text-gray-600 mb-6 max-w-2xl">We&apos;re building the easiest place for communities to earn together — keeping more money local and circulating it among the people who create real value.</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+            <Link href="/gardens" className="rounded-xl border p-4 hover:border-green-400 hover:bg-green-50 transition-colors">
+              <p className="font-semibold mb-1">🥬 Local food &amp; agriculture</p>
+              <p className="text-gray-600">CSA shares, farm boxes, and order cycles that connect growers directly to neighbors.</p>
+            </Link>
+            <Link href="/creators" className="rounded-xl border p-4 hover:border-green-400 hover:bg-green-50 transition-colors">
+              <p className="font-semibold mb-1">🎨 Creators &amp; vendor marketing</p>
+              <p className="text-gray-600">Storefronts, referrals, and audience tools that help makers get discovered and paid.</p>
+            </Link>
+            <Link href="/community-resources" className="rounded-xl border p-4 hover:border-green-400 hover:bg-green-50 transition-colors">
+              <p className="font-semibold mb-1">🤝 Mutual aid &amp; community programs</p>
+              <p className="text-gray-600">Fund fridges, free stores, and local initiatives through transparent, fiscally-sponsored giving.</p>
+            </Link>
+            <Link href="/why-we-exist" className="rounded-xl border p-4 hover:border-green-400 hover:bg-green-50 transition-colors">
+              <p className="font-semibold mb-1">🌍 Why we exist</p>
+              <p className="text-gray-600">Read the full mission, strategy, and how community governance works.</p>
+            </Link>
+          </div>
         </div>
       </section>
 
@@ -342,9 +369,12 @@ export default async function Home({
         </div>
       </section>
 
-      <div className="px-4 lg:px-8 w-full py-12">
+      <section className="px-4 lg:px-8 w-full py-12">
+        <p className="text-sm font-semibold uppercase tracking-wide text-green-700 mb-2">For shoppers</p>
+        <h2 className="text-2xl md:text-3xl font-semibold mb-2">What you get when you buy here</h2>
+        <p className="text-gray-600 mb-8 max-w-2xl">No corporate middlemen marking up the things you buy. You pay fair prices, your money reaches the people who actually made your goods, grew your food, or provided your service — and you can see exactly who they are.</p>
         <ValueProposition />
-      </div>
+      </section>
 
       <BannerSection />
       <ShopByStyleSection />

--- a/storefront/src/app/[locale]/(main)/why-we-exist/page.tsx
+++ b/storefront/src/app/[locale]/(main)/why-we-exist/page.tsx
@@ -20,16 +20,49 @@ export default function WhyWeExistPage() {
       <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 grid gap-5 md:grid-cols-3">
         <article className="rounded-2xl border p-6">
           <h2 className="text-xl font-semibold mb-2">Why 3%</h2>
-          <p className="text-sm text-gray-700">A flat coalition fee keeps costs understandable. Vendors keep 97% of each sale without surprise platform penalties.</p>
+          <p className="text-sm text-gray-700">A flat coalition fee keeps costs understandable. Vendors keep 97% of each sale — no listing, monthly, or payment processing fees passed to them. Settle through our internal ledger (Coalition Credits) and an internal payment processor, coming soon, to keep even more value inside the community.</p>
         </article>
         <article className="rounded-2xl border p-6">
           <h2 className="text-xl font-semibold mb-2">Why community governance</h2>
-          <p className="text-sm text-gray-700">Platform rules should be accountable to the people using the system. Governance is part of product design, not an afterthought.</p>
+          <p className="text-sm text-gray-700">Platform rules should be accountable to the people using the system. Coalitions steer platform-level decisions through petitions and proposals — and because the code is open source, any community that disagrees with the direction has the ultimate exit right: fork it and run it themselves.</p>
         </article>
         <article className="rounded-2xl border p-6">
           <h2 className="text-xl font-semibold mb-2">What problem we solve</h2>
-          <p className="text-sm text-gray-700">Most commerce tools optimize for platform extraction. We optimize for producer earnings, local resilience, and trust.</p>
+          <p className="text-sm text-gray-700">Most commerce tools optimize for platform extraction — renting your business back to you through fees, ads, and customer lock-in. We optimize for producer earnings, local resilience, and trust, so members own infrastructure instead of paying rent to extractive intermediaries.</p>
         </article>
+      </section>
+
+      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
+        <h2 className="text-2xl md:text-3xl font-bold mb-3">More than a marketplace: a cooperative economic substrate</h2>
+        <p className="text-gray-700 mb-6 max-w-3xl">Our goal is to be the easiest place on the internet for communities to earn together. Beneath the storefront sits shared infrastructure that records every economic event — a marketplace sale, a CSA delivery, a creator reward, a logistics fee, a transfer between members — and settles it transparently.</p>
+        <div className="grid gap-5 md:grid-cols-2">
+          <article className="rounded-2xl border p-6">
+            <h3 className="text-lg font-semibold mb-2">Coalition Credits settlement</h3>
+            <p className="text-sm text-gray-700">A shared settlement layer that pays creators and vendors across the ecosystem and settles obligations between coalition members — value stays in the community.</p>
+          </article>
+          <article className="rounded-2xl border p-6">
+            <h3 className="text-lg font-semibold mb-2">Order Cycles &amp; CSA share boxes</h3>
+            <p className="text-sm text-gray-700">Time-bounded ordering primitives built for local food: group buys, farm shares, and recurring boxes that connect growers directly to neighbors.</p>
+          </article>
+          <article className="rounded-2xl border p-6">
+            <h3 className="text-lg font-semibold mb-2">Demand pools &amp; bounties</h3>
+            <p className="text-sm text-gray-700">Communities pool demand and fund the work they need — from creative projects to local services — with milestone-based, escrowed payouts.</p>
+          </article>
+          <article className="rounded-2xl border p-6">
+            <h3 className="text-lg font-semibold mb-2">Verified vendors &amp; open transparency</h3>
+            <p className="text-sm text-gray-700">Vendor verification provides real trust signals, and the open-source codebase makes how the system works — and where money goes — publicly auditable.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
+        <h2 className="text-2xl md:text-3xl font-bold mb-3">Who we build for</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 text-sm">
+          <div className="rounded-2xl border p-5"><p className="font-semibold mb-1">Shoppers</p><p className="text-gray-700">Buy direct from verified makers at fair prices — no middlemen, no markups.</p></div>
+          <div className="rounded-2xl border p-5"><p className="font-semibold mb-1">Producers &amp; agriculture</p><p className="text-gray-700">Growers and food producers reach neighbors through CSA shares and order cycles.</p></div>
+          <div className="rounded-2xl border p-5"><p className="font-semibold mb-1">Creators &amp; vendors</p><p className="text-gray-700">Own your storefront, audience, and referrals — and keep 97% of every sale.</p></div>
+          <div className="rounded-2xl border p-5"><p className="font-semibold mb-1">Mutual aid &amp; organizers</p><p className="text-gray-700">Run community programs and route giving transparently through a fiscal sponsor.</p></div>
+        </div>
       </section>
 
       <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">

--- a/storefront/src/components/molecules/ConversionCopy/ConversionCopy.tsx
+++ b/storefront/src/components/molecules/ConversionCopy/ConversionCopy.tsx
@@ -129,7 +129,8 @@ export const ProducerPriceExplanation = ({
     <span className="font-medium text-green-700">
       {producerEarnings}% goes to the producer.
     </span>
-    {" "}{platformFee}% coalition fee keeps the marketplace running.
+    {" "}A flat {platformFee}% coalition fee keeps the marketplace running — no listing,
+    monthly, or payment processing fees passed to vendors.
   </div>
 )
 

--- a/storefront/src/components/sections/FeeBreakdown.tsx
+++ b/storefront/src/components/sections/FeeBreakdown.tsx
@@ -28,16 +28,15 @@ const platforms: Platform[] = [
     icon: "🌿",
     calcFees: (price) => {
       const commission = price * 0.03
-      const processing = price * 0.029 + 0.3
-      return { commission, processing, ads: 0, fulfillment: 0, listing: 0, other: 0, total: commission + processing }
+      return { commission, processing: 0, ads: 0, fulfillment: 0, listing: 0, other: 0, total: commission }
     },
     breakdown: [
       "3% marketplace commission",
-      "2.9% + $0.30 Stripe processing",
+      "No payment processing fees passed to you",
       "No listing fees",
       "No mandatory ads",
       "No monthly subscription",
-      "Community-owned cooperative",
+      "Internal ledger settlement (Coalition Credits) — internal processor coming soon",
     ],
     verdict: "COOPERATIVE",
   },


### PR DESCRIPTION
Restructure the homepage and supporting copy so the site accurately
reflects what the repo actually does:

- Hero and a new "For shoppers" section frame the problems FBM solves
  for customers (buy direct from verified makers, no middlemen/markups).
- "For vendors" block adds the problems-solved angle (own your customer,
  one stack, keep 97%, no listing/monthly/processing fees).
- Vendor economics restated accurately: flat 3% coalition fee, no
  processing fees passed to vendors, internal ledger (Coalition Credits)
  settlement and internal payment processor coming soon.
- New goals & strategy strip covering agriculture/CSA, creators/vendor
  marketing, and mutual aid, linking to existing routes.
- Expand /why-we-exist with the full mission and cooperative-substrate
  strategy (Coalition Credits, Order Cycles/CSA, demand pools,
  governance + fork rights, audience pillars).
- Align FeeBreakdown comparison and shared ConversionCopy with the
  3%/no-processing model.

https://claude.ai/code/session_01EEMu3ovUSvvzoWAENHTEN1