### PR TITLE
feat(storefront): calm tone/light experience layer + shaping onboarding

### DIFF
--- a/docs/BLACKOUT_EXPERIENCE_LAYER.md
+++ b/docs/BLACKOUT_EXPERIENCE_LAYER.md
@@ -1,0 +1,78 @@
+# Blackout Experience Layer — Calm Tones, Pleasant Lights & Shaping Onboarding
+
+This document describes the storefront "experience layer": psychologically-pleasant
+audio/visual feedback for positive moments, and an ethical (White-Hat) onboarding flow.
+It also records the **deferred** XP-economy design (Stage 2) so it can be picked up later.
+
+## Goals
+
+1. Acknowledge positive interactions (across FBM **and** Blackout-bridged moments) with
+   **calm, pleasant tones and lights** — psychoacoustically and visually gentle, not
+   slot-machine. **On by default, fully toggleable off.**
+2. Onboard members with **behavioral "shaping"** done ethically — momentum and encouragement,
+   never streak anxiety, guilt, or manufactured scarcity.
+
+## What shipped (Stage 1 — experience layer)
+
+Implemented entirely in the **storefront** (Next.js / React), reusing the existing
+`progression` (XP / character sheet) system as-is.
+
+### Audio — `src/lib/audio/earcons.ts`
+- Dependency-free Web Audio synthesizer. Calm earcon design: consonant simple-ratio intervals
+  (octave 2:1, perfect fifth 3:2, major third 5:4), fundamentals ~500–1000 Hz (clear of the
+  2–4 kHz "alarm" band), soft ≥20 ms attack + gentle exponential release, sine/triangle
+  oscillators, low default volume. Optional alternate tuning (e.g. 432 Hz).
+- Three earcons: `confirm` (small actions), `celebrate` (orders / onboarding steps),
+  `milestone` (level-ups / titles / onboarding complete).
+- SSR-safe; `AudioContext` created lazily on first use (autoplay-policy friendly).
+
+### Lights — `src/app/globals.css` + `BlackoutEffects/Bloom.tsx`
+- A transient warm amber/forest "bloom" glow on positive moments (reuses solarpunk palette).
+- Optional **warm night grading** (`html[data-blackout-night]`) for a lower-strain palette.
+- All motion is suppressed under `@media (prefers-reduced-motion: reduce)`.
+
+### Preferences + provider — `src/components/providers/BlackoutEffects/`
+- Context provider (mirrors the admin `theme-provider` pattern) persisting to `localStorage`
+  key `fbm_blackout_prefs`. Prefs: `soundEnabled`, `lightsEnabled`, `nightGrading`, `volume`
+  — **all sensory effects default ON**.
+- `useBlackoutEffects().celebrate(kind)` is the single entry point (plays tone if sound on,
+  shows bloom if lights on and motion is allowed).
+- `CelebrateOnMount` is a drop-in for server pages (dedupes per event via `sessionStorage`).
+
+### Settings — `src/components/molecules/BlackoutEffectsSettings/`
+- "Effects & Sound" section on `/user/settings`: switches for Sound, Lights, Warm night mode,
+  plus a volume slider.
+
+### Trigger wiring (all FBM moments + Blackout-bridged events)
+- **Order confirmed** (`order/[id]/confirmed`) — the `purchase.succeeded` moment → `celebrate`.
+- **Add to cart** — soft `confirm` (centralized in `CartProvider`).
+- **Level-up / new title** (`/character` via `ProgressWatcher`) → `milestone`.
+- **Onboarding step completion** (below) → `celebrate` / `milestone`.
+- Inside the Blackout embed the effects fire automatically (same React app) and respect prefs.
+
+### Onboarding — `src/components/sections/Onboarding/OnboardingChecklist.tsx`
+Rendered on `/start` for authenticated members; steps derived from real account signals.
+- **Endowed-progress head start**: the first step ("Account created") arrives pre-completed.
+- Progress **bar** (no bare "2/4" count) → framed as growth, not deficit.
+- Calm celebration on newly-completed steps (vs. last seen, persisted locally).
+- Always dismissible; every step optional. **No streaks, countdowns, guilt, or fake scarcity.**
+
+### Tests — `src/__tests__/earcons.test.ts`
+Cover the pure earcon acoustics (intervals, attack/release, frequency band, retuning) and the
+preferences normalization (defaults-on, validation/clamping).
+
+## Deferred — Stage 2 (XP economy; NOT yet built)
+
+Design decisions already made with the product owner, recorded here for continuity:
+
+- **Dual balance.** Keep `total_xp` as non-spendable lifetime *status* (drives levels/titles).
+  Add a separate **spendable** balance — either a `spendable_xp` column on `character_sheet`
+  or a dedicated `xp_wallet` reusing the append-only `XpEvent`/ledger pattern. Spending never
+  lowers a member's level.
+- **Redemption** for **both** entitlement perks (themes, emoji packs, access passes, featured
+  slots — via the `entitlement` module) **and** digital-product downloads (via
+  `digital-product` fulfillment). Follow the `volunteer/TimeCredit` earn→redeem precedent.
+- **Accrual wiring.** Call `progression.recordXpEvent` from the blackout/FBM subscribers
+  (`backend/src/subscribers/emit-blackout-*`) so XP accrues from both platforms.
+- Threshold gating via `entitlement`; anti-speculation guaranteed because XP is
+  non-transferable by construction.

