### PR TITLE
FBM Sites: auto-flip launched site provisioning → live

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -215,6 +215,14 @@ GITHUB_ORG=Blackmarket-coa
 # Template repo (must be marked "Template repository") new sites are generated
 # from. See templates/fbm-site-template/README.md.
 SITE_TEMPLATE_REPO=Blackmarket-coa/fbm-site-template
+#
+# --- Deploy callback (auto-flip provisioning -> live) ---
+# Shared HMAC secret for the POST /webhooks/site-deploy callback a launched
+# site's deploy workflow sends when it goes live. Set the SAME value as an
+# org-level `FBM_DEPLOY_SECRET` Actions secret on the launched-site repos.
+# Leave blank to disable the webhook; the vendor panel still auto-detects the
+# live site via a liveness probe + polling.
+SITE_DEPLOY_SECRET=
 
 
 # =============================================================================

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -19,6 +19,7 @@ import {
   authSessionRateLimiter,
   bugReportAnonymousRateLimiter,
   bugReportAuthRateLimiter,
+  standardRateLimiter,
   strictAuthRateLimiter,
   vendorRegistrationRateLimiter,
 } from "../shared/rate-limiter";
@@ -1032,6 +1033,12 @@ export default defineMiddlewares({
       matcher: "/admin/bug-report",
       method: "POST",
       middlewares: [bugReportAuthRateLimiter],
+    },
+    // FBM Sites — inbound deploy callback (HMAC-verified in the handler).
+    {
+      matcher: "/webhooks/site-deploy",
+      method: "POST",
+      middlewares: [standardRateLimiter],
     },
   ],
   // Sanitizes 5xx error responses in production so internal detail

--- a/backend/src/api/vendor/website/route.ts
+++ b/backend/src/api/vendor/website/route.ts
@@ -10,7 +10,10 @@ import {
   createSellerMetadataRecord,
   updateSellerMetadataRecord,
 } from "../../../modules/seller-extension/metadata-service";
-import { normalizeDomains } from "../../../shared/site-provisioning";
+import {
+  normalizeDomains,
+  probeSiteLive,
+} from "../../../shared/site-provisioning";
 import { serializeWebsite } from "../../../shared/website-config";
 
 type SellerRow = { id: string; handle: string };
@@ -62,7 +65,26 @@ export async function GET(
         .status(404)
         .json({ message: "Seller not found", type: "not_found" });
     }
-    return res.json({ website: serializeWebsite(seller.handle, meta) });
+
+    // Self-healing promote: while a launched site is provisioning, probe it and
+    // flip to "live" the moment it answers. Bounded + awaited so the response
+    // reflects the new status immediately (the panel polls this endpoint). This
+    // is the always-on fallback for the optional /webhooks/site-deploy callback.
+    let effectiveMeta = meta;
+    if (meta?.site_status === "provisioning" && meta.site_url) {
+      const live = await probeSiteLive(meta.site_url);
+      if (live) {
+        const sellerExtension = req.scope.resolve("sellerExtension");
+        await updateSellerMetadataRecord(sellerExtension as any, [
+          { id: meta.id, site_status: "live" },
+        ]);
+        effectiveMeta = { ...meta, site_status: "live" };
+      }
+    }
+
+    return res.json({
+      website: serializeWebsite(seller.handle, effectiveMeta),
+    });
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : "Unknown error";
     log.error("[GET /vendor/website] failed:", msg);

