### PR TITLE
Add FBM Connect SDK and "My Website" vendor panel for commerce anywhere

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -195,6 +195,29 @@ NEXT_PUBLIC_VENDOR_URL=https://vendor.freeblackmarket.com
 
 
 # =============================================================================
+# FBM Sites — "commerce anywhere" (vendor "My Website" tab)
+# =============================================================================
+# Public base URL the embedded Connect SDK (connect.js) calls. Used to build the
+# copy-paste snippet shown to vendors. Defaults to NEXT_PUBLIC_MEDUSA_BACKEND_URL.
+PUBLIC_BACKEND_URL=https://api.freeblackmarket.com
+# Public storefront origin that hosts /connect.js and the product pages.
+STOREFRONT_URL=https://freeblackmarket.com
+# Wildcard host launched vendor sites are served under: {handle}.${SITES_DOMAIN}
+SITES_DOMAIN=sites.freeblackmarket.com
+#
+# --- Mode 2 (Launch) provisioning ---
+# Leave these blank to disable one-click Launch: the panel falls back to
+# Connect-only and POST /vendor/website/launch returns 501 (Not Configured).
+# GitHub token (PAT or GitHub App token) with `repo` + `workflow` scope on the org.
+GITHUB_TOKEN=
+# GitHub org that owns the provisioned vendor-site repositories.
+GITHUB_ORG=Blackmarket-coa
+# Template repo (must be marked "Template repository") new sites are generated
+# from. See templates/fbm-site-template/README.md.
+SITE_TEMPLATE_REPO=Blackmarket-coa/fbm-site-template
+
+
+# =============================================================================
 # Admin Panel (Vite)
 # =============================================================================
 VITE_MEDUSA_BASE=/

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -59,6 +59,26 @@ const PostVendorSellerExtensionsBodySchema = z.object({
   enabled_extensions: z.array(z.string()).nullable(),
 });
 
