### PR TITLE
Harden FBM Connect/Sites for production: rate-limit, cache, launch timeout

### DIFF
--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -19,6 +19,7 @@ import {
   authSessionRateLimiter,
   bugReportAnonymousRateLimiter,
   bugReportAuthRateLimiter,
+  publicCatalogRateLimiter,
   standardRateLimiter,
   strictAuthRateLimiter,
   vendorRegistrationRateLimiter,
@@ -599,13 +600,16 @@ export default defineMiddlewares({
     // FBM Store API — public, website-agnostic vendor catalog
     // ============================================================
     // Open read-only CORS so any third-party site can embed the Connect SDK.
+    // Rate-limited per visitor IP (the SDK runs client-side) so a single
+    // scraper can't hammer the unauthenticated catalog; aggregate embed traffic
+    // is absorbed by the response Cache-Control headers (set in the handler).
     {
       matcher: "/store/vendors",
-      middlewares: [publicStoreCorsMiddleware],
+      middlewares: [publicStoreCorsMiddleware, publicCatalogRateLimiter],
     },
     {
       matcher: "/store/vendors/**",
-      middlewares: [publicStoreCorsMiddleware],
+      middlewares: [publicStoreCorsMiddleware, publicCatalogRateLimiter],
     },
     // ============================================================
     // CSRF: reject forged cross-site, cookie-authenticated writes

--- a/backend/src/api/store/vendors/[handle]/route.ts
+++ b/backend/src/api/store/vendors/[handle]/route.ts
@@ -257,6 +257,15 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       }
     }
 
+    // This is a public, read-only catalog embedded on arbitrary third-party
+    // sites — make it cacheable so browsers/CDNs absorb embed traffic instead
+    // of hitting the DB on every page load. Short browser TTL, longer shared
+    // (CDN) TTL, with stale-while-revalidate for a smooth refresh.
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+    );
+
     return res.json({
       vendor,
       products: wantProducts ? products : undefined,

--- a/backend/src/api/vendor/website/route.ts
+++ b/backend/src/api/vendor/website/route.ts
@@ -11,6 +11,7 @@ import {
   updateSellerMetadataRecord,
 } from "../../../modules/seller-extension/metadata-service";
 import {
+  isProvisioningStale,
   normalizeDomains,
   probeSiteLive,
 } from "../../../shared/site-provisioning";
@@ -23,6 +24,7 @@ type MetaRow = {
   site_status: string | null;
   site_url: string | null;
   site_repo: string | null;
+  updated_at?: string | Date | null;
 };
 
 async function loadContext(req: AuthenticatedMedusaRequest, sellerId: string) {
@@ -37,7 +39,14 @@ async function loadContext(req: AuthenticatedMedusaRequest, sellerId: string) {
 
   const { data: metaRows } = await query.graph({
     entity: "seller_metadata",
-    fields: ["id", "connect_domains", "site_status", "site_url", "site_repo"],
+    fields: [
+      "id",
+      "connect_domains",
+      "site_status",
+      "site_url",
+      "site_repo",
+      "updated_at",
+    ],
     filters: { seller_id: sellerId },
   });
   const meta = (metaRows?.[0] as MetaRow | undefined) || null;
@@ -70,15 +79,23 @@ export async function GET(
     // flip to "live" the moment it answers. Bounded + awaited so the response
     // reflects the new status immediately (the panel polls this endpoint). This
     // is the always-on fallback for the optional /webhooks/site-deploy callback.
+    // If it stays stuck past PROVISIONING_TIMEOUT_MS without ever answering,
+    // flip it to "failed" so the panel stops spinning and the vendor can retry.
     let effectiveMeta = meta;
-    if (meta?.site_status === "provisioning" && meta.site_url) {
-      const live = await probeSiteLive(meta.site_url);
+    if (meta?.site_status === "provisioning") {
+      const live = meta.site_url ? await probeSiteLive(meta.site_url) : false;
       if (live) {
         const sellerExtension = req.scope.resolve("sellerExtension");
         await updateSellerMetadataRecord(sellerExtension as any, [
           { id: meta.id, site_status: "live" },
         ]);
         effectiveMeta = { ...meta, site_status: "live" };
+      } else if (isProvisioningStale(meta.updated_at)) {
+        const sellerExtension = req.scope.resolve("sellerExtension");
+        await updateSellerMetadataRecord(sellerExtension as any, [
+          { id: meta.id, site_status: "failed" },
+        ]);
+        effectiveMeta = { ...meta, site_status: "failed" };
       }
     }
 

--- a/backend/src/shared/__tests__/site-provisioning.unit.spec.ts
+++ b/backend/src/shared/__tests__/site-provisioning.unit.spec.ts
@@ -1,6 +1,9 @@
 import { createHmac } from "crypto";
 import {
   isDeployCallbackConfigured,
+  isProvisioningStale,
+  normalizeDomains,
+  PROVISIONING_TIMEOUT_MS,
   verifyDeploySignature,
 } from "../site-provisioning";
 
@@ -47,5 +50,50 @@ describe("site-provisioning deploy callback verification", () => {
     expect(verifyDeploySignature("{}", "")).toBe(false);
     delete process.env.SITE_DEPLOY_SECRET;
     expect(verifyDeploySignature("{}", "abc123")).toBe(false);
+  });
+});
+
+describe("isProvisioningStale (launch timeout)", () => {
+  const now = 1_000_000_000_000;
+
+  it("is false for missing/unparseable timestamps", () => {
+    expect(isProvisioningStale(null, now)).toBe(false);
+    expect(isProvisioningStale(undefined, now)).toBe(false);
+    expect(isProvisioningStale("not-a-date", now)).toBe(false);
+  });
+
+  it("is false within the timeout window", () => {
+    const recent = now - (PROVISIONING_TIMEOUT_MS - 1000);
+    expect(isProvisioningStale(new Date(recent), now)).toBe(false);
+    expect(isProvisioningStale(new Date(recent).toISOString(), now)).toBe(false);
+  });
+
+  it("is true once past the timeout window", () => {
+    const old = now - (PROVISIONING_TIMEOUT_MS + 1000);
+    expect(isProvisioningStale(new Date(old), now)).toBe(true);
+    expect(isProvisioningStale(new Date(old).toISOString(), now)).toBe(true);
+    expect(isProvisioningStale(old, now)).toBe(true);
+  });
+});
+
+describe("normalizeDomains (Connect whitelist)", () => {
+  it("strips protocol, path, query, and www; lowercases; dedupes", () => {
+    expect(
+      normalizeDomains([
+        "https://www.Example.com/shop?ref=1",
+        "example.com",
+        "  SHOP.example.com  ",
+      ]),
+    ).toEqual(["example.com", "shop.example.com"]);
+  });
+
+  it("drops non-strings and implausible hostnames", () => {
+    expect(normalizeDomains(["localhost", "no-tld", 42, null, ""])).toEqual([]);
+  });
+
+  it("returns [] for non-array input and caps the list at 50", () => {
+    expect(normalizeDomains("example.com")).toEqual([]);
+    const many = Array.from({ length: 80 }, (_, i) => `site${i}.com`);
+    expect(normalizeDomains(many)).toHaveLength(50);
   });
 });

--- a/backend/src/shared/rate-limiter.ts
+++ b/backend/src/shared/rate-limiter.ts
@@ -254,6 +254,22 @@ export const standardRateLimiter = createRateLimiter({
   keyPrefix: "standard",
 })
 
+/**
+ * Public catalog rate limiter: 120 requests per minute per IP.
+ *
+ * Protects the open, unauthenticated FBM Store API (`/store/vendors`,
+ * `/store/vendors/:handle`) — the contract every Connect embed reads. Because
+ * the SDK runs in each visitor's browser, the key is the visitor's IP, so a
+ * generous ceiling avoids throttling legitimate multi-widget pages / SPA
+ * navigation while still capping a single scraper. Aggregate load is absorbed
+ * by the response's Cache-Control (CDN/browser caching), not by this limiter.
+ */
+export const publicCatalogRateLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 120,
+  keyPrefix: "public-catalog",
+})
+
 /** Auth rate limiter: 20 attempts per minute (login, register, etc.) */
 export const authRateLimiter = createRateLimiter({
   windowMs: 60_000,

--- a/backend/src/shared/site-provisioning.ts
+++ b/backend/src/shared/site-provisioning.ts
@@ -39,6 +39,32 @@ export function launchedSiteUrl(subdomain: string): string {
   return `https://${subdomain}.${SITES_DOMAIN}`;
 }
 
+/**
+ * How long a launched site may sit in "provisioning" before we give up and mark
+ * it "failed". A GitHub-template generate + Pages deploy normally completes in a
+ * couple of minutes; well past that with no successful liveness probe (and no
+ * deploy webhook) means something went wrong (bad token scope, Pages disabled,
+ * DNS not pointed). Flipping to "failed" stops the panel spinning forever and
+ * lets the vendor retry.
+ */
+export const PROVISIONING_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * True when a row that's still "provisioning" has been stuck longer than
+ * PROVISIONING_TIMEOUT_MS. `since` is the row's last-touched timestamp
+ * (updated_at). Returns false for missing/unparseable input so we never flip a
+ * site we can't reason about.
+ */
+export function isProvisioningStale(
+  since: Date | string | number | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (since === null || since === undefined) return false;
+  const ts = since instanceof Date ? since.getTime() : new Date(since).getTime();
+  if (Number.isNaN(ts)) return false;
+  return now - ts > PROVISIONING_TIMEOUT_MS;
+}
+
 // ─── Deploy → live status flip ───────────────────────────────────────────────
 
 /** True when the deploy → live webhook callback is wired (shared HMAC secret). */

--- a/docs/integrations/fbm-connect.md
+++ b/docs/integrations/fbm-connect.md
@@ -233,3 +233,46 @@ mechanism (both safe, independent):
   Enablement: set `SITE_DEPLOY_SECRET` on the backend **and** the same value as an
   org-level `FBM_DEPLOY_SECRET` Actions secret on the launched-site repos (the
   template's deploy step is inert without it).
+
+A site that never answers is **not** left spinning forever: if it sits in
+`provisioning` for longer than 15 minutes (`PROVISIONING_TIMEOUT_MS`) without a
+successful probe or webhook, the next `GET /vendor/website` flips it to `failed`
+so the vendor can retry. This is the safety net for a misconfigured launch (token
+scope, Pages disabled, DNS not pointed).
+
+## 4. Rate limiting & caching (public Store API)
+
+The Store API is unauthenticated and embedded on arbitrary third-party sites, so:
+
+- **Rate limit:** `/store/vendors` and `/store/vendors/:handle` are capped at
+  **120 requests/min per IP** (`publicCatalogRateLimiter`). The SDK runs in each
+  visitor's browser, so the key is the visitor's IP — generous enough for
+  multi-widget pages and SPA navigation, low enough to stop a single scraper.
+  Over-limit returns `429` with `Retry-After`.
+- **Caching:** successful responses set
+  `Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=600`,
+  so browsers and any CDN in front of the API absorb embed traffic instead of
+  hitting the DB on every page load. `404`/error responses are not cached.
+
+## 5. Production-readiness checklist (Launch / Mode 2)
+
+Connect (Mode 1) needs no infra beyond the backend itself. Launch (Mode 2) stays
+disabled (`501`) until **all** of the following are in place — verify each before
+enabling the panel button in production:
+
+- [ ] **GitHub token** — `GITHUB_TOKEN` with repo-create scope on `GITHUB_ORG`
+      (fine-grained: Administration + Contents + Actions: read/write).
+- [ ] **Template repo** — `SITE_TEMPLATE_REPO` points at
+      `templates/fbm-site-template` published as a GitHub *template* repository.
+- [ ] **DNS wildcard** — `*.sites.freeblackmarket.com` (or your `SITES_DOMAIN`)
+      `CNAME` → GitHub Pages, **and** the apex/subdomain verified at the org level
+      ("Verified domains") to prevent subdomain takeover of unclaimed names.
+- [ ] **Deploy callback (recommended)** — `SITE_DEPLOY_SECRET` on the backend and
+      the same value as the org-level `FBM_DEPLOY_SECRET` Actions secret; set the
+      `FBM_API` Actions *variable* on the org so the template can call back.
+- [ ] **Repo policy** — decide visibility/cleanup for the per-vendor
+      `site-<handle>` repos (they are created public; failed launches leave the
+      repo behind — re-launch is idempotent via GitHub's `422`).
+- [ ] **Smoke test** — run one real `POST /vendor/website/launch`, confirm the
+      repo is generated, Pages deploys, and `site_status` flips
+      `provisioning → live` via both the probe and the signed webhook.


### PR DESCRIPTION
Closes the launch-readiness gaps on the "website launch" feature (FBM
Connect + FBM Sites) so it is production-ready.

- Rate limit the public Store API: new publicCatalogRateLimiter (120 req/min
  per IP) on /store/vendors and /store/vendors/** — the unauthenticated,
  open-CORS catalog every Connect embed reads. Stops a single scraper from
  hammering the DB without throttling legitimate (client-side) visitors.
- Cache the public Store API: success responses now send
  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=600
  so browsers/CDN absorb embed traffic; 404/error stay uncached.
- Launch provisioning timeout: GET /vendor/website flips a site stuck in
  "provisioning" past PROVISIONING_TIMEOUT_MS (15m) with no successful probe
  or webhook to "failed", so the panel stops spinning and the vendor can retry.
  New pure helper isProvisioningStale() keeps it testable.
- Tests: extend the site-provisioning unit spec with isProvisioningStale and
  normalizeDomains coverage (10/10 passing).
- Docs: fbm-connect.md gains a rate-limit/caching section and a Launch (Mode 2)
  production-readiness checklist (token scope, template repo, DNS wildcard +
  org domain verification, deploy callback, repo policy, smoke test).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TmfpfjWh4JHjhoxzp9y1bS