--- a/backend/src/api/webhooks/site-deploy/route.ts
+++ b/backend/src/api/webhooks/site-deploy/route.ts
@@ -1,0 +1,89 @@
+import { createLogger } from "../../../shared/logger";
+const log = createLogger("api/webhooks/site-deploy");
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { updateSellerMetadataRecord } from "../../../modules/seller-extension/metadata-service";
+import {
+  isDeployCallbackConfigured,
+  verifyDeploySignature,
+} from "../../../shared/site-provisioning";
+
+/**
+ * POST /webhooks/site-deploy
+ *
+ * Inbound callback from a launched FBM site's GitHub Actions deploy. Flips the
+ * vendor's `seller_metadata.site_status` from "provisioning" to "live" (or
+ * "failed") in real time once the static site is published.
+ *
+ * Public + unauthenticated: authenticity is established by an HMAC-SHA256
+ * signature over the raw body (header `x-fbm-signature`, secret
+ * SITE_DEPLOY_SECRET). Gated on that secret — returns 501 when unconfigured,
+ * mirroring how Launch itself degrades. The liveness probe in
+ * GET /vendor/website is the always-on fallback when this isn't wired.
+ */
+export const AUTHENTICATE = false;
+
+type Body = { repo?: string; url?: string; status?: "live" | "failed" };
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  if (!isDeployCallbackConfigured()) {
+    return res.status(501).json({
+      message: "Deploy callback not configured",
+      type: "not_implemented",
+    });
+  }
+
+  const signature = String(req.headers["x-fbm-signature"] || "");
+  const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+  const payload =
+    rawBody && Buffer.isBuffer(rawBody)
+      ? rawBody
+      : JSON.stringify(req.body ?? {});
+
+  if (!verifyDeploySignature(payload, signature)) {
+    return res
+      .status(401)
+      .json({ message: "Invalid signature", type: "unauthorized" });
+  }
+
+  const body = (req.body || {}) as Body;
+  const repo = typeof body.repo === "string" ? body.repo.trim() : "";
+  const url = typeof body.url === "string" ? body.url.trim() : "";
+  const status = body.status === "failed" ? "failed" : "live";
+
+  if (!repo) {
+    return res
+      .status(400)
+      .json({ message: "repo is required", type: "invalid_data" });
+  }
+
+  try {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+    const { data: rows } = await query.graph({
+      entity: "seller_metadata",
+      fields: ["id", "site_status"],
+      filters: { site_repo: repo } as Record<string, unknown>,
+    });
+    const row = rows?.[0] as { id: string } | undefined;
+
+    if (row) {
+      const sellerExtension = req.scope.resolve("sellerExtension");
+      await updateSellerMetadataRecord(sellerExtension as any, [
+        { id: row.id, site_status: status, ...(url ? { site_url: url } : {}) },
+      ]);
+      log.info(`site-deploy callback: ${repo} -> ${status}`);
+    } else {
+      // Signed correctly but no matching site — don't reveal that to the caller.
+      log.warn(`site-deploy callback for unknown repo: ${repo}`);
+    }
+
+    // Always 200 once authenticated, regardless of whether a row matched.
+    return res.status(200).json({ ok: true });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    log.error(`site-deploy callback failed for ${repo}:`, msg);
+    return res
+      .status(500)
+      .json({ message: "Failed to update site status", type: "server_error" });
+  }
+}

--- a/backend/src/shared/__tests__/site-provisioning.unit.spec.ts
+++ b/backend/src/shared/__tests__/site-provisioning.unit.spec.ts
@@ -1,0 +1,51 @@
+import { createHmac } from "crypto";
+import {
+  isDeployCallbackConfigured,
+  verifyDeploySignature,
+} from "../site-provisioning";
+
+const sign = (body: string, secret: string) =>
+  createHmac("sha256", secret).update(body).digest("hex");
+
+describe("site-provisioning deploy callback verification", () => {
+  const ORIGINAL = process.env.SITE_DEPLOY_SECRET;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.SITE_DEPLOY_SECRET;
+    } else {
+      process.env.SITE_DEPLOY_SECRET = ORIGINAL;
+    }
+  });
+
+  it("isDeployCallbackConfigured reflects the env var", () => {
+    delete process.env.SITE_DEPLOY_SECRET;
+    expect(isDeployCallbackConfigured()).toBe(false);
+    process.env.SITE_DEPLOY_SECRET = "s3cret";
+    expect(isDeployCallbackConfigured()).toBe(true);
+  });
+
+  it("accepts a correct signature (string and Buffer bodies)", () => {
+    process.env.SITE_DEPLOY_SECRET = "s3cret";
+    const body = JSON.stringify({ repo: "org/site-x", status: "live" });
+    const sig = sign(body, "s3cret");
+    expect(verifyDeploySignature(body, sig)).toBe(true);
+    expect(verifyDeploySignature(Buffer.from(body), sig)).toBe(true);
+  });
+
+  it("rejects a wrong or malformed signature", () => {
+    process.env.SITE_DEPLOY_SECRET = "s3cret";
+    const body = JSON.stringify({ repo: "org/site-x" });
+    expect(verifyDeploySignature(body, sign(body, "different-secret"))).toBe(
+      false,
+    );
+    expect(verifyDeploySignature(body, "deadbeef")).toBe(false);
+  });
+
+  it("rejects when the secret or signature is missing", () => {
+    process.env.SITE_DEPLOY_SECRET = "s3cret";
+    expect(verifyDeploySignature("{}", "")).toBe(false);
+    delete process.env.SITE_DEPLOY_SECRET;
+    expect(verifyDeploySignature("{}", "abc123")).toBe(false);
+  });
+});

--- a/backend/src/shared/site-provisioning.ts
+++ b/backend/src/shared/site-provisioning.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "crypto";
 import { createLogger } from "./logger";
 
 const log = createLogger("shared/site-provisioning");