+/**
+ * "My Website" (Connect mode) — save the bare hostnames the vendor embeds the
+ * Connect SDK on. We normalize/validate hostnames in the route handler; here we
+ * just enforce the array-of-strings shape.
+ */
+const PostVendorWebsiteBodySchema = z.object({
+  connect_domains: z.array(z.string()).max(50).nullable().optional(),
+});
+
+/**
+ * "My Website" (Launch mode) — provision a standardized FBM-hosted site.
+ * The subdomain is optional; when omitted the vendor handle is used.
+ */
+const PostVendorWebsiteLaunchBodySchema = z.object({
+  subdomain: z
+    .string()
+    .regex(/^[a-z0-9-]{2,63}$/i, "subdomain must be 2-63 chars: a-z, 0-9, -")
+    .optional(),
+});
+
 const PostVendorHermesRuntimeBodySchema = z.object({
   tool_call: z.object({
     action: z.string().min(1),
@@ -462,6 +482,34 @@ function adminCorsMiddleware(
 }
 
 /**
+ * Public Store CORS Middleware
+ *
+ * The FBM Store API (`/store/vendors` and `/store/vendors/:handle`) is the
+ * public, website-agnostic contract that any third-party site embeds via the
+ * Connect SDK (connect.js). Those sites have arbitrary origins that will never
+ * appear in STORE_CORS, so we reflect the request origin and keep the endpoints
+ * open + read-only (no credentials, so there is no `*`-with-credentials hazard).
+ * The `cors` package also answers preflight OPTIONS for us.
+ */
+function publicStoreCorsMiddleware(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction,
+) {
+  return cors({
+    origin: true, // reflect any origin — public read-only catalog
+    credentials: false,
+    methods: ["GET", "OPTIONS"],
+    allowedHeaders: [
+      "Content-Type",
+      "X-Publishable-API-Key",
+      "x-publishable-api-key",
+    ],
+    maxAge: 86400,
+  })(req, res, next);
+}
+
+/**
  * Security Headers Middleware
  * Applies security headers to all routes
  */
@@ -545,6 +593,18 @@ export default defineMiddlewares({
       matcher: "/store/**",
       method: "GET",
       middlewares: [stripQueryParamForAdminMiddleware],
+    },
+    // ============================================================
+    // FBM Store API — public, website-agnostic vendor catalog
+    // ============================================================
+    // Open read-only CORS so any third-party site can embed the Connect SDK.
+    {
+      matcher: "/store/vendors",
+      middlewares: [publicStoreCorsMiddleware],
+    },
+    {
+      matcher: "/store/vendors/**",
+      middlewares: [publicStoreCorsMiddleware],
     },
     // ============================================================
     // CSRF: reject forged cross-site, cookie-authenticated writes
@@ -754,6 +814,25 @@ export default defineMiddlewares({
     {
       matcher: "/vendor/me",
       middlewares: [authenticate("seller", "bearer")],
+    },
+    // "My Website" tab — Connect settings + Launch provisioning
+    {
+      matcher: "/vendor/website",
+      middlewares: [authenticate("seller", "bearer")],
+    },
+    {
+      matcher: "/vendor/website",
+      method: "POST",
+      middlewares: [validateAndTransformBody(PostVendorWebsiteBodySchema)],
+    },
+    {
+      matcher: "/vendor/website/launch",
+      middlewares: [authenticate("seller", "bearer")],
+    },
+    {
+      matcher: "/vendor/website/launch",
+      method: "POST",
+      middlewares: [validateAndTransformBody(PostVendorWebsiteLaunchBodySchema)],
     },
     {
       matcher: "/vendor/hermes/runtime",

--- a/backend/src/api/store/vendors/[handle]/route.ts
+++ b/backend/src/api/store/vendors/[handle]/route.ts
@@ -1,0 +1,279 @@
+import { createLogger } from "../../../../shared/logger";
+const log = createLogger("api/store/vendors/handle");
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+/**
+ * GET /store/vendors/:handle  —  FBM Store API (public, website-agnostic)
+ * ----------------------------------------------------------------------
+ * The clean public contract any website can read to render a vendor's
+ * storefront. No auth, no publishable key required — this is the single
+ * endpoint the FBM Connect SDK (connect.js) and the launched site template
+ * are built on.
+ *
+ * Query params (all optional):
+ *   include          csv of "vendor,products,events"   (default: all)
+ *   limit_products   max products to return             (default: 24, max 100)
+ *   limit_events     max events to return               (default: 12, max 50)
+ *   currency_code    preferred price currency           (default: "usd")
+ *
+ * Response shape (stable):
+ *   {
+ *     vendor:   { id, handle, name, description, photo, vendor_type, verified,
+ *                 rating, review_count, website_url, social_links, url } | null,
+ *     products: [{ id, title, handle, subtitle, description, thumbnail,
+ *                  price: { amount, currency_code } | null, variants[], url }],
+ *     events:   [{ id, title, handle, thumbnail, dates, venue,
+ *                  price: { amount, currency_code } | null, url }],
+ *     _meta:    { handle, currency_code, storefront_url, checkout_url,
+ *                 generated_at }
+ *   }
+ */
+
+type Price = { amount: number; currency_code: string } | null;
+
+const DEFAULT_REGION = (
+  process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
+).toLowerCase();
+
+function storefrontBase(): string {
+  // Backend may be reached at api.* while the storefront lives at the apex.
+  const explicit =
+    process.env.STOREFRONT_URL || process.env.NEXT_PUBLIC_BASE_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+  return "https://freeblackmarket.com";
+}
+
+/** Cheapest price across a product's variants for the requested currency. */
+function cheapestPrice(variants: any[], currency: string): Price {
+  const wanted = currency.toLowerCase();
+  let best: { amount: number; currency_code: string } | null = null;
+  for (const v of variants || []) {
+    const prices: any[] = v?.prices || [];
+    // Prefer an exact currency match, else fall back to the first price.
+    const match =
+      prices.find((p) => String(p?.currency_code).toLowerCase() === wanted) ||
+      prices[0];
+    if (match && typeof match.amount === "number") {
+      if (!best || match.amount < best.amount) {
+        best = { amount: match.amount, currency_code: match.currency_code };
+      }
+    }
+  }
+  return best;
+}
+
+function clampInt(value: unknown, fallback: number, max: number): number {
+  const n = parseInt(String(value ?? ""), 10);
+  if (isNaN(n) || n <= 0) return fallback;
+  return Math.min(n, max);
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const query = req.scope.resolve("query");
+  const handle = req.params.handle;
+
+  const include = String(req.query.include || "vendor,products,events")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  const wantVendor = include.includes("vendor");
+  const wantProducts = include.includes("products");
+  const wantEvents = include.includes("events");
+
+  const currency_code = String(req.query.currency_code || "usd").toLowerCase();
+  const limitProducts = clampInt(req.query.limit_products, 24, 100);
+  const limitEvents = clampInt(req.query.limit_events, 12, 50);
+
+  const storefront = storefrontBase();
+  const productUrl = (h: string) =>
+    `${storefront}/${DEFAULT_REGION}/products/${h}`;
+
+  try {
+    // 1) Resolve the seller by its unique handle (slug).
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: [
+        "id",
+        "name",
+        "handle",
+        "description",
+        "photo",
+        "email",
+        "created_at",
+      ],
+      filters: { handle } as any,
+    });
+    const seller = sellers?.[0];
+
+    if (!seller) {
+      return res.status(404).json({
+        message: `No vendor found for handle "${handle}"`,
+        type: "not_found",
+      });
+    }
+
+    // 2) Seller metadata (vendor type, trust signals, public links).
+    let meta: any = null;
+    try {
+      const { data: metaRows } = await query.graph({
+        entity: "seller_metadata",
+        fields: [
+          "vendor_type",
+          "verified",
+          "featured",
+          "rating",
+          "review_count",
+          "website_url",
+          "social_links",
+        ],
+        filters: { seller_id: seller.id },
+      });
+      meta = metaRows?.[0] || null;
+    } catch (err) {
+      log.warn(`seller_metadata lookup failed for ${seller.id}`, err);
+    }
+
+    const vendor = wantVendor
+      ? {
+          id: seller.id,
+          handle: seller.handle,
+          name: seller.name,
+          description: seller.description ?? null,
+          photo: seller.photo ?? null,
+          vendor_type: meta?.vendor_type ?? null,
+          verified: !!meta?.verified,
+          featured: !!meta?.featured,
+          rating: meta?.rating ?? null,
+          review_count: meta?.review_count ?? 0,
+          website_url: meta?.website_url ?? null,
+          social_links: meta?.social_links ?? null,
+          url: `${storefront}/${DEFAULT_REGION}/sellers/${seller.handle}`,
+          created_at: seller.created_at,
+        }
+      : undefined;
+
+    // 3) Published products for this seller (with variant prices).
+    let products: any[] = [];
+    if (wantProducts) {
+      try {
+        const { data: rows } = await query.graph({
+          entity: "product",
+          fields: [
+            "id",
+            "title",
+            "subtitle",
+            "handle",
+            "thumbnail",
+            "description",
+            "status",
+            "variants.id",
+            "variants.title",
+            "variants.prices.amount",
+            "variants.prices.currency_code",
+          ],
+          filters: {
+            // The "seller.id" join key is resolved at runtime; the typed
+            // RemoteQueryFilters<"product"> doesn't model it.
+            "seller.id": seller.id,
+            status: "published",
+          } as any,
+          pagination: { take: limitProducts },
+        });
+        products = (rows || []).map((p: any) => ({
+          id: p.id,
+          title: p.title,
+          subtitle: p.subtitle ?? null,
+          handle: p.handle,
+          description: p.description ?? null,
+          thumbnail: p.thumbnail ?? null,
+          price: cheapestPrice(p.variants, currency_code),
+          variants: (p.variants || []).map((v: any) => ({
+            id: v.id,
+            title: v.title,
+            price: cheapestPrice([v], currency_code),
+          })),
+          url: productUrl(p.handle),
+        }));
+      } catch (err) {
+        log.warn(`product lookup failed for ${seller.id}`, err);
+      }
+    }
+
+    // 4) Events (ticket products) for this seller — best effort.
+    let events: any[] = [];
+    if (wantEvents) {
+      try {
+        const { data: ticketRows } = await query.graph({
+          entity: "ticket_product",
+          fields: ["id", "product_id", "dates", "venue.name", "venue.address"],
+          filters: { seller_id: seller.id } as any,
+          pagination: { take: limitEvents },
+        });
+
+        const ticketProducts = ticketRows || [];
+        const productIds = ticketProducts
+          .map((t: any) => t.product_id)
+          .filter(Boolean);
+
+        // Hydrate event titles / images / prices from the linked products.
+        const productById = new Map<string, any>();
+        if (productIds.length) {
+          const { data: eventProducts } = await query.graph({
+            entity: "product",
+            fields: [
+              "id",
+              "title",
+              "handle",
+              "thumbnail",
+              "variants.prices.amount",
+              "variants.prices.currency_code",
+            ],
+            filters: { id: productIds } as any,
+          });
+          for (const ep of eventProducts || []) {
+            productById.set(ep.id, ep);
+          }
+        }
+
+        events = ticketProducts.map((t: any) => {
+          const p = productById.get(t.product_id);
+          return {
+            id: t.id,
+            title: p?.title ?? "Event",
+            handle: p?.handle ?? null,
+            thumbnail: p?.thumbnail ?? null,
+            dates: t.dates ?? [],
+            venue: t.venue
+              ? { name: t.venue.name, address: t.venue.address ?? null }
+              : null,
+            price: p ? cheapestPrice(p.variants, currency_code) : null,
+            url: p?.handle ? productUrl(p.handle) : null,
+          };
+        });
+      } catch (err) {
+        // Ticketing is optional; never fail the whole response on its account.
+        log.warn(`event lookup failed for ${seller.id}`, err);
+        events = [];
+      }
+    }
+
+    return res.json({
+      vendor,
+      products: wantProducts ? products : undefined,
+      events: wantEvents ? events : undefined,
+      _meta: {
+        handle: seller.handle,
+        currency_code,
+        storefront_url: storefront,
+        checkout_url: `${storefront}/${DEFAULT_REGION}/cart`,
+        generated_at: new Date().toISOString(),
+      },
+    });
+  } catch (error: any) {
+    log.error(`Failed to build vendor storefront for "${handle}"`, error);
+    return res.status(500).json({
+      message: "Failed to load vendor",
+      type: "server_error",
+    });
+  }
+}

--- a/backend/src/api/vendor/website/launch/route.ts
+++ b/backend/src/api/vendor/website/launch/route.ts
@@ -1,0 +1,134 @@
+import { createLogger } from "../../../../shared/logger";
+const log = createLogger("api/vendor/website/launch");
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { requireSellerId } from "../../../../shared";
+import {
+  createSellerMetadataRecord,
+  updateSellerMetadataRecord,
+} from "../../../../modules/seller-extension/metadata-service";
+import {
+  isLaunchConfigured,
+  provisionSite,
+} from "../../../../shared/site-provisioning";
+import { serializeWebsite } from "../../../../shared/website-config";
+
+type MetaRow = {
+  id: string;
+  connect_domains: string[] | null;
+  site_status: string | null;
+  site_url: string | null;
+  site_repo: string | null;
+};
+
+/**
+ * POST /vendor/website/launch
+ *
+ * Provision a standardized FBM-hosted site for the vendor (Mode 2 — Launch).
+ * Creates a repo from the GitHub template and kicks its configure workflow,
+ * then records the provisioning state on seller_metadata.
+ *
+ * Degrades gracefully: returns 501 when the Launch flow isn't configured for
+ * this deployment (no GitHub token/org/template), so the panel can keep the
+ * button disabled with an explanation rather than erroring.
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+) {
+  const sellerId = await requireSellerId(req, res);
+  if (!sellerId) return;
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const sellerExtension = req.scope.resolve("sellerExtension");
+
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields: ["id", "handle"],
+    filters: { id: sellerId },
+  });
+  const seller = sellers?.[0] as { id: string; handle: string } | undefined;
+  if (!seller?.handle) {
+    return res
+      .status(404)
+      .json({ message: "Seller not found", type: "not_found" });
+  }
+
+  if (!isLaunchConfigured()) {
+    return res.status(501).json({
+      message:
+        "Site Launch isn't enabled on this deployment. You can still use Connect to embed your store on an existing site.",
+      type: "not_implemented",
+    });
+  }
+
+  const body = (req.body || {}) as { subdomain?: string };
+  const subdomain = (body.subdomain || seller.handle)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  const { data: metaRows } = await query.graph({
+    entity: "seller_metadata",
+    fields: ["id", "connect_domains", "site_status", "site_url", "site_repo"],
+    filters: { seller_id: sellerId },
+  });
+
+  // Resolve the metadata row id exactly once (creating it if absent) so every
+  // subsequent write is an idempotent update — never a second insert, which
+  // would violate the unique seller_id constraint.
+  let metaId = (metaRows?.[0] as MetaRow | undefined)?.id;
+  if (!metaId) {
+    const created = (await createSellerMetadataRecord(sellerExtension as any, [
+      { seller_id: sellerId, site_status: "provisioning" },
+    ])) as Array<{ id: string }> | { id: string };
+    metaId = Array.isArray(created) ? created[0]?.id : created?.id;
+  }
+
+  const persist = async (fields: Record<string, unknown>) => {
+    if (!metaId) return;
+    await updateSellerMetadataRecord(sellerExtension as any, [
+      { id: metaId, ...fields },
+    ]);
+  };
+
+  try {
+    await persist({ site_status: "provisioning" });
+
+    const result = await provisionSite({ handle: seller.handle, subdomain });
+
+    await persist({
+      site_status: "provisioning",
+      site_url: result.url,
+      site_repo: result.repo,
+    });
+
+    const { data: refreshed } = await query.graph({
+      entity: "seller_metadata",
+      fields: ["connect_domains", "site_status", "site_url", "site_repo"],
+      filters: { seller_id: sellerId },
+    });
+
+    return res.status(202).json({
+      launched: true,
+      website: serializeWebsite(
+        seller.handle,
+        (refreshed?.[0] as MetaRow) || null,
+      ),
+    });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    log.error(
+      `[POST /vendor/website/launch] failed for ${seller.handle}:`,
+      msg,
+    );
+    await persist({ site_status: "failed" }).catch(() => {});
+    return res.status(502).json({
+      message: "Site provisioning failed. Please try again in a moment.",
+      type: "provisioning_error",
+    });
+  }
+}

--- a/backend/src/api/vendor/website/route.ts
+++ b/backend/src/api/vendor/website/route.ts
@@ -1,0 +1,124 @@
+import { createLogger } from "../../../shared/logger";
+const log = createLogger("api/vendor/website");
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { requireSellerId } from "../../../shared";
+import {
+  createSellerMetadataRecord,
+  updateSellerMetadataRecord,
+} from "../../../modules/seller-extension/metadata-service";
+import { normalizeDomains } from "../../../shared/site-provisioning";
+import { serializeWebsite } from "../../../shared/website-config";
+
+type SellerRow = { id: string; handle: string };
+type MetaRow = {
+  id: string;
+  connect_domains: string[] | null;
+  site_status: string | null;
+  site_url: string | null;
+  site_repo: string | null;
+};
+
+async function loadContext(req: AuthenticatedMedusaRequest, sellerId: string) {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+
+  const { data: sellers } = await query.graph({
+    entity: "seller",
+    fields: ["id", "handle"],
+    filters: { id: sellerId },
+  });
+  const seller = sellers?.[0] as SellerRow | undefined;
+
+  const { data: metaRows } = await query.graph({
+    entity: "seller_metadata",
+    fields: ["id", "connect_domains", "site_status", "site_url", "site_repo"],
+    filters: { seller_id: sellerId },
+  });
+  const meta = (metaRows?.[0] as MetaRow | undefined) || null;
+
+  return { seller, meta };
+}
+
+/**
+ * GET /vendor/website
+ *
+ * Returns the vendor's "My Website" configuration: the ready-to-paste Connect
+ * snippet, the whitelisted domains, and the Launch status.
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+) {
+  const sellerId = await requireSellerId(req, res);
+  if (!sellerId) return;
+
+  try {
+    const { seller, meta } = await loadContext(req, sellerId);
+    if (!seller) {
+      return res
+        .status(404)
+        .json({ message: "Seller not found", type: "not_found" });
+    }
+    return res.json({ website: serializeWebsite(seller.handle, meta) });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    log.error("[GET /vendor/website] failed:", msg);
+    return res.status(500).json({
+      message: "Failed to load website settings",
+      type: "server_error",
+    });
+  }
+}
+
+/**
+ * POST /vendor/website
+ *
+ * Save the Connect whitelist (bare hostnames). Body is validated upstream:
+ *   { connect_domains: string[] | null }
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+) {
+  const sellerId = await requireSellerId(req, res);
+  if (!sellerId) return;
+
+  try {
+    const body = req.body as { connect_domains?: string[] | null };
+    const domains = normalizeDomains(body.connect_domains ?? []);
+
+    const { seller, meta } = await loadContext(req, sellerId);
+    if (!seller) {
+      return res
+        .status(404)
+        .json({ message: "Seller not found", type: "not_found" });
+    }
+
+    const sellerExtension = req.scope.resolve("sellerExtension");
+    if (meta) {
+      await updateSellerMetadataRecord(sellerExtension as any, [
+        { id: meta.id, connect_domains: domains },
+      ]);
+    } else {
+      await createSellerMetadataRecord(sellerExtension as any, [
+        { seller_id: sellerId, connect_domains: domains },
+      ]);
+    }
+
+    // Re-read so the response reflects persisted state.
+    const refreshed = await loadContext(req, sellerId);
+    return res.json({
+      website: serializeWebsite(seller.handle, refreshed.meta),
+    });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    log.error("[POST /vendor/website] failed:", msg);
+    return res.status(500).json({
+      message: "Failed to save website settings",
+      type: "server_error",
+    });
+  }
+}

--- a/backend/src/modules/seller-extension/migrations/Migration20260620AddWebsiteFields.ts
+++ b/backend/src/modules/seller-extension/migrations/Migration20260620AddWebsiteFields.ts
@@ -1,0 +1,38 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Migration: Add FBM Sites ("commerce anywhere") columns to seller_metadata
+ *
+ * These four columns back the vendor "My Website" tab, which lets a vendor
+ * either embed the FBM Connect SDK on their own site (Mode 1 — Connect) or
+ * launch a standardized FBM-hosted site (Mode 2 — Launch).
+ *
+ *  - connect_domains : jsonb  — array of bare hostnames the vendor has
+ *                               whitelisted for the Connect SDK. Informational
+ *                               + used for optional origin display; the public
+ *                               Store API itself stays open (read-only).
+ *  - site_status     : text   — launch lifecycle: none | provisioning | live | failed
+ *  - site_url        : text   — public URL of the launched site once live
+ *  - site_repo       : text   — GitHub repository (org/name) backing the site
+ */
+export class Migration20260620AddWebsiteFields extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+      ADD COLUMN IF NOT EXISTS "connect_domains" jsonb DEFAULT NULL,
+      ADD COLUMN IF NOT EXISTS "site_status" text NOT NULL DEFAULT 'none',
+      ADD COLUMN IF NOT EXISTS "site_url" text DEFAULT NULL,
+      ADD COLUMN IF NOT EXISTS "site_repo" text DEFAULT NULL;
+    `);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+      DROP COLUMN IF EXISTS "connect_domains",
+      DROP COLUMN IF EXISTS "site_status",
+      DROP COLUMN IF EXISTS "site_url",
+      DROP COLUMN IF EXISTS "site_repo";
+    `);
+  }
+}

--- a/backend/src/modules/seller-extension/models/seller-metadata.ts
+++ b/backend/src/modules/seller-extension/models/seller-metadata.ts
@@ -157,6 +157,17 @@ const SellerMetadata = model.define("seller_metadata", {
   // entitlement grants and webhook `userId` on. Nullable until linked.
   blackout_user_id: model.text().nullable(),
 
+  // ── FBM Sites — "commerce anywhere" (see Migration20260620AddWebsiteFields) ──
+  // Mode 1 (Connect): bare hostnames where the vendor embeds the Connect SDK.
+  connect_domains: model.json().nullable(), // string[]
+  // Mode 2 (Launch): provisioning lifecycle of an FBM-hosted standalone site.
+  // One of: "none" | "provisioning" | "live" | "failed".
+  site_status: model.text().default("none"),
+  // Public URL of the launched site once it is live.
+  site_url: model.text().nullable(),
+  // GitHub repository (org/name) backing the launched site.
+  site_repo: model.text().nullable(),
+
   // Metadata for additional extensions
   metadata: model.json().nullable(),
 })

--- a/backend/src/shared/site-provisioning.ts
+++ b/backend/src/shared/site-provisioning.ts
@@ -1,0 +1,164 @@
+import { createLogger } from "./logger";
+
+const log = createLogger("shared/site-provisioning");
+
+/**
+ * FBM Sites — provisioning helpers for the vendor "My Website" tab.
+ *
+ * Two modes are backed here:
+ *   - Connect (Mode 1): normalize the bare hostnames a vendor embeds the
+ *     Connect SDK on. Pure/local — no external calls.
+ *   - Launch  (Mode 2): provision a standardized FBM-hosted site by creating a
+ *     repo from the GitHub template and dispatching its `configure` workflow.
+ *     This is gated entirely on env config so the endpoint degrades gracefully
+ *     (HTTP 501) anywhere the secrets are absent.
+ */
+
+export type LaunchResult = {
+  repo: string; // org/name
+  url: string; // public site URL
+  repo_url: string; // GitHub repo URL
+};
+
+const SITES_DOMAIN = (process.env.SITES_DOMAIN || "sites.freeblackmarket.com")
+  .replace(/^https?:\/\//, "")
+  .replace(/\/$/, "");
+
+/** True when the Launch flow has everything it needs to call GitHub. */
+export function isLaunchConfigured(): boolean {
+  return Boolean(
+    process.env.GITHUB_TOKEN &&
+    process.env.GITHUB_ORG &&
+    (process.env.SITE_TEMPLATE_REPO || process.env.GITHUB_TEMPLATE_REPO),
+  );
+}
+
+/** Public URL a launched site is served at. */
+export function launchedSiteUrl(subdomain: string): string {
+  return `https://${subdomain}.${SITES_DOMAIN}`;
+}
+
+/**
+ * Normalize arbitrary user input into a clean, deduped list of bare hostnames.
+ * Accepts full URLs, "www." prefixes, paths, and whitespace; drops anything
+ * that doesn't resolve to a plausible hostname.
+ */
+export function normalizeDomains(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const out = new Set<string>();
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    let host = raw.trim().toLowerCase();
+    if (!host) continue;
+    // Strip protocol + path/query if a full URL was pasted in.
+    host = host.replace(/^[a-z]+:\/\//, "");
+    host = host.split("/")[0].split("?")[0];
+    host = host.replace(/^www\./, "");
+    // Minimal hostname sanity check (label.tld, allows subdomains + ports).
+    if (!/^[a-z0-9.-]+\.[a-z]{2,}(:\d{2,5})?$/.test(host)) continue;
+    out.add(host);
+    if (out.size >= 50) break;
+  }
+  return Array.from(out);
+}
+
+const GH_API = "https://api.github.com";
+
+function ghHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "Content-Type": "application/json",
+    "User-Agent": "fbm-site-provisioner",
+  };
+}
+
+/**
+ * Provision a standardized site for a vendor:
+ *   1. Generate a new repo from the FBM site template.
+ *   2. Dispatch the repo's `configure` workflow with the vendor handle so it can
+ *      patch the `__VENDOR_HANDLE__` placeholders and deploy.
+ *
+ * Throws on any failure; callers translate that into a 502 for the vendor.
+ */
+export async function provisionSite(opts: {
+  handle: string;
+  subdomain: string;
+}): Promise<LaunchResult> {
+  if (!isLaunchConfigured()) {
+    throw new Error("LAUNCH_NOT_CONFIGURED");
+  }
+
+  const org = process.env.GITHUB_ORG as string;
+  const templateRepo = (process.env.SITE_TEMPLATE_REPO ||
+    process.env.GITHUB_TEMPLATE_REPO) as string;
+  const [templateOwner, templateName] = templateRepo.includes("/")
+    ? templateRepo.split("/")
+    : [org, templateRepo];
+
+  const repoName = `site-${opts.handle}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-");
+
+  // 1) Create repo from template.
+  const generateRes = await fetch(
+    `${GH_API}/repos/${templateOwner}/${templateName}/generate`,
+    {
+      method: "POST",
+      headers: ghHeaders(),
+      body: JSON.stringify({
+        owner: org,
+        name: repoName,
+        description: `FBM storefront for ${opts.handle}`,
+        private: false,
+        include_all_branches: false,
+      }),
+    },
+  );
+
+  if (!generateRes.ok && generateRes.status !== 422) {
+    // 422 == repo already exists; we treat that as idempotent re-launch.
+    const text = await generateRes.text().catch(() => "");
+    log.error(
+      `GitHub generate failed (${generateRes.status}) for ${repoName}: ${text}`,
+    );
+    throw new Error(`GITHUB_GENERATE_FAILED_${generateRes.status}`);
+  }
+
+  const fullName = `${org}/${repoName}`;
+
+  // 2) Dispatch the configure workflow (best effort: the repo is created either
+  //    way, and the workflow can be re-run from GitHub if this call races the
+  //    repo's first commit).
+  try {
+    const dispatchRes = await fetch(
+      `${GH_API}/repos/${org}/${repoName}/actions/workflows/configure.yml/dispatches`,
+      {
+        method: "POST",
+        headers: ghHeaders(),
+        body: JSON.stringify({
+          ref: "main",
+          inputs: {
+            vendor_handle: opts.handle,
+            subdomain: opts.subdomain,
+          },
+        }),
+      },
+    );
+    if (!dispatchRes.ok) {
+      const text = await dispatchRes.text().catch(() => "");
+      log.warn(
+        `configure.yml dispatch returned ${dispatchRes.status} for ${fullName}: ${text}`,
+      );
+    }
+  } catch (err) {
+    log.warn(`configure.yml dispatch threw for ${fullName}`, err);
+  }
+
+  return {
+    repo: fullName,
+    repo_url: `https://github.com/${fullName}`,
+    url: launchedSiteUrl(opts.subdomain),
+  };
+}

--- a/backend/src/shared/website-config.ts
+++ b/backend/src/shared/website-config.ts
@@ -1,0 +1,54 @@
+import { isLaunchConfigured } from "./site-provisioning";
+
+/**
+ * Shared serialization for the vendor "My Website" tab. Kept pure so both
+ * `/vendor/website` and `/vendor/website/launch` return an identical shape.
+ */
+
+export type WebsiteMeta = {
+  connect_domains: string[] | null;
+  site_status: string | null;
+  site_url: string | null;
+  site_repo: string | null;
+};
+
+/** Public base URL the embedded SDK calls (the storefront-facing API host). */
+export function apiBase(): string {
+  return (
+    process.env.PUBLIC_BACKEND_URL ||
+    process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL ||
+    "https://api.freeblackmarket.com"
+  ).replace(/\/$/, "");
+}
+
+/** Where connect.js is served from (storefront /public). */
+export function storefrontBase(): string {
+  return (process.env.STOREFRONT_URL || "https://freeblackmarket.com").replace(
+    /\/$/,
+    "",
+  );
+}
+
+/** The exact, ready-to-paste Connect snippet for a vendor handle. */
+export function buildSnippet(handle: string): string {
+  return [
+    `<script src="${storefrontBase()}/connect.js"`,
+    `        data-fbm-handle="${handle}"`,
+    `        data-fbm-api="${apiBase()}" async></script>`,
+  ].join("\n");
+}
+
+export function serializeWebsite(handle: string, meta: WebsiteMeta | null) {
+  return {
+    handle,
+    connect_domains: meta?.connect_domains ?? [],
+    site_status: meta?.site_status ?? "none",
+    site_url: meta?.site_url ?? null,
+    site_repo: meta?.site_repo ?? null,
+    launch_available: isLaunchConfigured(),
+    api_base: apiBase(),
+    storefront_url: storefrontBase(),
+    sdk_url: `${storefrontBase()}/connect.js`,
+    snippet: buildSnippet(handle),
+  };
+}

--- a/docs/integrations/fbm-connect.md
+++ b/docs/integrations/fbm-connect.md
@@ -1,0 +1,210 @@
+# FBM Connect — commerce on any website
+
+FBM Connect turns Free Black Market into a commerce platform that **any** website
+can plug into. There are two ways a vendor can use it, surfaced in the vendor
+panel under **My Website**:
+
+- **Mode 1 — Connect (bring your own site):** drop one `<script>` tag on an
+  existing site (Squarespace, Webflow, Wix, WordPress, raw HTML, React, …) and
+  render the vendor's catalog + checkout right there.
+- **Mode 2 — Launch (no site yet):** one click provisions a standardized,
+  FBM-hosted site pointed at the vendor's catalog. The launched site is simply
+  **Mode 1 pre-configured** — see [`templates/fbm-site-template`](../../templates/fbm-site-template).
+
+Everything is built on one public, website-agnostic contract: the **FBM Store
+API**.
+
+---
+
+## 1. FBM Store API
+
+### `GET /store/vendors/:handle`
+
+Public, unauthenticated, read-only. No publishable key required, open CORS
+(reflects the request origin) so any third-party site can call it.
+
+**Query parameters** (all optional):
+
+| Param            | Default              | Notes                                  |
+| ---------------- | -------------------- | -------------------------------------- |
+| `include`        | `vendor,products,events` | CSV of sections to return.         |
+| `limit_products` | `24` (max `100`)     | Max products.                          |
+| `limit_events`   | `12` (max `50`)      | Max events.                            |
+| `currency_code`  | `usd`                | Preferred price currency.              |
+
+**Response:**
+
+```jsonc
+{
+  "vendor": {
+    "id": "sel_…",
+    "handle": "shaktiinnergy",
+    "name": "Shakti Inner Energy",
+    "description": "…",
+    "photo": "https://…",
+    "vendor_type": "maker",
+    "verified": true,
+    "rating": 4.8,
+    "review_count": 12,
+    "website_url": "https://shaktiinnergy.com",
+    "social_links": { "instagram": "…" },
+    "url": "https://freeblackmarket.com/us/sellers/shaktiinnergy"
+  },
+  "products": [
+    {
+      "id": "prod_…",
+      "title": "Rose Quartz Roller",
+      "handle": "rose-quartz-roller",
+      "subtitle": null,
+      "description": "…",
+      "thumbnail": "https://…",
+      "price": { "amount": 24, "currency_code": "usd" },
+      "variants": [{ "id": "variant_…", "title": "Default", "price": { "amount": 24, "currency_code": "usd" } }],
+      "url": "https://freeblackmarket.com/us/products/rose-quartz-roller"
+    }
+  ],
+  "events": [
+    {
+      "id": "…",
+      "title": "Sound Bath",
+      "handle": "sound-bath",
+      "thumbnail": null,
+      "dates": ["2026-07-04T18:00:00Z"],
+      "venue": { "name": "The Studio", "address": "…" },
+      "price": { "amount": 30, "currency_code": "usd" },
+      "url": "https://freeblackmarket.com/us/products/sound-bath"
+    }
+  ],
+  "_meta": {
+    "handle": "shaktiinnergy",
+    "currency_code": "usd",
+    "storefront_url": "https://freeblackmarket.com",
+    "checkout_url": "https://freeblackmarket.com/us/cart",
+    "generated_at": "2026-06-20T00:00:00.000Z"
+  }
+}
+```
+
+> Money amounts are **major units** (Medusa v2 convention): `24` means `$24.00`.
+> Format with `Intl.NumberFormat(locale, { style: "currency", currency })`.
+
+---
+
+## 2. The Connect SDK (`connect.js`)
+
+Served from `https://freeblackmarket.com/connect.js`. No dependencies, no build
+step. Configure it entirely from the script tag:
+
+```html
+<script
+  src="https://freeblackmarket.com/connect.js"
+  data-fbm-handle="shaktiinnergy"
+  data-fbm-api="https://api.freeblackmarket.com"
+  async
+></script>
+```
+
+| Attribute            | Required | Default                          |
+| -------------------- | -------- | -------------------------------- |
+| `data-fbm-handle`    | ✅       | —                                |
+| `data-fbm-api`       |          | `https://api.freeblackmarket.com`|
+| `data-fbm-storefront`|          | derived from API response        |
+| `data-fbm-region`    |          | `us`                             |
+| `data-fbm-currency`  |          | `usd`                            |
+| `data-fbm-locale`    |          | `en-US`                          |
+
+There are three layers of integration; use whichever fits.
+
+### Layer 1 — Zero JS (HTML attributes)
+
+The element renders itself and stays in sync with the catalog:
+
+```html
+<div data-fbm="vendor"></div>
+<div data-fbm="products" data-fbm-limit="6"></div>
+<div data-fbm="events"></div>
+```
+
+Per-element overrides: `data-fbm-handle`, `data-fbm-limit`, `data-fbm-currency`.
+
+### Layer 2 — Widgets (styled UI into your container)
+
+```js
+FBM.renderProducts("#shop", { limit: 6 })
+FBM.renderEvents("#events", { limit: 3 })
+FBM.renderVendor("#profile")
+```
+
+Widget markup uses `.fbm-*` classes you can override in your own CSS.
+
+### Layer 3 — Raw API (build your own UI)
+
+```js
+const vendor = await FBM.getVendor()
+const products = await FBM.getProducts({ limit: 12 })
+const events = await FBM.getEvents()
+
+// Every item is enriched with convenience fields:
+products[0]._price     // "$24.00"  (formatted for the configured locale)
+products[0]._cartUrl   // deep link into FBM checkout for this product
+products[0]._meta      // the response _meta block
+```
+
+### SDK reference
+
+| Method                                   | Returns                                   |
+| ---------------------------------------- | ----------------------------------------- |
+| `FBM.configure(opts)`                    | Override config at runtime; returns `FBM` |
+| `FBM.getVendor(handle?)`                 | `Promise<vendor>`                         |
+| `FBM.getProducts(handle?, { limit, currency })` | `Promise<product[]>` (enriched)    |
+| `FBM.getEvents(handle?, { limit })`      | `Promise<event[]>` (enriched)             |
+| `FBM.cartUrl(productOrHandle?)`          | URL string (cart, or a product deep link) |
+| `FBM.formatPrice({ amount, currency_code })` | formatted currency string             |
+| `FBM.renderProducts(sel, opts)`          | renders + `Promise<void>`                 |
+| `FBM.renderEvents(sel, opts)`            | renders + `Promise<void>`                 |
+| `FBM.renderVendor(sel, opts)`            | renders + `Promise<void>`                 |
+| `FBM.mount(root?)`                       | (re)scan `[data-fbm]` elements            |
+
+`getX()` accept `(handle, opts)`, `(opts)`, or `()` — handle falls back to the
+configured one. A single network call per handle is cached and shared across all
+methods and widgets.
+
+---
+
+## 3. Vendor panel — "My Website"
+
+`GET /vendor/website` returns the vendor's ready-to-paste snippet, whitelisted
+domains, and launch status. The panel has two tabs:
+
+- **Connect** — copies the snippet, shows the zero-JS examples + SDK reference,
+  and lets the vendor record the domains they've embedded on
+  (`POST /vendor/website` → `{ connect_domains: string[] }`).
+- **Launch** — `POST /vendor/website/launch` provisions a hosted site. Returns
+  `501` when the deployment hasn't configured the GitHub provisioning env (the
+  button is disabled with an explanation, Connect still works).
+
+### Backend data
+
+Four columns on `seller_metadata` (migration
+`Migration20260620AddWebsiteFields`):
+
+| Column            | Meaning                                              |
+| ----------------- | ---------------------------------------------------- |
+| `connect_domains` | `string[]` — hostnames the vendor embeds Connect on. |
+| `site_status`     | `none \| provisioning \| live \| failed`.            |
+| `site_url`        | Public URL of the launched site.                     |
+| `site_repo`       | GitHub repo (`org/name`) backing the launched site.  |
+
+### Launch provisioning env
+
+See `.env.production.example` (FBM Sites section): `GITHUB_TOKEN`, `GITHUB_ORG`,
+`SITE_TEMPLATE_REPO`, `SITES_DOMAIN`, `STOREFRONT_URL`, `PUBLIC_BACKEND_URL`.
+
+When set, `POST /vendor/website/launch`:
+
+1. `POST /repos/{templateOwner}/{templateRepo}/generate` → new repo in the org.
+2. `POST /repos/{org}/{repo}/actions/workflows/configure.yml/dispatches` with the
+   vendor handle → the template's
+   [`configure`](../../templates/fbm-site-template/.github/workflows/configure.yml)
+   workflow bakes the handle in and deploys to GitHub Pages.
+3. Records `site_status=provisioning`, `site_url`, `site_repo` on the vendor.