--- a/storefront/src/__tests__/earcons.test.ts
+++ b/storefront/src/__tests__/earcons.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import { getEarconSpec, RATIOS, type EarconKind } from "@/lib/audio/earcons"
+import {
+  DEFAULT_PREFS,
+  normalizePrefs,
+} from "@/components/providers/BlackoutEffects/context"
+
+describe("getEarconSpec", () => {
+  const kinds: EarconKind[] = ["confirm", "celebrate", "milestone"]
+
+  it("produces at least one tone for every earcon", () => {
+    for (const kind of kinds) {
+      const spec = getEarconSpec(kind)
+      expect(spec.tones.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("uses a click-free soft attack (>= 20ms) and a release tail", () => {
+    for (const kind of kinds) {
+      const spec = getEarconSpec(kind)
+      expect(spec.attack).toBeGreaterThanOrEqual(0.02)
+      expect(spec.release).toBeGreaterThan(0)
+    }
+  })
+
+  it("keeps fundamentals in a calm, audible band (well below the 2-4kHz alarm zone)", () => {
+    for (const kind of kinds) {
+      const spec = getEarconSpec(kind)
+      for (const tone of spec.tones) {
+        expect(tone.freq).toBeGreaterThan(200)
+        expect(tone.freq).toBeLessThan(2000)
+        expect(tone.duration).toBeGreaterThan(0)
+        expect(tone.at).toBeGreaterThanOrEqual(0)
+      }
+    }
+  })
+
+  it("builds the celebrate motif from consonant ratios of the fundamental", () => {
+    const base = 528
+    const spec = getEarconSpec("celebrate", base)
+    const freqs = spec.tones.map((t) => t.freq)
+    expect(freqs).toContain(base)
+    expect(freqs).toContain(base * RATIOS.majorThird)
+    expect(freqs).toContain(base * RATIOS.perfectFifth)
+  })
+
+  it("retunes to an alternate fundamental (e.g. 432)", () => {
+    const spec = getEarconSpec("confirm", 432)
+    expect(spec.tones[0].freq).toBe(432)
+  })
+})
+
+describe("normalizePrefs", () => {
+  it("falls back to defaults for non-object input", () => {
+    expect(normalizePrefs(null)).toEqual(DEFAULT_PREFS)
+    expect(normalizePrefs("nope")).toEqual(DEFAULT_PREFS)
+    expect(normalizePrefs(42)).toEqual(DEFAULT_PREFS)
+  })
+
+  it("defaults all sensory effects to ON", () => {
+    expect(DEFAULT_PREFS.soundEnabled).toBe(true)
+    expect(DEFAULT_PREFS.lightsEnabled).toBe(true)
+  })
+
+  it("keeps valid persisted values and repairs invalid ones", () => {
+    const result = normalizePrefs({
+      soundEnabled: false,
+      lightsEnabled: true,
+      nightGrading: true,
+      volume: 0.5,
+    })
+    expect(result).toEqual({
+      soundEnabled: false,
+      lightsEnabled: true,
+      nightGrading: true,
+      volume: 0.5,
+    })
+  })
+
+  it("clamps an out-of-range or non-numeric volume back to the default", () => {
+    expect(normalizePrefs({ volume: 5 }).volume).toBe(DEFAULT_PREFS.volume)
+    expect(normalizePrefs({ volume: -1 }).volume).toBe(DEFAULT_PREFS.volume)
+    expect(normalizePrefs({ volume: "loud" }).volume).toBe(DEFAULT_PREFS.volume)
+  })
+
+  it("ignores malformed boolean fields", () => {
+    const result = normalizePrefs({ soundEnabled: "yes", nightGrading: 1 })
+    expect(result.soundEnabled).toBe(DEFAULT_PREFS.soundEnabled)
+    expect(result.nightGrading).toBe(DEFAULT_PREFS.nightGrading)
+  })
+})

--- a/storefront/src/app/[locale]/(main)/character/page.tsx
+++ b/storefront/src/app/[locale]/(main)/character/page.tsx
@@ -4,6 +4,7 @@ import { retrieveCustomerContext } from "@/lib/data/customer"
 import { getCharacterSheet } from "@/lib/data/progression"
 import { RoleTrackBar } from "@/components/organisms/CharacterSheet/RoleTrackBar"
 import { TitleBadge } from "@/components/organisms/CharacterSheet/TitleBadge"
+import { ProgressWatcher } from "@/components/organisms/CharacterSheet/ProgressWatcher"
 
 export const metadata: Metadata = {
   title: "Character",
@@ -46,6 +47,10 @@ export default async function CharacterPage() {
 
   return (
     <main className="container">
+      <ProgressWatcher
+        overallLevel={overallLevel}
+        titleCount={character?.titles.length ?? 0}
+      />
       <div className="mt-6 space-y-8">
         <header className="rounded-lg border border-tertiary bg-green-50 p-6">
           <p className="text-secondary text-sm uppercase tracking-wide">

--- a/storefront/src/app/[locale]/(main)/order/[id]/confirmed/page.tsx
+++ b/storefront/src/app/[locale]/(main)/order/[id]/confirmed/page.tsx
@@ -1,4 +1,5 @@
 import { OrderConfirmedSection } from "@/components/sections/OrderConfirmedSection/OrderConfirmedSection"
+import { CelebrateOnMount } from "@/components/providers/BlackoutEffects"
 import { retrieveOrder } from "@/lib/data/orders"
 import { Metadata } from "next"
 import { notFound } from "next/navigation"
@@ -21,6 +22,8 @@ export default async function OrderConfirmedPage(props: Props) {
 
   return (
     <main className="container">
+      {/* Calm tone + warm bloom for the purchase.succeeded moment (once per order). */}
+      <CelebrateOnMount kind="celebrate" dedupeKey={`order:${order.id}`} />
       <OrderConfirmedSection order={order} />
     </main>
   )

--- a/storefront/src/app/[locale]/(main)/start/page.tsx
+++ b/storefront/src/app/[locale]/(main)/start/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next"
+import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
-import { setStance, type Stance } from "@/lib/data/progression"
+import { getCharacterSheet, setStance, type Stance } from "@/lib/data/progression"
+import {
+  OnboardingChecklist,
+  type OnboardingStep,
+} from "@/components/sections/Onboarding/OnboardingChecklist"
 
 export const metadata: Metadata = {
   title: "What are you doing today?",
@@ -64,9 +69,51 @@ async function chooseStance(formData: FormData) {
   redirect(destination)
 }
 
-export default function StartPage() {
+/**
+ * Build the endowed-progress onboarding steps from real account signals.
+ * Returns null for logged-out visitors (the stance cards are their entry point).
+ */
+async function buildOnboardingSteps(): Promise<OnboardingStep[] | null> {
+  const character = await getCharacterSheet()
+  if (!character) return null
+
+  const cookieStore = await cookies()
+  const hasChosenRole = Boolean(cookieStore.get("fbm_stance")?.value)
+
+  return [
+    {
+      id: "join",
+      label: "Account created",
+      hint: "You're in — welcome to the coalition.",
+      done: true, // Endowed-progress head start: the first step is already yours.
+    },
+    {
+      id: "role",
+      label: "Pick how you'll take part",
+      hint: "Produce, acquire, invest, or support — choose a stance below.",
+      done: hasChosenRole,
+    },
+    {
+      id: "xp",
+      label: "Make your first contribution",
+      hint: "Your first action earns experience and grows your character.",
+      done: character.totalXp > 0,
+    },
+    {
+      id: "order",
+      label: "Complete your first exchange",
+      hint: "Place an order to close the loop with another member.",
+      done: character.stats.ordersCompleted > 0,
+    },
+  ]
+}
+
+export default async function StartPage() {
+  const onboardingSteps = await buildOnboardingSteps()
+
   return (
     <main className="container py-10">
+      {onboardingSteps && <OnboardingChecklist steps={onboardingSteps} />}
       <header className="text-center max-w-2xl mx-auto mb-10">
         <h1 className="heading-xl">What are you doing today?</h1>
         <p className="text-secondary mt-3">

--- a/storefront/src/app/[locale]/(main)/user/settings/page.tsx
+++ b/storefront/src/app/[locale]/(main)/user/settings/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { AccountLoadingState, LoginForm, ProfileDetails, UserNavigation } from "@/components/molecules"
 import { ProfilePassword } from "@/components/molecules/ProfileDetails/ProfilePassword"
+import { BlackoutEffectsSettings } from "@/components/molecules/BlackoutEffectsSettings/BlackoutEffectsSettings"
 import { retrieveCustomerContext } from "@/lib/data/customer"
 
 
@@ -25,6 +26,7 @@ export default async function ReviewsPage() {
           <h1 className="heading-md uppercase mb-8">Settings</h1>
           <ProfileDetails user={customer} />
           <ProfilePassword user={customer} />
+          <BlackoutEffectsSettings />
         </div>
       </div>
     </main>

--- a/storefront/src/app/globals.css
+++ b/storefront/src/app/globals.css
@@ -292,3 +292,57 @@ a.link-solarpunk:hover {
   background: rgba(var(--brand-300), 0.4);
   color: rgb(var(--brand-900));
 }
+
+/* ------------------------------------------------------------------ */
+/* Blackout effects — calm "bloom" celebration + warm night grading   */
+/* ------------------------------------------------------------------ */
+
+/* Transient warm glow shown on positive interactions. Decorative only. */
+.blackout-bloom {
+  animation: blackout-bloom-fade 1100ms ease-out forwards;
+}
+.blackout-bloom__glow {
+  background: radial-gradient(
+    circle,
+    rgba(var(--amber-300), 0.5) 0%,
+    rgba(var(--amber-200), 0.3) 30%,
+    rgba(var(--brand-300), 0.12) 55%,
+    rgba(var(--brand-300), 0) 72%
+  );
+  filter: blur(8px);
+  transform: scale(0.4);
+  animation: blackout-bloom-grow 1100ms ease-out forwards;
+}
+
+@keyframes blackout-bloom-fade {
+  0% { opacity: 0; }
+  18% { opacity: 1; }
+  100% { opacity: 0; }
+}
+@keyframes blackout-bloom-grow {
+  0% { transform: scale(0.4); }
+  100% { transform: scale(1); }
+}
+
+/* Gentle organic "breathing" pulse, available for ambient accents. */
+@keyframes blackout-breathe {
+  0%, 100% { opacity: 0.85; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.015); }
+}
+
+/*
+ * Warm night grading: shift the whole UI toward a low-strain, warm palette
+ * (a softened, slightly amber, lower-contrast feel). Toggled by the effects
+ * provider via the `data-blackout-night` attribute on <html>.
+ */
+html[data-blackout-night] body {
+  filter: sepia(0.12) saturate(0.92) brightness(0.97) hue-rotate(-6deg);
+}
+
+/* Respect users who prefer reduced motion: drop all effect animation. */
+@media (prefers-reduced-motion: reduce) {
+  .blackout-bloom,
+  .blackout-bloom__glow {
+    animation: none !important;
+  }
+}

--- a/storefront/src/app/providers.tsx
+++ b/storefront/src/app/providers.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CartProvider } from "@/components/providers"
+import { BlackoutEffectsProvider, CartProvider } from "@/components/providers"
 import { Cart } from "@/types/cart"
 import type React from "react"
 
@@ -11,5 +11,9 @@ interface ProvidersProps extends PropsWithChildren {
 }
 
 export function Providers({ children, cart }: ProvidersProps) {
-  return <CartProvider cart={cart}>{children}</CartProvider>
+  return (
+    <BlackoutEffectsProvider>
+      <CartProvider cart={cart}>{children}</CartProvider>
+    </BlackoutEffectsProvider>
+  )
 }

--- a/storefront/src/components/molecules/BlackoutEffectsSettings/BlackoutEffectsSettings.tsx
+++ b/storefront/src/components/molecules/BlackoutEffectsSettings/BlackoutEffectsSettings.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { Card } from "@/components/atoms/Card/Card"
+import { useBlackoutEffects } from "@/components/providers"
+import { Divider, Heading, Label, Switch, Text } from "@medusajs/ui"
+
+type ToggleRow = {
+  key: "soundEnabled" | "lightsEnabled" | "nightGrading"
+  label: string
+  description: string
+}
+
+const ROWS: ToggleRow[] = [
+  {
+    key: "soundEnabled",
+    label: "Sound",
+    description:
+      "Play soft, calm tones to acknowledge orders, milestones, and other positive moments.",
+  },
+  {
+    key: "lightsEnabled",
+    label: "Lights",
+    description:
+      "Show a gentle warm glow on positive moments. Respects your system's reduced-motion setting.",
+  },
+  {
+    key: "nightGrading",
+    label: "Warm night mode",
+    description:
+      "Shift the interface toward a warmer, lower-strain palette that's easier on the eyes.",
+  },
+]
+
+/**
+ * Account-settings controls for the calm tone + light experience layer.
+ * Effects are ON by default; everything here lets a person dial them back.
+ */
+export const BlackoutEffectsSettings = () => {
+  const { prefs, setPref, celebrate } = useBlackoutEffects()
+
+  return (
+    <>
+      <Card className="bg-secondary p-4 flex justify-between items-center mt-8">
+        <Heading level="h2" className="heading-sm uppercase">
+          Effects &amp; Sound
+        </Heading>
+      </Card>
+      <Card className="p-0">
+        {ROWS.map((row, i) => (
+          <div key={row.key}>
+            <div className="p-4 flex items-start justify-between gap-4">
+              <div className="flex-1">
+                <Label htmlFor={`fx-${row.key}`} className="label-lg text-primary">
+                  {row.label}
+                </Label>
+                <Text className="label-md text-secondary mt-1">
+                  {row.description}
+                </Text>
+              </div>
+              <Switch
+                id={`fx-${row.key}`}
+                checked={prefs[row.key]}
+                onCheckedChange={(checked) => {
+                  setPref(row.key, checked)
+                  // A quick confirmation so a person hears/sees the effect they
+                  // just enabled (no cue when switching something off).
+                  if (checked && row.key !== "nightGrading") {
+                    celebrate("confirm")
+                  }
+                }}
+              />
+            </div>
+            {i < ROWS.length - 1 && <Divider />}
+          </div>
+        ))}
+
+        <Divider />
+        <div className="p-4">
+          <Label htmlFor="fx-volume" className="label-lg text-primary">
+            Sound volume
+          </Label>
+          <Text className="label-md text-secondary mt-1 mb-3">
+            How loud the confirmation tones are.
+          </Text>
+          <input
+            id="fx-volume"
+            type="range"
+            min={0}
+            max={1}
+            step={0.02}
+            value={prefs.volume}
+            disabled={!prefs.soundEnabled}
+            onChange={(e) => setPref("volume", Number(e.target.value))}
+            onMouseUp={() => prefs.soundEnabled && celebrate("confirm")}
+            className="w-full max-w-xs accent-[rgb(var(--brand-500))] disabled:opacity-50"
+            aria-label="Sound volume"
+          />
+        </div>
+      </Card>
+    </>
+  )
+}

--- a/storefront/src/components/organisms/CharacterSheet/ProgressWatcher.tsx
+++ b/storefront/src/components/organisms/CharacterSheet/ProgressWatcher.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import { useBlackoutEffects } from "@/components/providers"
+
+const LEVEL_KEY = "fbm_seen_level"
+const TITLES_KEY = "fbm_seen_titles"
+
+/**
+ * Watches the rendered character sheet and plays a calm milestone celebration
+ * the first time a person sees a new overall level or a newly earned title
+ * (compared to what they last saw, persisted locally). Renders nothing.
+ */
+export function ProgressWatcher({
+  overallLevel,
+  titleCount,
+}: {
+  overallLevel: number
+  titleCount: number
+}) {
+  const { celebrate } = useBlackoutEffects()
+  const fired = useRef(false)
+
+  useEffect(() => {
+    if (fired.current) return
+    fired.current = true
+
+    let leveledUp = false
+    let newTitle = false
+    try {
+      const seenLevel = Number(localStorage.getItem(LEVEL_KEY) ?? "NaN")
+      const seenTitles = Number(localStorage.getItem(TITLES_KEY) ?? "NaN")
+
+      // Only celebrate when we have a prior baseline to compare against, so a
+      // first-ever visit doesn't fire spuriously.
+      leveledUp = Number.isFinite(seenLevel) && overallLevel > seenLevel
+      newTitle = Number.isFinite(seenTitles) && titleCount > seenTitles
+
+      localStorage.setItem(LEVEL_KEY, String(overallLevel))
+      localStorage.setItem(TITLES_KEY, String(titleCount))
+    } catch {
+      return
+    }
+
+    if (leveledUp || newTitle) {
+      celebrate("milestone")
+    }
+  }, [overallLevel, titleCount, celebrate])
+
+  return null
+}

--- a/storefront/src/components/providers/BlackoutEffects/BlackoutEffectsProvider.tsx
+++ b/storefront/src/components/providers/BlackoutEffects/BlackoutEffectsProvider.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { playEarcon, type EarconKind } from "@/lib/audio/earcons"
+import { Bloom } from "./Bloom"
+import {
+  BLACKOUT_PREFS_KEY,
+  BlackoutEffectsContext,
+  DEFAULT_PREFS,
+  normalizePrefs,
+  type BlackoutEffectPrefs,
+} from "./context"
+
+type ActiveBloom = { id: number; kind: EarconKind }
+
+/**
+ * Provides calm tone + light "effects" across the storefront, plus the
+ * preferences (persisted to localStorage) that gate them. Effects default ON
+ * and can be toggled off from account settings.
+ */
+export function BlackoutEffectsProvider({ children }: PropsWithChildren) {
+  // Render with defaults on the server / first paint, then hydrate from storage.
+  const [prefs, setPrefs] = useState<BlackoutEffectPrefs>(DEFAULT_PREFS)
+  const [ready, setReady] = useState(false)
+  const [blooms, setBlooms] = useState<ActiveBloom[]>([])
+  const bloomId = useRef(0)
+
+  // Hydrate persisted prefs once on mount.
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(BLACKOUT_PREFS_KEY)
+      if (raw) setPrefs(normalizePrefs(JSON.parse(raw)))
+    } catch {
+      // Ignore malformed / unavailable storage — defaults stand.
+    }
+    setReady(true)
+  }, [])
+
+  // Reflect night grading onto the document so global CSS can respond.
+  useEffect(() => {
+    if (typeof document === "undefined") return
+    document.documentElement.toggleAttribute(
+      "data-blackout-night",
+      prefs.nightGrading
+    )
+  }, [prefs.nightGrading])
+
+  const setPref = useCallback(
+    <K extends keyof BlackoutEffectPrefs>(
+      key: K,
+      value: BlackoutEffectPrefs[K]
+    ) => {
+      setPrefs((prev) => {
+        const next = { ...prev, [key]: value }
+        try {
+          window.localStorage.setItem(BLACKOUT_PREFS_KEY, JSON.stringify(next))
+        } catch {
+          // Storage may be unavailable (private mode) — keep in-memory state.
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const prefersReducedMotion = useCallback(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    []
+  )
+
+  const celebrate = useCallback(
+    (kind: EarconKind = "confirm") => {
+      if (prefs.soundEnabled) {
+        playEarcon(kind, { volume: prefs.volume })
+      }
+      // The bloom is motion; skip it when the user prefers reduced motion.
+      if (prefs.lightsEnabled && !prefersReducedMotion()) {
+        const id = ++bloomId.current
+        setBlooms((prev) => [...prev, { id, kind }])
+      }
+    },
+    [prefs.soundEnabled, prefs.lightsEnabled, prefs.volume, prefersReducedMotion]
+  )
+
+  const removeBloom = useCallback((id: number) => {
+    setBlooms((prev) => prev.filter((b) => b.id !== id))
+  }, [])
+
+  return (
+    <BlackoutEffectsContext.Provider
+      value={{ prefs, ready, setPref, celebrate }}
+    >
+      {children}
+      {blooms.map((b) => (
+        <Bloom key={b.id} kind={b.kind} onDone={() => removeBloom(b.id)} />
+      ))}
+    </BlackoutEffectsContext.Provider>
+  )
+}

--- a/storefront/src/components/providers/BlackoutEffects/Bloom.tsx
+++ b/storefront/src/components/providers/BlackoutEffects/Bloom.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import type { EarconKind } from "@/lib/audio/earcons"
+
+/**
+ * A transient, full-screen warm "bloom" glow that fades in and out to
+ * acknowledge a positive moment. Reuses the solarpunk amber/forest palette and
+ * is purely decorative (`aria-hidden`, `pointer-events-none`).
+ *
+ * Motion is driven by the `blackout-bloom` keyframes in globals.css, which are
+ * suppressed under `prefers-reduced-motion: reduce`.
+ */
+export function Bloom({
+  kind = "confirm",
+  onDone,
+}: {
+  kind?: EarconKind
+  onDone: () => void
+}) {
+  // Bigger moments glow a touch larger / warmer.
+  const scale =
+    kind === "milestone" ? "70vmax" : kind === "celebrate" ? "55vmax" : "40vmax"
+
+  return (
+    <div
+      aria-hidden
+      onAnimationEnd={onDone}
+      className="blackout-bloom pointer-events-none fixed inset-0 z-[60] flex items-center justify-center"
+    >
+      <span
+        className="blackout-bloom__glow block rounded-full"
+        style={{ width: scale, height: scale }}
+      />
+    </div>
+  )
+}

--- a/storefront/src/components/providers/BlackoutEffects/CelebrateOnMount.tsx
+++ b/storefront/src/components/providers/BlackoutEffects/CelebrateOnMount.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import type { EarconKind } from "@/lib/audio/earcons"
+import { useBlackoutEffects } from "./context"
+
+/**
+ * Fires a single calm celebration when mounted — a drop-in for server-rendered
+ * pages (e.g. order confirmation) that mark a positive moment.
+ *
+ * Pass a stable `dedupeKey` (such as an order id) to ensure the cue plays only
+ * once per real event, even across refreshes or React StrictMode double-mounts.
+ */
+export function CelebrateOnMount({
+  kind = "celebrate",
+  dedupeKey,
+}: {
+  kind?: EarconKind
+  dedupeKey?: string
+}) {
+  const { celebrate } = useBlackoutEffects()
+  const fired = useRef(false)
+
+  useEffect(() => {
+    if (fired.current) return
+    fired.current = true
+
+    if (dedupeKey) {
+      const storeKey = `fbm_celebrated:${dedupeKey}`
+      try {
+        if (sessionStorage.getItem(storeKey)) return
+        sessionStorage.setItem(storeKey, "1")
+      } catch {
+        // sessionStorage unavailable — fall through and celebrate anyway.
+      }
+    }
+
+    celebrate(kind)
+  }, [celebrate, kind, dedupeKey])
+
+  return null
+}

--- a/storefront/src/components/providers/BlackoutEffects/context.tsx
+++ b/storefront/src/components/providers/BlackoutEffects/context.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { createContext, useContext } from "react"
+
+import type { EarconKind } from "@/lib/audio/earcons"
+
+/** User-controllable effect preferences. All sensory effects default ON. */
+export type BlackoutEffectPrefs = {
+  /** Play calm earcons on positive interactions. */
+  soundEnabled: boolean
+  /** Render the warm "bloom" glow on positive interactions. */
+  lightsEnabled: boolean
+  /** Shift the UI toward a warm, low-strain night palette. */
+  nightGrading: boolean
+  /** Earcon master volume, 0..1. */
+  volume: number
+}
+
+export const DEFAULT_PREFS: BlackoutEffectPrefs = {
+  soundEnabled: true,
+  lightsEnabled: true,
+  nightGrading: false,
+  volume: 0.18,
+}
+
+/** localStorage key for persisted preferences. */
+export const BLACKOUT_PREFS_KEY = "fbm_blackout_prefs"
+
+export type BlackoutEffectsContextValue = {
+  prefs: BlackoutEffectPrefs
+  /** Whether prefs have been hydrated from storage (avoids SSR/first-paint flashes). */
+  ready: boolean
+  setPref: <K extends keyof BlackoutEffectPrefs>(
+    key: K,
+    value: BlackoutEffectPrefs[K]
+  ) => void
+  /**
+   * Acknowledge a positive moment: plays an earcon (if sound is on) and shows
+   * a bloom (if lights are on). Honors `prefers-reduced-motion` for the visual.
+   */
+  celebrate: (kind?: EarconKind) => void
+}
+
+export const BlackoutEffectsContext =
+  createContext<BlackoutEffectsContextValue | null>(null)
+
+export function useBlackoutEffects(): BlackoutEffectsContextValue {
+  const context = useContext(BlackoutEffectsContext)
+  if (!context) {
+    throw new Error(
+      "useBlackoutEffects must be used within a BlackoutEffectsProvider"
+    )
+  }
+  return context
+}
+
+/**
+ * Merge an unknown persisted value with defaults, dropping anything malformed.
+ * Pure + exported so the persistence logic is unit-testable.
+ */
+export function normalizePrefs(raw: unknown): BlackoutEffectPrefs {
+  if (!raw || typeof raw !== "object") return { ...DEFAULT_PREFS }
+  const r = raw as Partial<Record<keyof BlackoutEffectPrefs, unknown>>
+  return {
+    soundEnabled:
+      typeof r.soundEnabled === "boolean"
+        ? r.soundEnabled
+        : DEFAULT_PREFS.soundEnabled,
+    lightsEnabled:
+      typeof r.lightsEnabled === "boolean"
+        ? r.lightsEnabled
+        : DEFAULT_PREFS.lightsEnabled,
+    nightGrading:
+      typeof r.nightGrading === "boolean"
+        ? r.nightGrading
+        : DEFAULT_PREFS.nightGrading,
+    volume:
+      typeof r.volume === "number" && r.volume >= 0 && r.volume <= 1
+        ? r.volume
+        : DEFAULT_PREFS.volume,
+  }
+}

--- a/storefront/src/components/providers/BlackoutEffects/index.ts
+++ b/storefront/src/components/providers/BlackoutEffects/index.ts
@@ -1,0 +1,12 @@
+export { BlackoutEffectsProvider } from "./BlackoutEffectsProvider"
+export { CelebrateOnMount } from "./CelebrateOnMount"
+export {
+  useBlackoutEffects,
+  DEFAULT_PREFS,
+  BLACKOUT_PREFS_KEY,
+  normalizePrefs,
+} from "./context"
+export type {
+  BlackoutEffectPrefs,
+  BlackoutEffectsContextValue,
+} from "./context"

--- a/storefront/src/components/providers/Cart/CartProvider.tsx
+++ b/storefront/src/components/providers/Cart/CartProvider.tsx
@@ -3,6 +3,7 @@
 import { PropsWithChildren, useEffect, useState } from "react"
 
 import { CartContext } from "./context"
+import { useBlackoutEffects } from "../BlackoutEffects"
 import { Cart, StoreCartLineItemOptimisticUpdate } from "@/types/cart"
 
 interface CartProviderProps extends PropsWithChildren {
@@ -11,6 +12,7 @@ interface CartProviderProps extends PropsWithChildren {
 
 export function CartProvider({ cart, children }: CartProviderProps) {
   const [cartState, setCartState] = useState(cart)
+  const { celebrate } = useBlackoutEffects()
 
   useEffect(() => {
     setCartState(cart)
@@ -20,6 +22,8 @@ export function CartProvider({ cart, children }: CartProviderProps) {
     newItem: StoreCartLineItemOptimisticUpdate,
     currency_code: string
   ) {
+    // A soft, calm acknowledgement for a small positive action.
+    celebrate("confirm")
     setCartState((prev) => {
       const currentItems = prev?.items || []
       const isNewItemInCart = currentItems.find(

--- a/storefront/src/components/providers/index.ts
+++ b/storefront/src/components/providers/index.ts
@@ -1,4 +1,13 @@
 import { CartProvider } from "./Cart/CartProvider"
 import { useCartContext } from "./Cart/context"
+import {
+  BlackoutEffectsProvider,
+  useBlackoutEffects,
+} from "./BlackoutEffects"
 
-export { CartProvider, useCartContext }
+export {
+  CartProvider,
+  useCartContext,
+  BlackoutEffectsProvider,
+  useBlackoutEffects,
+}

--- a/storefront/src/components/sections/Onboarding/OnboardingChecklist.tsx
+++ b/storefront/src/components/sections/Onboarding/OnboardingChecklist.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { useBlackoutEffects } from "@/components/providers"
+
+export type OnboardingStep = {
+  id: string
+  label: string
+  /** Short, encouraging "why this matters" line (epic-meaning framing). */
+  hint: string
+  done: boolean
+}
+
+const DISMISS_KEY = "fbm_onboarding_dismissed"
+const SEEN_DONE_KEY = "fbm_onboarding_seen_done"
+
+/**
+ * White-hat "shaping" onboarding checklist.
+ *
+ * Behavioral design choices, all on the encouraging side of the ledger:
+ *  - Endowed progress: the first step ("Account created") arrives pre-completed
+ *    so a new member starts with momentum rather than at zero.
+ *  - A progress *bar* communicates advancement without a bare "2 / 4" count, so
+ *    the framing is "you're growing" rather than "you're behind".
+ *  - Completing a step plays a calm celebration (competence signal), but there
+ *    are deliberately NO streaks, countdowns, guilt prompts, or fake scarcity.
+ *  - It is always dismissible and every step is optional.
+ */
+export function OnboardingChecklist({ steps }: { steps: OnboardingStep[] }) {
+  const { celebrate } = useBlackoutEffects()
+  const [dismissed, setDismissed] = useState(true) // assume dismissed until storage confirms otherwise
+  const [hydrated, setHydrated] = useState(false)
+  const celebrated = useRef(false)
+
+  const doneCount = useMemo(() => steps.filter((s) => s.done).length, [steps])
+  const total = steps.length
+  const pct = total > 0 ? Math.round((doneCount / total) * 100) : 0
+  const allDone = doneCount === total && total > 0
+
+  // Hydrate dismissal state from storage.
+  useEffect(() => {
+    try {
+      setDismissed(window.localStorage.getItem(DISMISS_KEY) === "1")
+    } catch {
+      setDismissed(false)
+    }
+    setHydrated(true)
+  }, [])
+
+  // Celebrate steps newly completed since the member last saw the checklist.
+  useEffect(() => {
+    if (!hydrated || dismissed || celebrated.current) return
+    celebrated.current = true
+
+    let seen = 0
+    try {
+      seen = Number(window.localStorage.getItem(SEEN_DONE_KEY) ?? "0") || 0
+    } catch {
+      seen = 0
+    }
+
+    if (doneCount > seen) {
+      celebrate(allDone ? "milestone" : "celebrate")
+    }
+
+    try {
+      window.localStorage.setItem(SEEN_DONE_KEY, String(doneCount))
+    } catch {
+      // best-effort persistence
+    }
+  }, [hydrated, dismissed, doneCount, allDone, celebrate])
+
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      window.localStorage.setItem(DISMISS_KEY, "1")
+    } catch {
+      // best-effort persistence
+    }
+  }
+
+  // Avoid a hydration flash; render nothing until we know the dismissal state.
+  if (!hydrated || dismissed || total === 0) return null
+
+  return (
+    <section
+      aria-label="Getting started"
+      className="card-organic max-w-2xl mx-auto mb-10 p-6"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="heading-sm">
+            {allDone
+              ? "You're growing the cooperative economy 🌿"
+              : "Welcome — let's grow your roots"}
+          </h2>
+          <p className="text-secondary text-sm mt-1">
+            {allDone
+              ? "You've planted every starter step. Keep going at your own pace."
+              : "A few gentle steps to find your place in the market. No rush — take them whenever you like."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="text-secondary text-sm underline shrink-0"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      {/* Progress bar (no raw count) */}
+      <div
+        className="mt-4 h-2 w-full rounded-full bg-[rgba(var(--neutral-200),0.6)] overflow-hidden"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Onboarding progress"
+      >
+        <div
+          className="h-full gradient-solarpunk transition-all duration-700"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <ul className="mt-5 flex flex-col gap-3">
+        {steps.map((step) => (
+          <li key={step.id} className="flex items-start gap-3">
+            <span
+              aria-hidden
+              className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs ${
+                step.done
+                  ? "bg-[rgb(var(--brand-500))] text-white"
+                  : "border border-[rgb(var(--neutral-300))] text-transparent"
+              }`}
+            >
+              ✓
+            </span>
+            <div>
+              <p
+                className={`label-md ${
+                  step.done ? "text-secondary line-through" : "text-primary"
+                }`}
+              >
+                {step.label}
+              </p>
+              {!step.done && (
+                <p className="text-secondary text-sm mt-0.5">{step.hint}</p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/storefront/src/lib/audio/earcons.ts
+++ b/storefront/src/lib/audio/earcons.ts
@@ -1,0 +1,203 @@
+/**
+ * Calm earcon synthesizer (Web Audio API, no dependencies).
+ *
+ * Earcons are short, non-verbal sounds used to acknowledge an interaction.
+ * These are deliberately designed to be *pleasant and unobtrusive* rather than
+ * attention-grabbing, following well-established psychoacoustic guidance:
+ *
+ *  - Consonant, simple-ratio intervals (octave 2:1, perfect fifth 3:2, major
+ *    third 5:4) read as "harmonious / resolved" rather than tense.
+ *  - Fundamentals sit in the ~500-1000 Hz range so the tone is clearly audible
+ *    without parking energy in the 2-4 kHz band the ear finds most "alarming".
+ *  - Soft attack (>= 20 ms) and gentle exponential release avoid the click /
+ *    startle of an abrupt gate.
+ *  - Sine / triangle oscillators keep the spectral centroid low (warm, not
+ *    metallic or buzzy).
+ *  - Master gain is low by default — a quiet confirmation, not a slot machine.
+ *
+ * The synth is SSR-safe (every entry point no-ops when `window` /
+ * `AudioContext` is unavailable) and the `AudioContext` is created lazily on
+ * first use so we respect browser autoplay policies (it should be triggered
+ * from a user gesture or an event that follows one).
+ */
+
+export type EarconKind = "confirm" | "celebrate" | "milestone"
+
+/** Consonant interval ratios relative to a fundamental. */
+export const RATIOS = {
+  unison: 1,
+  majorThird: 5 / 4,
+  perfectFifth: 3 / 2,
+  octave: 2,
+} as const
+
+/** A single tone within an earcon, expressed declaratively so it is testable. */
+export type Tone = {
+  /** Frequency in Hz. */
+  freq: number
+  /** Start offset from the earcon trigger, in seconds. */
+  at: number
+  /** Sustained duration in seconds (excludes the release tail). */
+  duration: number
+  /** Peak gain for this voice, 0..1 (scaled by the master volume). */
+  gain?: number
+  type?: OscillatorType
+}
+
+export type EarconSpec = {
+  tones: Tone[]
+  /** Attack ramp in seconds (>= 0.02 to stay click-free). */
+  attack: number
+  /** Release tail in seconds. */
+  release: number
+}
+
+/**
+ * Build the declarative spec for an earcon. Pure (no audio side effects) so the
+ * acoustic design can be unit-tested.
+ *
+ * @param kind   Which earcon to render.
+ * @param baseHz Fundamental frequency. Defaults to a warm 528 Hz. Passing 432
+ *               simply retunes the fundamental — offered as an honest option,
+ *               with no health claims attached.
+ */
+export function getEarconSpec(kind: EarconKind, baseHz = 528): EarconSpec {
+  const attack = 0.025
+  const release = 0.4
+
+  switch (kind) {
+    case "confirm":
+      // A single, soft resolved tone — the everyday acknowledgement.
+      return {
+        attack,
+        release,
+        tones: [{ freq: baseHz, at: 0, duration: 0.16, gain: 1, type: "sine" }],
+      }
+
+    case "celebrate":
+      // A gentle rising motif: fundamental -> major third -> perfect fifth.
+      return {
+        attack,
+        release,
+        tones: [
+          { freq: baseHz, at: 0, duration: 0.16, gain: 0.9, type: "sine" },
+          {
+            freq: baseHz * RATIOS.majorThird,
+            at: 0.12,
+            duration: 0.16,
+            gain: 0.8,
+            type: "sine",
+          },
+          {
+            freq: baseHz * RATIOS.perfectFifth,
+            at: 0.24,
+            duration: 0.28,
+            gain: 0.85,
+            type: "sine",
+          },
+        ],
+      }
+
+    case "milestone":
+      // A fuller "bloom": a fifth chord that opens into the octave above.
+      return {
+        attack: 0.03,
+        release: 0.6,
+        tones: [
+          { freq: baseHz, at: 0, duration: 0.5, gain: 0.7, type: "sine" },
+          {
+            freq: baseHz * RATIOS.perfectFifth,
+            at: 0.06,
+            duration: 0.46,
+            gain: 0.55,
+            type: "sine",
+          },
+          {
+            freq: baseHz * RATIOS.octave,
+            at: 0.18,
+            duration: 0.42,
+            gain: 0.6,
+            type: "triangle",
+          },
+        ],
+      }
+  }
+}
+
+let sharedContext: AudioContext | null = null
+
+/** Lazily create (and resume) a shared AudioContext. SSR-safe. */
+function getAudioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null
+
+  const Ctor =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext
+
+  if (!Ctor) return null
+
+  if (!sharedContext) {
+    try {
+      sharedContext = new Ctor()
+    } catch {
+      return null
+    }
+  }
+
+  // Autoplay policies can leave the context "suspended" until a gesture.
+  if (sharedContext.state === "suspended") {
+    void sharedContext.resume().catch(() => undefined)
+  }
+
+  return sharedContext
+}
+
+export type PlayOptions = {
+  /** Master volume 0..1. Defaults low so the cue stays calm. */
+  volume?: number
+  /** Override the fundamental frequency (e.g. 432). */
+  baseHz?: number
+}
+
+/**
+ * Play an earcon. No-ops silently when audio is unavailable or volume <= 0.
+ */
+export function playEarcon(kind: EarconKind, opts: PlayOptions = {}): void {
+  const { volume = 0.18, baseHz } = opts
+  if (volume <= 0) return
+
+  const ctx = getAudioContext()
+  if (!ctx) return
+
+  const spec = getEarconSpec(kind, baseHz)
+  const now = ctx.currentTime
+
+  // A shared master bus keeps the overall level under control.
+  const master = ctx.createGain()
+  master.gain.value = Math.min(Math.max(volume, 0), 1)
+  master.connect(ctx.destination)
+
+  for (const tone of spec.tones) {
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = tone.type ?? "sine"
+    osc.frequency.value = tone.freq
+
+    const start = now + tone.at
+    const peak = tone.gain ?? 1
+    const sustainEnd = start + tone.duration
+    const stop = sustainEnd + spec.release
+
+    // Soft attack -> sustain -> gentle exponential release (click-free).
+    gain.gain.setValueAtTime(0.0001, start)
+    gain.gain.linearRampToValueAtTime(peak, start + spec.attack)
+    gain.gain.setValueAtTime(peak, sustainEnd)
+    gain.gain.exponentialRampToValueAtTime(0.0001, stop)
+
+    osc.connect(gain)
+    gain.connect(master)
+    osc.start(start)
+    osc.stop(stop + 0.02)
+  }
+}


### PR DESCRIPTION
Add a psychologically-pleasant audio/visual feedback layer and an ethical
onboarding flow, reusing the existing progression (XP) system as-is.

Experience layer (on by default, toggleable off):
- Web Audio earcon synth (no deps) with calm, consonant earcons: soft attack,
  warm fundamentals, low volume. confirm/celebrate/milestone.
- Warm "bloom" glow + optional night grading via CSS; suppressed under
  prefers-reduced-motion.
- BlackoutEffects provider persisting prefs to localStorage; useBlackoutEffects()
  exposes celebrate(). Settings UI on /user/settings.
- Triggers across FBM + Blackout-bridged moments: order confirmed, add-to-cart,
  level-up/new title, onboarding step completion.

Shaping onboarding (White-Hat):
- Endowed-progress checklist on /start with a pre-completed first step, a
  progress bar (no raw count), calm celebrations, fully dismissible, and no
  streaks/guilt/scarcity.

Docs + tests:
- docs/BLACKOUT_EXPERIENCE_LAYER.md (incl. deferred Stage 2 XP-economy design).
- Unit tests for earcon acoustics and prefs normalization.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SdDwSpqTV77uuzyk1c8f7Q