@@ -36,6 +37,63 @@ export function isLaunchConfigured(): boolean {
 /** Public URL a launched site is served at. */
 export function launchedSiteUrl(subdomain: string): string {
   return `https://${subdomain}.${SITES_DOMAIN}`;
+}
+
+// ─── Deploy → live status flip ───────────────────────────────────────────────
+
+/** True when the deploy → live webhook callback is wired (shared HMAC secret). */
+export function isDeployCallbackConfigured(): boolean {
+  return Boolean(process.env.SITE_DEPLOY_SECRET);
+}
+
+/**
+ * Verify an HMAC-SHA256 signature over the raw webhook body using
+ * SITE_DEPLOY_SECRET. Timing-safe. Mirrors the Printful webhook verification at
+ * src/api/store/printful/webhooks/route.ts.
+ */
+export function verifyDeploySignature(
+  rawBody: Buffer | string,
+  signature: string,
+): boolean {
+  const secret = process.env.SITE_DEPLOY_SECRET;
+  if (!secret || !signature) return false;
+
+  const body = Buffer.isBuffer(rawBody)
+    ? rawBody.toString("utf8")
+    : String(rawBody ?? "");
+  const digest = createHmac("sha256", secret).update(body).digest("hex");
+
+  const expected = Buffer.from(digest);
+  const provided = Buffer.from(signature);
+  // timingSafeEqual throws on length mismatch — guard first.
+  if (expected.length !== provided.length) return false;
+  try {
+    return timingSafeEqual(expected, provided);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lightweight liveness probe for a launched site. `url` is always server-derived
+ * (launchedSiteUrl / persisted site_url), never user input, so this is not an
+ * SSRF vector. Never throws — returns false on any error or timeout.
+ */
+export async function probeSiteLive(
+  url: string,
+  timeoutMs = 2500,
+): Promise<boolean> {
+  try {
+    const res = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    // 2xx/3xx means the host is serving the site; 404 = not published yet.
+    return res.status >= 200 && res.status < 400;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/docs/integrations/fbm-connect.md
+++ b/docs/integrations/fbm-connect.md
@@ -208,3 +208,28 @@ When set, `POST /vendor/website/launch`:
    [`configure`](../../templates/fbm-site-template/.github/workflows/configure.yml)
    workflow bakes the handle in and deploys to GitHub Pages.
 3. Records `site_status=provisioning`, `site_url`, `site_repo` on the vendor.
+
+### Status lifecycle: `none → provisioning → live | failed`
+
+A launched site starts at `provisioning`. It is promoted to `live` by **either**
+mechanism (both safe, independent):
+
+- **Liveness probe + poll (always on, zero config).** While `provisioning`, the
+  vendor panel polls `GET /vendor/website` every 8s. That read fires a bounded,
+  server-side `HEAD` probe against the (server-derived) `site_url` and flips the
+  row to `live` the moment the site answers. No secret required.
+- **Deploy webhook (real-time, opt-in).** `POST /webhooks/site-deploy` —
+  unauthenticated but HMAC-verified. The launched site's deploy workflow signs
+  `{ repo, url, status }` with `SITE_DEPLOY_SECRET` (header `x-fbm-signature`,
+  HMAC-SHA256 over the raw body) and posts it the instant Pages publishes. The
+  backend finds the row by `site_repo` and sets `site_status` + `site_url`.
+
+  | Condition                       | Response |
+  | ------------------------------- | -------- |
+  | `SITE_DEPLOY_SECRET` unset      | `501`    |
+  | bad/missing signature           | `401`    |
+  | valid (matched or not)          | `200 { ok: true }` |
+
+  Enablement: set `SITE_DEPLOY_SECRET` on the backend **and** the same value as an
+  org-level `FBM_DEPLOY_SECRET` Actions secret on the launched-site repos (the
+  template's deploy step is inert without it).

--- a/templates/fbm-site-template/.github/workflows/configure.yml
+++ b/templates/fbm-site-template/.github/workflows/configure.yml
@@ -81,3 +81,29 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # Tell FBM the site is live so the vendor panel flips provisioning -> live.
+      # Inert unless the FBM_DEPLOY_SECRET repo/org secret is set.
+      - name: Notify FBM that the site is live
+        continue-on-error: true
+        env:
+          FBM_DEPLOY_SECRET: ${{ secrets.FBM_DEPLOY_SECRET }}
+          FBM_API: ${{ vars.FBM_API }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FBM_DEPLOY_SECRET:-}" ]; then
+            echo "FBM_DEPLOY_SECRET not set; skipping status callback."
+            exit 0
+          fi
+          API="${FBM_API:-https://api.freeblackmarket.com}"
+          BODY=$(printf '{"repo":"%s","url":"%s","status":"live"}' \
+            "$GITHUB_REPOSITORY" "${PAGE_URL:-}")
+          SIG=$(printf '%s' "$BODY" \
+            | openssl dgst -sha256 -hmac "$FBM_DEPLOY_SECRET" \
+            | sed 's/^.*= *//')
+          echo "Notifying $API/webhooks/site-deploy"
+          curl -fsS -X POST "$API/webhooks/site-deploy" \
+            -H "Content-Type: application/json" \
+            -H "x-fbm-signature: $SIG" \
+            --data "$BODY"

--- a/templates/fbm-site-template/.github/workflows/deploy.yml
+++ b/templates/fbm-site-template/.github/workflows/deploy.yml
@@ -37,3 +37,29 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # Tell FBM the site is live so the vendor panel flips provisioning -> live.
+      # Inert unless the FBM_DEPLOY_SECRET repo/org secret is set.
+      - name: Notify FBM that the site is live
+        continue-on-error: true
+        env:
+          FBM_DEPLOY_SECRET: ${{ secrets.FBM_DEPLOY_SECRET }}
+          FBM_API: ${{ vars.FBM_API }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FBM_DEPLOY_SECRET:-}" ]; then
+            echo "FBM_DEPLOY_SECRET not set; skipping status callback."
+            exit 0
+          fi
+          API="${FBM_API:-https://api.freeblackmarket.com}"
+          BODY=$(printf '{"repo":"%s","url":"%s","status":"live"}' \
+            "$GITHUB_REPOSITORY" "${PAGE_URL:-}")
+          SIG=$(printf '%s' "$BODY" \
+            | openssl dgst -sha256 -hmac "$FBM_DEPLOY_SECRET" \
+            | sed 's/^.*= *//')
+          echo "Notifying $API/webhooks/site-deploy"
+          curl -fsS -X POST "$API/webhooks/site-deploy" \
+            -H "Content-Type: application/json" \
+            -H "x-fbm-signature: $SIG" \
+            --data "$BODY"

--- a/vendor-panel/src/hooks/api/website.tsx
+++ b/vendor-panel/src/hooks/api/website.tsx
@@ -43,6 +43,13 @@ export const useWebsite = (
   const { data, ...rest } = useQuery({
     queryFn: () => fetchQuery("/vendor/website", { method: "GET" }),
     queryKey: websiteQueryKeys.details(),
+    // Auto-poll while a launched site is provisioning so the panel flips to
+    // "Live" on its own — the backend promotes the row once the site answers.
+    refetchInterval: (query) =>
+      (query.state.data as FbmWebsiteResponse | undefined)?.website
+        ?.site_status === "provisioning"
+        ? 8000
+        : false,
     ...options,
   })
 


### PR DESCRIPTION
## Why

PR #705 shipped one-click **Launch** but left launched sites stuck showing **"Provisioning…"** forever — nothing flipped `seller_metadata.site_status` to `live` once the GitHub Pages deploy finished. This follow-up makes the status update itself.

## What

Two complementary, independently-safe mechanisms (no new infra required to merge — both degrade gracefully):

**1. Liveness probe + panel auto-poll (always on, zero config)**
While a site is `provisioning`, the vendor panel polls `GET /vendor/website` every 8s. That read fires a bounded, server-side `HEAD` probe against the (server-derived) `site_url` and promotes the row to `live` the moment the site answers. No secret needed.

**2. Deploy webhook (real-time, opt-in)**
New public `POST /webhooks/site-deploy` — `AUTHENTICATE = false`, HMAC-SHA256 verified over the raw body (`x-fbm-signature` / `SITE_DEPLOY_SECRET`, mirroring the Printful webhook). Finds the row by `site_repo`, sets `site_status` + `site_url`. Gated like Launch itself:

| Condition | Response |
| --- | --- |
| `SITE_DEPLOY_SECRET` unset | `501` |
| bad/missing signature | `401` |
| valid (matched or not) | `200 {"ok":true}` |

The launched site's deploy workflow posts the signed callback the instant Pages publishes — inert until the org-level `FBM_DEPLOY_SECRET` Actions secret is set.

## Changes
- **backend** — `verifyDeploySignature` / `isDeployCallbackConfigured` / `probeSiteLive` helpers (`shared/site-provisioning.ts`); `webhooks/site-deploy` route; `GET /vendor/website` promote; `standardRateLimiter` on the webhook; unit test for the HMAC verify.
- **vendor-panel** — `useWebsite` auto-polls while provisioning.
- **template** — `configure.yml` + `deploy.yml` gain a signed "Notify FBM" step (gated on the secret).
- **docs + `.env.production.example`** — status lifecycle (`none → provisioning → live | failed`), the webhook contract, and `SITE_DEPLOY_SECRET`.

## Verification
- ✅ backend typecheck · backend eslint (changed files) · no-console
- ✅ vendor-panel typecheck + routes typecheck · eslint
- ✅ new Jest unit test (`site-provisioning.unit.spec.ts`, 4/4) · both workflow YAMLs parse

Scope note: creating/populating the `fbm-site-template` repo and setting env/DNS remain operational steps (already documented) and are intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgiH4wvxyHKpU3NfdDTKib)_