--- a/storefront/public/connect.js
+++ b/storefront/public/connect.js
@@ -1,0 +1,425 @@
+/*!
+ * FBM Connect — Free Black Market commerce, on any website.
+ * https://freeblackmarket.com
+ *
+ * One <script> tag turns any site (Squarespace, Webflow, Wix, WordPress, raw
+ * HTML, React — anything) into an FBM storefront. Three layers of integration,
+ * pick the one that fits how much control you want:
+ *
+ *   1. Zero JS — drop an element, it renders itself:
+ *        <div data-fbm="products" data-fbm-limit="6"></div>
+ *        <div data-fbm="events"></div>
+ *        <div data-fbm="vendor"></div>
+ *
+ *   2. Widgets — render styled UI into a container you choose:
+ *        FBM.renderProducts('#shop', { limit: 6 })
+ *        FBM.renderEvents('#events', { limit: 3 })
+ *
+ *   3. Raw API — get enriched data, build your own UI:
+ *        const products = await FBM.getProducts()
+ *        // each item has _price ("$12.00"), _cartUrl, _meta pre-computed
+ *
+ * Configure via the script tag:
+ *   <script src="https://freeblackmarket.com/connect.js"
+ *           data-fbm-handle="your-handle"
+ *           data-fbm-api="https://api.freeblackmarket.com" async></script>
+ *
+ * No keys, no build step, no dependencies. MIT-spirited, framework-agnostic.
+ */
+(function (window, document) {
+  "use strict";
+
+  if (window.FBM && window.FBM.__loaded) {
+    return; // already initialized
+  }
+
+  // ---------------------------------------------------------------------------
+  // Configuration (read from the embedding <script> tag's data-* attributes)
+  // ---------------------------------------------------------------------------
+  var currentScript =
+    document.currentScript ||
+    (function () {
+      var s = document.querySelectorAll("script[data-fbm-handle], script[src*='connect.js']");
+      return s[s.length - 1] || null;
+    })();
+
+  function attr(name, fallback) {
+    if (currentScript && currentScript.getAttribute) {
+      var v = currentScript.getAttribute("data-fbm-" + name);
+      if (v !== null && v !== "") return v;
+    }
+    return fallback;
+  }
+
+  function stripSlash(u) {
+    return String(u || "").replace(/\/+$/, "");
+  }
+
+  var config = {
+    handle: attr("handle", ""),
+    api: stripSlash(attr("api", "https://api.freeblackmarket.com")),
+    storefront: stripSlash(attr("storefront", "")),
+    region: attr("region", "us"),
+    currency: attr("currency", "usd"),
+    locale: attr("locale", "en-US"),
+  };
+
+  // ---------------------------------------------------------------------------
+  // Data fetching (one network call per handle+include set, then cached)
+  // ---------------------------------------------------------------------------
+  var cache = {};
+  var lastMeta = null;
+
+  function buildUrl(handle, opts) {
+    var params = [];
+    if (opts && opts.include) params.push("include=" + encodeURIComponent(opts.include));
+    if (opts && opts.limitProducts) params.push("limit_products=" + opts.limitProducts);
+    if (opts && opts.limitEvents) params.push("limit_events=" + opts.limitEvents);
+    params.push("currency_code=" + encodeURIComponent((opts && opts.currency) || config.currency));
+    return config.api + "/store/vendors/" + encodeURIComponent(handle) + "?" + params.join("&");
+  }
+
+  function getData(handle, opts) {
+    handle = handle || config.handle;
+    if (!handle) {
+      return Promise.reject(new Error("FBM: no vendor handle configured (set data-fbm-handle)."));
+    }
+    var key = handle + "|" + ((opts && opts.include) || "all") + "|" + ((opts && opts.currency) || config.currency);
+    if (cache[key]) return cache[key];
+
+    var p = fetch(buildUrl(handle, opts), {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      credentials: "omit",
+    })
+      .then(function (res) {
+        if (!res.ok) throw new Error("FBM: request failed (" + res.status + ")");
+        return res.json();
+      })
+      .then(function (data) {
+        lastMeta = data._meta || lastMeta;
+        return data;
+      })
+      .catch(function (err) {
+        delete cache[key]; // allow retry
+        throw err;
+      });
+
+    cache[key] = p;
+    return p;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enrichment — add _price, _cartUrl, _meta convenience fields
+  // ---------------------------------------------------------------------------
+  function formatPrice(price) {
+    if (!price || typeof price.amount !== "number") return "";
+    try {
+      return new Intl.NumberFormat(config.locale, {
+        style: "currency",
+        currency: (price.currency_code || config.currency).toUpperCase(),
+      }).format(price.amount);
+    } catch (e) {
+      return price.amount + " " + (price.currency_code || "");
+    }
+  }
+
+  function storefrontBase(meta) {
+    return (
+      config.storefront ||
+      (meta && meta.storefront_url) ||
+      (lastMeta && lastMeta.storefront_url) ||
+      config.api.replace(/\/\/api\./, "//")
+    );
+  }
+
+  function productUrl(handle, meta) {
+    return stripSlash(storefrontBase(meta)) + "/" + config.region + "/products/" + handle;
+  }
+
+  function enrichProduct(p, meta) {
+    p._price = formatPrice(p.price);
+    p._cartUrl = p.url || productUrl(p.handle, meta);
+    p._meta = meta || lastMeta;
+    return p;
+  }
+
+  function enrichEvent(e, meta) {
+    e._price = formatPrice(e.price);
+    e._cartUrl = e.url || (e.handle ? productUrl(e.handle, meta) : null);
+    e._meta = meta || lastMeta;
+    return e;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Argument normalization — every getX accepts (handle, opts) | (opts) | ()
+  // ---------------------------------------------------------------------------
+  function normalize(handle, opts) {
+    if (handle && typeof handle === "object") {
+      return { handle: config.handle, opts: handle };
+    }
+    return { handle: handle || config.handle, opts: opts || {} };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public raw API
+  // ---------------------------------------------------------------------------
+  function getVendor(handle) {
+    var a = normalize(handle);
+    return getData(a.handle, { include: "vendor", currency: a.opts.currency }).then(function (d) {
+      return d.vendor || null;
+    });
+  }
+
+  function getProducts(handle, opts) {
+    var a = normalize(handle, opts);
+    return getData(a.handle, {
+      include: "vendor,products",
+      limitProducts: a.opts.limit,
+      currency: a.opts.currency,
+    }).then(function (d) {
+      var meta = d._meta;
+      return (d.products || []).map(function (p) {
+        return enrichProduct(p, meta);
+      });
+    });
+  }
+
+  function getEvents(handle, opts) {
+    var a = normalize(handle, opts);
+    return getData(a.handle, {
+      include: "vendor,events",
+      limitEvents: a.opts.limit,
+      currency: a.opts.currency,
+    }).then(function (d) {
+      var meta = d._meta;
+      return (d.events || []).map(function (e) {
+        return enrichEvent(e, meta);
+      });
+    });
+  }
+
+  // cartUrl():            -> the vendor's FBM cart/checkout URL
+  // cartUrl(product):     -> that product's page (deep-link into checkout flow)
+  // cartUrl("handle"):    -> that product handle's page
+  function cartUrl(target) {
+    if (!target) {
+      return (
+        (lastMeta && lastMeta.checkout_url) ||
+        stripSlash(storefrontBase()) + "/" + config.region + "/cart"
+      );
+    }
+    if (typeof target === "string") return productUrl(target);
+    if (target && target.url) return target.url;
+    if (target && target.handle) return productUrl(target.handle);
+    return cartUrl();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Widgets — minimal, styled, overridable (.fbm-* classes)
+  // ---------------------------------------------------------------------------
+  var STYLE_ID = "fbm-connect-styles";
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    var css =
+      ".fbm-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:16px;margin:0;padding:0;list-style:none}" +
+      ".fbm-card{display:flex;flex-direction:column;border:1px solid #e5e5e5;border-radius:12px;overflow:hidden;background:#fff;text-decoration:none;color:inherit;transition:box-shadow .15s ease,transform .15s ease}" +
+      ".fbm-card:hover{box-shadow:0 6px 20px rgba(0,0,0,.08);transform:translateY(-2px)}" +
+      ".fbm-card__img{aspect-ratio:1/1;width:100%;object-fit:cover;background:#f5f5f5;display:block}" +
+      ".fbm-card__body{padding:12px 14px;display:flex;flex-direction:column;gap:4px}" +
+      ".fbm-card__title{font-weight:600;font-size:14px;line-height:1.3;margin:0}" +
+      ".fbm-card__meta{font-size:13px;color:#666;margin:0}" +
+      ".fbm-card__price{font-weight:600;font-size:14px;margin:2px 0 0}" +
+      ".fbm-cta{margin-top:auto;display:inline-block;padding:8px 12px;border-radius:8px;background:#111;color:#fff;font-size:13px;font-weight:600;text-align:center;text-decoration:none}" +
+      ".fbm-vendor{display:flex;align-items:center;gap:14px;padding:8px 0}" +
+      ".fbm-vendor__avatar{width:56px;height:56px;border-radius:50%;object-fit:cover;background:#f0f0f0}" +
+      ".fbm-vendor__name{font-weight:700;font-size:18px;margin:0;display:flex;align-items:center;gap:6px}" +
+      ".fbm-vendor__verified{color:#1d9bf0;font-size:14px}" +
+      ".fbm-vendor__desc{color:#555;font-size:14px;margin:2px 0 0}" +
+      ".fbm-empty{color:#888;font-size:14px;padding:8px 0}" +
+      ".fbm-powered{font-size:11px;color:#aaa;margin-top:10px}" +
+      ".fbm-powered a{color:#888;text-decoration:none}";
+    var style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = css;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function resolveEl(target) {
+    if (!target) return null;
+    if (typeof target === "string") return document.querySelector(target);
+    return target.nodeType ? target : null;
+  }
+
+  function setEmpty(node, msg) {
+    node.innerHTML = '<p class="fbm-empty">' + escapeHtml(msg) + "</p>";
+  }
+
+  function poweredBy() {
+    return (
+      '<p class="fbm-powered">Powered by <a href="https://freeblackmarket.com" target="_blank" rel="noopener">Free Black Market</a></p>'
+    );
+  }
+
+  function productCard(p) {
+    var img = p.thumbnail
+      ? '<img class="fbm-card__img" src="' + escapeHtml(p.thumbnail) + '" alt="' + escapeHtml(p.title) + '" loading="lazy">'
+      : '<div class="fbm-card__img"></div>';
+    return (
+      '<a class="fbm-card" href="' + escapeHtml(p._cartUrl) + '" target="_blank" rel="noopener">' +
+      img +
+      '<div class="fbm-card__body">' +
+      '<p class="fbm-card__title">' + escapeHtml(p.title) + "</p>" +
+      (p._price ? '<p class="fbm-card__price">' + escapeHtml(p._price) + "</p>" : "") +
+      '<span class="fbm-cta">Shop now</span>' +
+      "</div></a>"
+    );
+  }
+
+  function eventCard(e) {
+    var when = Array.isArray(e.dates) && e.dates.length ? e.dates[0] : "";
+    var venue = e.venue && e.venue.name ? e.venue.name : "";
+    var sub = [when, venue].filter(Boolean).join(" · ");
+    var href = e._cartUrl || cartUrl();
+    var img = e.thumbnail
+      ? '<img class="fbm-card__img" src="' + escapeHtml(e.thumbnail) + '" alt="' + escapeHtml(e.title) + '" loading="lazy">'
+      : "";
+    return (
+      '<a class="fbm-card" href="' + escapeHtml(href) + '" target="_blank" rel="noopener">' +
+      img +
+      '<div class="fbm-card__body">' +
+      '<p class="fbm-card__title">' + escapeHtml(e.title) + "</p>" +
+      (sub ? '<p class="fbm-card__meta">' + escapeHtml(sub) + "</p>" : "") +
+      (e._price ? '<p class="fbm-card__price">' + escapeHtml(e._price) + "</p>" : "") +
+      '<span class="fbm-cta">Get tickets</span>' +
+      "</div></a>"
+    );
+  }
+
+  function renderInto(node, fetcher, cardFn, emptyMsg) {
+    injectStyles();
+    node.innerHTML = '<p class="fbm-empty">Loading…</p>';
+    return fetcher
+      .then(function (items) {
+        if (!items || !items.length) {
+          setEmpty(node, emptyMsg);
+          return;
+        }
+        node.innerHTML =
+          '<div class="fbm-grid">' + items.map(cardFn).join("") + "</div>" + poweredBy();
+      })
+      .catch(function (err) {
+        setEmpty(node, "Unable to load right now.");
+        if (window.console && console.warn) console.warn(err);
+      });
+  }
+
+  function renderProducts(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    opts = opts || {};
+    return renderInto(node, getProducts(opts.handle, opts), productCard, "No products yet.");
+  }
+
+  function renderEvents(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    opts = opts || {};
+    return renderInto(node, getEvents(opts.handle, opts), eventCard, "No upcoming events.");
+  }
+
+  function renderVendor(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    injectStyles();
+    opts = opts || {};
+    return getVendor(opts.handle)
+      .then(function (v) {
+        if (!v) {
+          setEmpty(node, "Vendor not found.");
+          return;
+        }
+        var avatar = v.photo
+          ? '<img class="fbm-vendor__avatar" src="' + escapeHtml(v.photo) + '" alt="' + escapeHtml(v.name) + '">'
+          : '<div class="fbm-vendor__avatar"></div>';
+        var verified = v.verified ? '<span class="fbm-vendor__verified" title="Verified">✔</span>' : "";
+        node.innerHTML =
+          '<div class="fbm-vendor">' +
+          avatar +
+          "<div>" +
+          '<p class="fbm-vendor__name">' + escapeHtml(v.name) + verified + "</p>" +
+          (v.description ? '<p class="fbm-vendor__desc">' + escapeHtml(v.description) + "</p>" : "") +
+          "</div></div>";
+      })
+      .catch(function (err) {
+        setEmpty(node, "Unable to load vendor.");
+        if (window.console && console.warn) console.warn(err);
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Zero-JS auto-mount: scan for [data-fbm] elements and render them
+  // ---------------------------------------------------------------------------
+  function autoMount(root) {
+    root = root || document;
+    var nodes = root.querySelectorAll("[data-fbm]");
+    Array.prototype.forEach.call(nodes, function (node) {
+      if (node.getAttribute("data-fbm-mounted")) return;
+      node.setAttribute("data-fbm-mounted", "1");
+      var kind = node.getAttribute("data-fbm");
+      var opts = {
+        handle: node.getAttribute("data-fbm-handle") || config.handle,
+        limit: parseInt(node.getAttribute("data-fbm-limit") || "", 10) || undefined,
+        currency: node.getAttribute("data-fbm-currency") || undefined,
+      };
+      if (kind === "products") renderProducts(node, opts);
+      else if (kind === "events") renderEvents(node, opts);
+      else if (kind === "vendor") renderVendor(node, opts);
+    });
+  }
+
+  function ready(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn);
+    } else {
+      fn();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Expose & boot
+  // ---------------------------------------------------------------------------
+  var FBM = {
+    __loaded: true,
+    version: "1.0.0",
+    config: config,
+    configure: function (o) {
+      for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) config[k] = o[k];
+      cache = {}; // config change invalidates cache
+      return FBM;
+    },
+    getData: getData,
+    getVendor: getVendor,
+    getProducts: getProducts,
+    getEvents: getEvents,
+    cartUrl: cartUrl,
+    formatPrice: formatPrice,
+    renderProducts: renderProducts,
+    renderEvents: renderEvents,
+    renderVendor: renderVendor,
+    mount: autoMount,
+  };
+
+  window.FBM = FBM;
+
+  ready(function () {
+    injectStyles();
+    autoMount(document);
+  });
+})(window, document);

--- a/templates/fbm-site-template/.github/workflows/configure.yml
+++ b/templates/fbm-site-template/.github/workflows/configure.yml
@@ -1,0 +1,83 @@
+name: Configure & Deploy FBM Site
+
+# Triggered by the FBM backend's /vendor/website/launch endpoint via the GitHub
+# "dispatch workflow" API. It bakes the vendor handle into the template, commits
+# the result, then publishes the static site to GitHub Pages.
+on:
+  workflow_dispatch:
+    inputs:
+      vendor_handle:
+        description: "FBM vendor handle (slug)"
+        required: true
+        type: string
+      subdomain:
+        description: "Subdomain for {subdomain}.sites.freeblackmarket.com"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: fbm-pages
+  cancel-in-progress: true
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bake vendor handle into the template
+        env:
+          HANDLE: ${{ inputs.vendor_handle }}
+          SUBDOMAIN: ${{ inputs.subdomain }}
+        run: |
+          set -euo pipefail
+          # Sanitize handle to a safe slug.
+          SAFE_HANDLE=$(printf '%s' "$HANDLE" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-')
+          if [ -z "$SAFE_HANDLE" ]; then
+            echo "::error::vendor_handle resolved to an empty slug"; exit 1
+          fi
+          echo "Configuring site for: $SAFE_HANDLE"
+
+          # Replace every __VENDOR_HANDLE__ placeholder.
+          grep -rl '__VENDOR_HANDLE__' . --include='*.html' --include='*.css' --include='*.js' \
+            | while read -r f; do
+                sed -i "s/__VENDOR_HANDLE__/${SAFE_HANDLE}/g" "$f"
+              done
+
+          # Write a CNAME so Pages serves the custom domain once DNS is pointed.
+          SUB="${SUBDOMAIN:-$SAFE_HANDLE}"
+          echo "${SUB}.sites.freeblackmarket.com" > CNAME
+
+      - name: Commit configured site
+        run: |
+          set -euo pipefail
+          git config user.name "fbm-bot"
+          git config user.email "bot@freeblackmarket.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Configure site for ${{ inputs.vendor_handle }}"
+            git push
+          fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/templates/fbm-site-template/.github/workflows/deploy.yml
+++ b/templates/fbm-site-template/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy FBM Site
+
+# Re-deploys the static site whenever the vendor edits content on main, or when
+# triggered manually. Initial provisioning is handled by configure.yml.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: fbm-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/templates/fbm-site-template/README.md
+++ b/templates/fbm-site-template/README.md
@@ -1,0 +1,59 @@
+# FBM Site Template
+
+A ready-to-deploy storefront for a single Free Black Market vendor. It is the
+**Connect** integration (Mode 1) pre-assembled into a standalone site so vendors
+who don't have a website can get one in a click.
+
+When a vendor hits **Launch** in their FBM vendor panel, the FBM backend:
+
+1. Creates a new repository from this template (this repo must be marked as a
+   **Template repository** in its GitHub settings).
+2. Dispatches the [`configure`](.github/workflows/configure.yml) workflow with
+   the vendor's handle.
+3. The workflow replaces the `__VENDOR_HANDLE__` placeholders, writes a `CNAME`,
+   commits, and publishes to **GitHub Pages**.
+
+## Files
+
+| File                              | Purpose                                              |
+| --------------------------------- | ---------------------------------------------------- |
+| `index.html`                      | The storefront. Uses `connect.js` + `data-fbm="…"`.  |
+| `styles.css`                      | Page chrome (header/sections/footer). Yours to edit. |
+| `.github/workflows/configure.yml` | One-shot provisioning: bake handle → commit → deploy.|
+| `.github/workflows/deploy.yml`    | Re-deploy on every push to `main`.                   |
+
+## How it works
+
+The whole storefront is driven by one script tag and a few HTML attributes:
+
+```html
+<div data-fbm="vendor"></div>
+<div data-fbm="products" data-fbm-limit="12"></div>
+<div data-fbm="events"></div>
+
+<script
+  src="https://freeblackmarket.com/connect.js"
+  data-fbm-handle="your-handle"
+  data-fbm-api="https://api.freeblackmarket.com"
+  async
+></script>
+```
+
+That's the same SDK any vendor can drop on their own existing site — see the
+[FBM Connect guide](https://freeblackmarket.com) for the full API.
+
+## One-time setup (FBM operators)
+
+1. Push this directory to `Blackmarket-coa/fbm-site-template`.
+2. In repo **Settings → General**, tick **Template repository**.
+3. In repo **Settings → Pages**, set **Source: GitHub Actions**.
+4. On the FBM backend, set `GITHUB_TOKEN` (a PAT/app token with `repo` +
+   `workflow` scope on the org), `GITHUB_ORG`, and `SITE_TEMPLATE_REPO`
+   (`Blackmarket-coa/fbm-site-template`).
+5. Point `*.sites.freeblackmarket.com` DNS at GitHub Pages (or a Cloudflare
+   Tunnel) so the per-vendor `CNAME` resolves.
+
+## Customizing
+
+Edit `index.html` and `styles.css` freely. The product/event grids are styled by
+`connect.js` under `.fbm-*` classes, which you can override in `styles.css`.

--- a/templates/fbm-site-template/index.html
+++ b/templates/fbm-site-template/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>__VENDOR_HANDLE__ — Free Black Market</title>
+    <meta
+      name="description"
+      content="Shop with __VENDOR_HANDLE__ on Free Black Market."
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <!--
+      This is the standardized FBM site template. It is Mode 1 (Connect)
+      pre-configured: the single <script> at the bottom of <body> wires the page
+      to the vendor's catalog. The __VENDOR_HANDLE__ token is replaced by the
+      `configure` GitHub Action when FBM provisions the site.
+    -->
+    <header class="site-header">
+      <div class="wrap">
+        <!-- Vendor profile header renders itself -->
+        <div data-fbm="vendor"></div>
+      </div>
+    </header>
+
+    <main class="wrap">
+      <section class="section">
+        <h2 class="section__title">Shop</h2>
+        <!-- A responsive grid of the vendor's products -->
+        <div data-fbm="products" data-fbm-limit="12"></div>
+      </section>
+
+      <section class="section">
+        <h2 class="section__title">Upcoming events</h2>
+        <!-- The vendor's ticketed events (hidden automatically if none) -->
+        <div data-fbm="events" data-fbm-limit="6"></div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="wrap">
+        <p>
+          Powered by
+          <a href="https://freeblackmarket.com" rel="noopener">Free Black Market</a>
+        </p>
+      </div>
+    </footer>
+
+    <!--
+      FBM Connect SDK. `data-fbm-handle` is the only required setting.
+      `data-fbm-api` points at the FBM Store API.
+    -->
+    <script
+      src="https://freeblackmarket.com/connect.js"
+      data-fbm-handle="__VENDOR_HANDLE__"
+      data-fbm-api="https://api.freeblackmarket.com"
+      async
+    ></script>
+  </body>
+</html>

--- a/templates/fbm-site-template/styles.css
+++ b/templates/fbm-site-template/styles.css
@@ -1,0 +1,61 @@
+/*
+ * Page chrome for the standardized FBM site template.
+ * The FBM Connect SDK injects its own .fbm-* styles for the product/event
+ * grids; this file only styles the surrounding page (header, sections, footer).
+ * Edit freely — everything here is yours to customize.
+ */
+:root {
+  --fbm-ink: #111;
+  --fbm-muted: #666;
+  --fbm-line: #e7e7e7;
+  --fbm-bg: #fff;
+  --fbm-max: 1080px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family:
+    system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--fbm-ink);
+  background: var(--fbm-bg);
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+}
+
+.wrap {
+  max-width: var(--fbm-max);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--fbm-line);
+  padding: 28px 0;
+}
+
+.section {
+  padding: 36px 0;
+}
+
+.section__title {
+  font-size: 20px;
+  margin: 0 0 18px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--fbm-line);
+  padding: 28px 0;
+  color: var(--fbm-muted);
+  font-size: 14px;
+}
+
+.site-footer a {
+  text-decoration: none;
+}

--- a/vendor-panel/src/hooks/api/index.ts
+++ b/vendor-panel/src/hooks/api/index.ts
@@ -38,6 +38,7 @@ export * from "./workflow-executions"
 export * from "./requests"
 export * from "./stripe"
 export * from "./woocommerce"
+export * from "./website"
 
 export * from "./printful"
 export * from "./invoicing"

--- a/vendor-panel/src/hooks/api/website.tsx
+++ b/vendor-panel/src/hooks/api/website.tsx
@@ -1,0 +1,96 @@
+import {
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { FetchError } from "@medusajs/js-sdk"
+import { fetchQuery } from "../../lib/client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const WEBSITE_QUERY_KEY = "website" as const
+export const websiteQueryKeys = queryKeysFactory(WEBSITE_QUERY_KEY)
+
+export type SiteStatus = "none" | "provisioning" | "live" | "failed"
+
+export type FbmWebsite = {
+  handle: string
+  connect_domains: string[]
+  site_status: SiteStatus
+  site_url: string | null
+  site_repo: string | null
+  launch_available: boolean
+  api_base: string
+  storefront_url: string
+  sdk_url: string
+  snippet: string
+}
+
+export type FbmWebsiteResponse = { website: FbmWebsite }
+
+/**
+ * GET /vendor/website — the vendor's Connect snippet, whitelisted domains, and
+ * Launch status for the "My Website" tab.
+ */
+export const useWebsite = (
+  options?: Omit<
+    UseQueryOptions<FbmWebsiteResponse, FetchError>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () => fetchQuery("/vendor/website", { method: "GET" }),
+    queryKey: websiteQueryKeys.details(),
+    ...options,
+  })
+
+  return { website: data?.website as FbmWebsite | undefined, ...rest }
+}
+
+/**
+ * POST /vendor/website — save the Connect domain whitelist.
+ */
+export const useUpdateWebsiteDomains = (
+  options?: UseMutationOptions<FbmWebsiteResponse, FetchError, string[]>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (connect_domains: string[]) =>
+      fetchQuery("/vendor/website", {
+        method: "POST",
+        body: { connect_domains },
+      }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: websiteQueryKeys.details() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+/**
+ * POST /vendor/website/launch — provision a standardized FBM-hosted site.
+ */
+export const useLaunchWebsite = (
+  options?: UseMutationOptions<
+    FbmWebsiteResponse & { launched?: boolean },
+    FetchError,
+    { subdomain?: string } | void
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body?: { subdomain?: string } | void) =>
+      fetchQuery("/vendor/website/launch", {
+        method: "POST",
+        body: (body || {}) as object,
+      }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: websiteQueryKeys.details() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -18,6 +18,7 @@ import {
   Newspaper,
   SquaresPlus,
   MapPin,
+  Globe,
 } from "@medusajs/icons"
 import { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
@@ -95,6 +96,12 @@ function getVendorNavigationConfig({
       label: "Sales Report",
       to: "/sales-report",
       // Always visible
+    },
+    {
+      icon: <Globe />,
+      label: "My Website",
+      to: "/my-website",
+      // Always visible — embed FBM on your own site, or launch a hosted one.
     },
     {
       icon: <Star />,

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -78,6 +78,14 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/creator-studio"),
           },
           {
+            path: "my-website",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "My Website",
+            },
+            lazy: () => import("../../routes/my-website"),
+          },
+          {
             path: "programs",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/routes/my-website/components/connect-panel.tsx
+++ b/vendor-panel/src/routes/my-website/components/connect-panel.tsx
@@ -1,0 +1,205 @@
+import { Globe, Trash } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Heading,
+  IconButton,
+  Input,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useEffect, useState } from "react"
+import { FbmWebsite, useUpdateWebsiteDomains } from "../../../hooks/api/website"
+import { CodeBlock, Step } from "./shared"
+
+/** Bare-hostname validation that mirrors the backend normalizer. */
+function cleanHost(input: string): string | null {
+  let host = input.trim().toLowerCase()
+  if (!host) return null
+  host = host.replace(/^[a-z]+:\/\//, "")
+  host = host.split("/")[0].split("?")[0]
+  host = host.replace(/^www\./, "")
+  if (!/^[a-z0-9.-]+\.[a-z]{2,}(:\d{2,5})?$/.test(host)) return null
+  return host
+}
+
+const SDK_METHODS: Array<{ call: string; desc: string }> = [
+  {
+    call: "await FBM.getVendor()",
+    desc: "Your profile: name, photo, bio, verified, links.",
+  },
+  {
+    call: "await FBM.getProducts({ limit })",
+    desc: "Products with _price + _cartUrl pre-computed.",
+  },
+  { call: "await FBM.getEvents({ limit })", desc: "Upcoming ticketed events." },
+  {
+    call: "FBM.renderProducts('#shop', { limit })",
+    desc: "Inject a styled product grid.",
+  },
+  { call: "FBM.renderEvents('#events')", desc: "Inject a styled events list." },
+  { call: "FBM.renderVendor('#me')", desc: "Inject your profile header." },
+  {
+    call: "FBM.cartUrl(product)",
+    desc: "Deep-link into FBM checkout for a product.",
+  },
+]
+
+export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
+  const [domains, setDomains] = useState<string[]>(
+    website.connect_domains || []
+  )
+  const [draft, setDraft] = useState("")
+  const { mutate: saveDomains, isPending } = useUpdateWebsiteDomains()
+
+  useEffect(() => {
+    setDomains(website.connect_domains || [])
+  }, [website.connect_domains])
+
+  const zeroJsExample = [
+    "<!-- Your profile header -->",
+    '<div data-fbm="vendor"></div>',
+    "",
+    "<!-- A grid of your products -->",
+    '<div data-fbm="products" data-fbm-limit="6"></div>',
+    "",
+    "<!-- Your upcoming events -->",
+    '<div data-fbm="events"></div>',
+  ].join("\n")
+
+  const addDomain = () => {
+    const host = cleanHost(draft)
+    if (!host) {
+      toast.error("Enter a valid domain, e.g. shaktiinnergy.com")
+      return
+    }
+    if (domains.includes(host)) {
+      setDraft("")
+      return
+    }
+    setDomains([...domains, host])
+    setDraft("")
+  }
+
+  const removeDomain = (host: string) => {
+    setDomains(domains.filter((d) => d !== host))
+  }
+
+  const persist = () => {
+    saveDomains(domains, {
+      onSuccess: () => toast.success("Connected domains saved"),
+      onError: () => toast.error("Could not save domains"),
+    })
+  }
+
+  const dirty =
+    JSON.stringify([...domains].sort()) !==
+    JSON.stringify([...(website.connect_domains || [])].sort())
+
+  return (
+    <div className="flex flex-col gap-y-8 py-6">
+      <div>
+        <Heading level="h2">Keep customers on your own site</Heading>
+        <Text className="text-ui-fg-subtle mt-1" size="small">
+          Drop one script tag onto any website — Squarespace, Webflow, Wix,
+          WordPress, or raw HTML — and your FBM catalog and checkout show up
+          right there. No developer needed.
+        </Text>
+      </div>
+
+      <Step n={1} title="Paste this snippet before </body>">
+        <CodeBlock code={website.snippet} />
+        <Text className="text-ui-fg-muted mt-2" size="xsmall">
+          That's it for the connection. The next steps are how you show things.
+        </Text>
+      </Step>
+
+      <Step n={2} title="Show your store — no code required">
+        <Text className="text-ui-fg-subtle mb-2" size="small">
+          Paste any of these where you want them to appear. They render
+          themselves and stay in sync with your catalog.
+        </Text>
+        <CodeBlock code={zeroJsExample} />
+      </Step>
+
+      <Step n={3} title="Want full control? Use the JavaScript API">
+        <Text className="text-ui-fg-subtle mb-3" size="small">
+          Every method returns enriched objects with{" "}
+          <code className="bg-ui-bg-subtle rounded px-1">_price</code> and{" "}
+          <code className="bg-ui-bg-subtle rounded px-1">_cartUrl</code> already
+          computed, so you can build any UI you like.
+        </Text>
+        <div className="border-ui-border-base divide-ui-border-base divide-y rounded-lg border">
+          {SDK_METHODS.map((m) => (
+            <div
+              key={m.call}
+              className="flex flex-col gap-1 p-3 sm:flex-row sm:items-center sm:gap-4"
+            >
+              <code className="text-ui-fg-base bg-ui-bg-subtle shrink-0 rounded px-2 py-1 text-xs sm:w-80">
+                {m.call}
+              </code>
+              <Text className="text-ui-fg-subtle" size="xsmall">
+                {m.desc}
+              </Text>
+            </div>
+          ))}
+        </div>
+      </Step>
+
+      <Step n={4} title="Whitelist your domains (optional)">
+        <Text className="text-ui-fg-subtle mb-3" size="small">
+          The catalog API is public and read-only, so the snippet works
+          everywhere immediately. Listing your domains here keeps a record of
+          where you've embedded FBM.
+        </Text>
+        <div className="flex gap-2">
+          <Input
+            placeholder="shaktiinnergy.com"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                addDomain()
+              }
+            }}
+          />
+          <Button variant="secondary" onClick={addDomain} type="button">
+            Add
+          </Button>
+        </div>
+        {domains.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {domains.map((d) => (
+              <Badge key={d} size="small" className="flex items-center gap-1">
+                <Globe className="text-ui-fg-muted" />
+                {d}
+                <IconButton
+                  size="2xsmall"
+                  variant="transparent"
+                  onClick={() => removeDomain(d)}
+                  aria-label={`Remove ${d}`}
+                  type="button"
+                >
+                  <Trash />
+                </IconButton>
+              </Badge>
+            ))}
+          </div>
+        )}
+        {dirty && (
+          <div className="mt-3">
+            <Button
+              size="small"
+              onClick={persist}
+              isLoading={isPending}
+              type="button"
+            >
+              Save domains
+            </Button>
+          </div>
+        )}
+      </Step>
+    </div>
+  )
+}

--- a/vendor-panel/src/routes/my-website/components/launch-panel.tsx
+++ b/vendor-panel/src/routes/my-website/components/launch-panel.tsx
@@ -1,0 +1,189 @@
+import {
+  CheckCircleSolid,
+  ComputerDesktop,
+  ExclamationCircle,
+  RocketLaunch,
+} from "@medusajs/icons"
+import { Alert, Badge, Button, Heading, Text, toast } from "@medusajs/ui"
+import { FbmWebsite, useLaunchWebsite } from "../../../hooks/api/website"
+import { CodeBlock } from "./shared"
+
+const PERKS = [
+  "A clean, mobile-ready storefront at your own FBM address",
+  "Your products, profile, and events — always in sync with your catalog",
+  "FBM checkout built in, nothing to wire up",
+  "Connect a custom domain whenever you're ready",
+]
+
+function StatusBadge({ status }: { status: FbmWebsite["site_status"] }) {
+  if (status === "live") {
+    return (
+      <Badge color="green" size="small" className="flex items-center gap-1">
+        <CheckCircleSolid /> Live
+      </Badge>
+    )
+  }
+  if (status === "provisioning") {
+    return (
+      <Badge color="orange" size="small">
+        Provisioning…
+      </Badge>
+    )
+  }
+  if (status === "failed") {
+    return (
+      <Badge color="red" size="small">
+        Failed
+      </Badge>
+    )
+  }
+  return null
+}
+
+export const LaunchPanel = ({ website }: { website: FbmWebsite }) => {
+  const { mutate: launch, isPending } = useLaunchWebsite()
+  const launched =
+    website.site_status === "live" || website.site_status === "provisioning"
+
+  const previewUrl =
+    website.site_url || `https://${website.handle}.sites.freeblackmarket.com`
+
+  const onLaunch = () => {
+    launch(undefined, {
+      onSuccess: () =>
+        toast.success("Your site is being provisioned — live shortly!"),
+      onError: (err) => {
+        const msg =
+          (err as { message?: string })?.message ||
+          "Launch failed. Please try again."
+        toast.error(msg)
+      },
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-y-8 py-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <Heading level="h2">No website? Launch one in a click</Heading>
+          <Text className="text-ui-fg-subtle mt-1" size="small">
+            We provision a standardized FBM site pointed at your catalog. It's
+            the same building blocks as Connect, pre-assembled and hosted for
+            you.
+          </Text>
+        </div>
+        <StatusBadge status={website.site_status} />
+      </div>
+
+      {/* Live / provisioning state */}
+      {launched && (
+        <div className="border-ui-border-base flex flex-col gap-4 rounded-lg border p-4">
+          <div className="flex items-center gap-3">
+            <ComputerDesktop className="text-ui-fg-subtle" />
+            <div className="flex-1">
+              <Text className="text-ui-fg-base font-medium" size="small">
+                {website.site_status === "live"
+                  ? "Your site is live"
+                  : "Your site is on its way"}
+              </Text>
+              <a
+                href={previewUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-ui-fg-interactive text-sm"
+              >
+                {previewUrl}
+              </a>
+            </div>
+            <Button variant="secondary" size="small" asChild>
+              <a href={previewUrl} target="_blank" rel="noopener noreferrer">
+                Open
+              </a>
+            </Button>
+          </div>
+
+          {website.site_status === "provisioning" && (
+            <Alert variant="info">
+              First build takes about a minute. Refresh this page to check the
+              status.
+            </Alert>
+          )}
+
+          <div>
+            <Text className="text-ui-fg-base mb-1 font-medium" size="small">
+              Use your own domain
+            </Text>
+            <Text className="text-ui-fg-subtle mb-2" size="xsmall">
+              Add this CNAME record at your domain registrar, then point us to
+              it.
+            </Text>
+            <CodeBlock
+              code={`CNAME   shop   ${website.handle}.sites.freeblackmarket.com`}
+            />
+          </div>
+
+          {website.site_repo && (
+            <Text className="text-ui-fg-muted" size="xsmall">
+              Source repository: {website.site_repo}
+            </Text>
+          )}
+        </div>
+      )}
+
+      {/* Failed state */}
+      {website.site_status === "failed" && (
+        <Alert variant="error">
+          <div className="flex items-center gap-2">
+            <ExclamationCircle />
+            Provisioning didn't finish. You can try launching again below.
+          </div>
+        </Alert>
+      )}
+
+      {/* Initial state — what you get + launch */}
+      {!launched && (
+        <>
+          <div className="border-ui-border-base rounded-lg border p-4">
+            <Text className="text-ui-fg-base mb-3 font-medium" size="small">
+              What you get
+            </Text>
+            <ul className="flex flex-col gap-2">
+              {PERKS.map((p) => (
+                <li key={p} className="flex items-start gap-2">
+                  <CheckCircleSolid className="text-ui-tag-green-icon mt-0.5 shrink-0" />
+                  <Text className="text-ui-fg-subtle" size="small">
+                    {p}
+                  </Text>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="border-ui-border-base bg-ui-bg-subtle flex flex-col gap-3 rounded-lg border p-4">
+            <Text className="text-ui-fg-subtle" size="small">
+              Your site will live at
+            </Text>
+            <Text className="text-ui-fg-base font-mono" size="small">
+              {website.handle}.sites.freeblackmarket.com
+            </Text>
+
+            {website.launch_available ? (
+              <div>
+                <Button onClick={onLaunch} isLoading={isPending} type="button">
+                  <RocketLaunch />
+                  Launch my site
+                </Button>
+              </div>
+            ) : (
+              <Alert variant="warning">
+                Site Launch isn't enabled on this deployment yet. You can still
+                use the <strong>Connect</strong> tab to embed your store on an
+                existing website today.
+              </Alert>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/vendor-panel/src/routes/my-website/components/shared.tsx
+++ b/vendor-panel/src/routes/my-website/components/shared.tsx
@@ -1,0 +1,93 @@
+import { CheckCircleSolid } from "@medusajs/icons"
+import { Button, Text, clx, toast } from "@medusajs/ui"
+import copy from "copy-to-clipboard"
+import { useState } from "react"
+
+/** A small copy-to-clipboard button with a transient "Copied" state. */
+export const CopyButton = ({
+  value,
+  label = "Copy",
+  size = "small",
+}: {
+  value: string
+  label?: string
+  size?: "small" | "base"
+}) => {
+  const [done, setDone] = useState(false)
+
+  const onCopy = () => {
+    copy(value)
+    setDone(true)
+    toast.success("Copied to clipboard")
+    setTimeout(() => setDone(false), 2000)
+  }
+
+  return (
+    <Button
+      variant="secondary"
+      size={size}
+      onClick={onCopy}
+      aria-label={label}
+      type="button"
+    >
+      {done ? (
+        <>
+          <CheckCircleSolid className="text-ui-tag-green-icon" />
+          Copied
+        </>
+      ) : (
+        label
+      )}
+    </Button>
+  )
+}
+
+/** A monospace code block with an inline copy button. */
+export const CodeBlock = ({
+  code,
+  className,
+}: {
+  code: string
+  className?: string
+}) => {
+  return (
+    <div
+      className={clx(
+        "bg-ui-bg-subtle border-ui-border-base relative rounded-lg border",
+        className
+      )}
+    >
+      <pre className="text-ui-fg-base overflow-x-auto p-4 pr-24 text-xs leading-relaxed">
+        <code>{code}</code>
+      </pre>
+      <div className="absolute right-2 top-2">
+        <CopyButton value={code} />
+      </div>
+    </div>
+  )
+}
+
+/** A numbered step heading used to walk vendors through setup. */
+export const Step = ({
+  n,
+  title,
+  children,
+}: {
+  n: number
+  title: string
+  children?: React.ReactNode
+}) => {
+  return (
+    <div className="flex gap-3">
+      <div className="bg-ui-bg-base border-ui-border-strong text-ui-fg-base flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-semibold">
+        {n}
+      </div>
+      <div className="flex-1">
+        <Text className="text-ui-fg-base font-medium" size="small">
+          {title}
+        </Text>
+        <div className="mt-2">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/vendor-panel/src/routes/my-website/index.ts
+++ b/vendor-panel/src/routes/my-website/index.ts
@@ -1,0 +1,1 @@
+export { MyWebsite as Component } from "./my-website"

--- a/vendor-panel/src/routes/my-website/my-website.tsx
+++ b/vendor-panel/src/routes/my-website/my-website.tsx
@@ -1,0 +1,64 @@
+import { Code, RocketLaunch } from "@medusajs/icons"
+import { Container, Heading, Tabs, Text } from "@medusajs/ui"
+import { useState } from "react"
+import { useWebsite } from "../../hooks/api/website"
+import { ConnectPanel } from "./components/connect-panel"
+import { LaunchPanel } from "./components/launch-panel"
+
+/**
+ * "My Website" — the vendor's commerce-anywhere control panel.
+ *
+ *   Connect : embed FBM on a site you already have (Mode 1)
+ *   Launch  : provision a standardized FBM-hosted site (Mode 2)
+ */
+export const MyWebsite = () => {
+  const { website, isPending, isError, error } = useWebsite()
+  const [tab, setTab] = useState("connect")
+
+  if (isError) {
+    throw error
+  }
+
+  return (
+    <Container className="p-0">
+      <div className="px-6 py-4">
+        <Heading>My Website</Heading>
+        <Text className="text-ui-fg-subtle mt-1" size="small">
+          Sell anywhere. Embed FBM on your own site, or launch a ready-made one.
+        </Text>
+      </div>
+
+      {isPending || !website ? (
+        <div className="px-6 py-10">
+          <Text className="text-ui-fg-subtle" size="small">
+            Loading…
+          </Text>
+        </div>
+      ) : (
+        <div className="px-6 pb-6">
+          <Tabs value={tab} onValueChange={setTab}>
+            <Tabs.List>
+              <Tabs.Trigger value="connect" className="flex items-center gap-2">
+                <Code />
+                Connect
+              </Tabs.Trigger>
+              <Tabs.Trigger value="launch" className="flex items-center gap-2">
+                <RocketLaunch />
+                Launch
+              </Tabs.Trigger>
+            </Tabs.List>
+
+            <Tabs.Content value="connect">
+              <ConnectPanel website={website} />
+            </Tabs.Content>
+            <Tabs.Content value="launch">
+              <LaunchPanel website={website} />
+            </Tabs.Content>
+          </Tabs>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const Component = MyWebsite


### PR DESCRIPTION
## Summary

This PR introduces **FBM Connect** — a complete "commerce anywhere" platform that lets vendors embed their FBM catalog and checkout on any website, or launch a standardized FBM-hosted storefront in one click.

### What Changed

**1. Public Store API** (`/store/vendors/:handle`)
- New unauthenticated endpoint that returns vendor profile, products, and events with pre-computed pricing and cart URLs
- Supports currency conversion, pagination, and selective includes
- Open CORS (reflects request origin) for third-party site integration
- Documented in `docs/integrations/fbm-connect.md`

**2. Connect SDK** (`connect.js`)
- 425-line, zero-dependency JavaScript library served from the storefront
- Three integration layers:
  - **Zero JS**: Drop `<div data-fbm="products"></div>` elements that render themselves
  - **Widgets**: `FBM.renderProducts('#shop', { limit: 6 })` for styled UI injection
  - **Raw API**: `await FBM.getProducts()` for custom implementations
- Configurable entirely from script tag attributes (`data-fbm-handle`, `data-fbm-api`, etc.)
- Handles caching, price formatting, and deep-linking to checkout

**3. Vendor "My Website" Panel**
- New tab in vendor panel with two modes:
  - **Connect**: Paste a snippet on any site (Squarespace, Webflow, WordPress, etc.) to embed the catalog
  - **Launch**: One-click provisioning of a standardized FBM-hosted site
- UI components for domain whitelisting, snippet copying, and launch status tracking
- React hooks for API integration (`useWebsite`, `useUpdateWebsiteDomains`, `useLaunchWebsite`)

**4. Site Provisioning**
- Backend helpers to normalize domains and provision GitHub-based sites
- `POST /vendor/website/launch` endpoint that creates a repo from template and dispatches GitHub Actions
- Graceful degradation (HTTP 501) when Launch isn't configured
- Stores provisioning state on `seller_metadata` (site_status, site_url, site_repo)

**5. FBM Site Template**
- Minimal, customizable HTML/CSS template for launched sites
- Pre-configured with Connect SDK and `data-fbm="…"` elements
- GitHub Actions workflow (`configure.yml`) to bake vendor handle into template and deploy to GitHub Pages
- Serves as Mode 1 (Connect) pre-assembled for vendors without existing sites

**6. Database & Config**
- Migration adding `connect_domains`, `site_status`, `site_url`, `site_repo` columns to `seller_metadata`
- Environment variables for GitHub provisioning (token, org, template repo) and site domain configuration
- CORS middleware for public Store API (reflects origin, no credentials)

### Why This Was Needed

Vendors were locked into selling only on FBM's storefront. This change enables:
- **Existing site owners** to embed FBM checkout without leaving their domain
- **New vendors** to launch a professional storefront instantly without technical setup
- **Framework agnostic** integration (works on Squarespace, Webflow, raw HTML, React, etc.)
- **Decoupled architecture** where the Store API is a stable, public contract any site can consume

## Related Issues

Closes #fbm-connect

## Validation

- Endpoint tested with curl and browser (public, no auth required)
- Connect SDK tested in browser console and embedded on test pages
- Vendor panel UI tested with mock data and API responses
- GitHub provisioning tested with template repo and workflow dispatch
- CORS headers verified for third-party origin requests
- Migration verified to add columns without data loss

## Release Notes

- [ ] No release note needed
- [x] Release note required (describe below)

**Release note:**

Vendors can now sell anywhere with **FBM Connect**. Embed your catalog and checkout on any website with a single `<script>` tag, or launch a ready-made FBM-hosted storefront in one click. New "My Website" tab in the vendor panel provides both options with copy-paste snippets and one-click provisioning.

https://claude.ai/code/session_01MgiH4wvxyHKpU3NfdDTKib