### PR TITLE
XP economy: dual balance + reward redemption (Stage 2)

### DIFF
--- a/backend/src/api/store/xp/redeem/route.ts
+++ b/backend/src/api/store/xp/redeem/route.ts
@@ -1,0 +1,101 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/xp/redeem")
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { PROGRESSION_MODULE } from "../../../../modules/progression"
+import { InsufficientXpError } from "../../../../modules/progression/service"
+import type ProgressionModuleService from "../../../../modules/progression/service"
+import { ENTITLEMENT_MODULE } from "../../../../modules/entitlement"
+import {
+  EntitlementKind,
+  EntitlementSource,
+} from "../../../../modules/entitlement/models"
+import type EntitlementModuleService from "../../../../modules/entitlement/service"
+
+/**
+ * POST /store/xp/redeem  { reward_key }
+ *
+ * Redeems spendable XP for a catalog reward. Flow:
+ *   1. progression.beginRedemption — validate balance, debit XP, open a
+ *      `pending` redemption (throws InsufficientXpError if too poor).
+ *   2. entitlement.grant — grant the perk / digital-download entitlement.
+ *   3. progression.completeRedemption — mark fulfilled with the entitlement id;
+ *      on a grant failure, progression.refundRedemption credits the XP back.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const { reward_key } = (req.body as { reward_key?: string }) ?? {}
+  if (!reward_key || typeof reward_key !== "string") {
+    return res.status(400).json({ error: "reward_key is required" })
+  }
+
+  const progression = req.scope.resolve<ProgressionModuleService>(
+    PROGRESSION_MODULE
+  )
+  const entitlement = req.scope.resolve<EntitlementModuleService>(
+    ENTITLEMENT_MODULE
+  )
+
+  let redemptionId: string | undefined
+  try {
+    const { redemption, reward } = await progression.beginRedemption(
+      customerId,
+      reward_key
+    )
+    redemptionId = redemption.id
+
+    try {
+      const expires_at = reward.durationDays
+        ? new Date(Date.now() + reward.durationDays * 24 * 60 * 60 * 1000)
+        : null
+
+      const grant = await entitlement.grant({
+        customer_id: customerId,
+        feature_key: reward.featureKey,
+        kind: reward.entitlementKind as EntitlementKind,
+        source: EntitlementSource.MANUAL,
+        expires_at,
+        metadata: {
+          redeemed_with_xp: true,
+          reward_key: reward.key,
+          xp_cost: reward.xpCost,
+          redemption_id: redemption.id,
+        },
+      })
+
+      await progression.completeRedemption(redemption.id, grant.id)
+
+      const balance = await progression.getSpendableXp(customerId)
+      return res.json({
+        success: true,
+        balance,
+        redemption: { ...redemption, status: "fulfilled", entitlement_id: grant.id },
+        entitlement: grant,
+      })
+    } catch (grantError) {
+      // Granting failed — refund the XP so it is never lost.
+      log.error("Entitlement grant failed; refunding XP redemption:", grantError)
+      await progression.refundRedemption(redemption.id)
+      const balance = await progression.getSpendableXp(customerId)
+      return res
+        .status(502)
+        .json({ error: "Failed to grant reward; XP refunded", balance })
+    }
+  } catch (error) {
+    if (error instanceof InsufficientXpError) {
+      return res.status(409).json({
+        error: "Insufficient spendable XP",
+        required: error.required,
+        available: error.available,
+      })
+    }
+    if (error instanceof Error && error.message.startsWith("Unknown reward")) {
+      return res.status(404).json({ error: "Unknown reward" })
+    }
+    log.error("Error redeeming XP:", error)
+    return res.status(500).json({ error: "Failed to redeem XP" })
+  }
+}

--- a/backend/src/api/store/xp/rewards/route.ts
+++ b/backend/src/api/store/xp/rewards/route.ts
@@ -1,0 +1,32 @@
+import { createLogger } from "../../../../shared/logger"
+const log = createLogger("api/store/xp/rewards")
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { PROGRESSION_MODULE } from "../../../../modules/progression"
+import type ProgressionModuleService from "../../../../modules/progression/service"
+
+/**
+ * GET /store/xp/rewards
+ *
+ * Returns the authenticated customer's spendable-XP balance, the redeemable
+ * reward catalog (annotated with affordability), and their redemption history.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const progression = req.scope.resolve<ProgressionModuleService>(
+    PROGRESSION_MODULE
+  )
+
+  try {
+    const balance = await progression.getSpendableXp(customerId)
+    const rewards = progression.listRewards(balance)
+    const history = await progression.listRedemptionsForCustomer(customerId)
+    res.json({ balance, rewards, history })
+  } catch (error) {
+    log.error("Error listing XP rewards:", error)
+    res.status(500).json({ error: "Failed to list XP rewards" })
+  }
+}

--- a/backend/src/modules/progression/__tests__/rewards.unit.spec.ts
+++ b/backend/src/modules/progression/__tests__/rewards.unit.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * XP reward catalog unit tests.
+ *
+ * The catalog is the spendable-XP economy's price list, so it must be coherent:
+ *   - keys are unique and resolvable
+ *   - every reward has a positive integer cost and an entitlement to grant
+ *   - both reward kinds (perk + download) are offered
+ */
+
+import { XP_REWARDS, getXpReward } from "../rewards"
+import { XpRewardKind } from "../models/xp-redemption"
+
+describe("XP reward catalog", () => {
+  it("has unique, resolvable keys", () => {
+    const keys = XP_REWARDS.map((r) => r.key)
+    expect(new Set(keys).size).toBe(keys.length)
+    for (const key of keys) {
+      expect(getXpReward(key)?.key).toBe(key)
+    }
+  })
+
+  it("returns undefined for an unknown key", () => {
+    expect(getXpReward("does-not-exist")).toBeUndefined()
+  })
+
+  it("prices every reward as a positive integer", () => {
+    for (const r of XP_REWARDS) {
+      expect(Number.isInteger(r.xpCost)).toBe(true)
+      expect(r.xpCost).toBeGreaterThan(0)
+    }
+  })
+
+  it("gives every reward an entitlement to grant", () => {
+    for (const r of XP_REWARDS) {
+      expect(r.featureKey).toBeTruthy()
+      expect(r.entitlementKind).toBeTruthy()
+    }
+  })
+
+  it("offers both perk and download reward kinds", () => {
+    const kinds = new Set(XP_REWARDS.map((r) => r.kind))
+    expect(kinds.has(XpRewardKind.ENTITLEMENT)).toBe(true)
+    expect(kinds.has(XpRewardKind.DIGITAL_DOWNLOAD)).toBe(true)
+  })
+
+  it("maps digital downloads onto a digital entitlement kind", () => {
+    for (const r of XP_REWARDS) {
+      if (r.kind === XpRewardKind.DIGITAL_DOWNLOAD) {
+        expect(r.entitlementKind).toBe("digital")
+      }
+    }
+  })
+})

--- a/backend/src/modules/progression/migrations/Migration20260622AddXpEconomy.ts
+++ b/backend/src/modules/progression/migrations/Migration20260622AddXpEconomy.ts
@@ -1,0 +1,62 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Stage 2 XP economy: dual balance + redemption ledger.
+ *  - Adds `spendable_xp` to character_sheet (separate from lifetime total_xp).
+ *  - Creates the `xp_redemption` append-only spend ledger.
+ */
+export class Migration20260622AddXpEconomy extends Migration {
+  async up(): Promise<void> {
+    // ── character_sheet.spendable_xp ────────────────────────────────────
+    this.addSql(
+      `ALTER TABLE "character_sheet" ADD COLUMN IF NOT EXISTS "spendable_xp" INTEGER NOT NULL DEFAULT 0;`
+    )
+
+    // ── enums ───────────────────────────────────────────────────────────
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "xp_redemption_status_enum" AS ENUM (
+          'pending','fulfilled','refunded'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+    this.addSql(`
+      DO $$ BEGIN
+        CREATE TYPE "xp_reward_kind_enum" AS ENUM (
+          'entitlement','digital_download'
+        );
+      EXCEPTION WHEN duplicate_object THEN null; END $$;
+    `)
+
+    // ── xp_redemption ───────────────────────────────────────────────────
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "xp_redemption" (
+        "id" TEXT NOT NULL,
+        "customer_id" TEXT NOT NULL,
+        "reward_key" TEXT NOT NULL,
+        "reward_name" TEXT NOT NULL,
+        "reward_kind" xp_reward_kind_enum NOT NULL,
+        "xp_cost" INTEGER NOT NULL,
+        "feature_key" TEXT NULL,
+        "status" xp_redemption_status_enum NOT NULL DEFAULT 'pending',
+        "entitlement_id" TEXT NULL,
+        "fulfilled_at" TIMESTAMPTZ NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "xp_redemption_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_xp_redemption_customer_id" ON "xp_redemption" ("customer_id") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_xp_redemption_reward_key" ON "xp_redemption" ("reward_key") WHERE "deleted_at" IS NULL;`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_xp_redemption_status" ON "xp_redemption" ("status") WHERE "deleted_at" IS NULL;`)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`DROP TABLE IF EXISTS "xp_redemption";`)
+    this.addSql(`DROP TYPE IF EXISTS "xp_reward_kind_enum";`)
+    this.addSql(`DROP TYPE IF EXISTS "xp_redemption_status_enum";`)
+    this.addSql(`ALTER TABLE "character_sheet" DROP COLUMN IF EXISTS "spendable_xp";`)
+  }
+}

--- a/backend/src/modules/progression/models/character-sheet.ts
+++ b/backend/src/modules/progression/models/character-sheet.ts
@@ -39,6 +39,11 @@ const CharacterSheet = model.define("character_sheet", {
   // Sum of all role XP — used for leaderboards / "overall level".
   total_xp: model.number().default(0),
 
+  // Spendable XP balance ("dual balance"): accrues alongside total_xp when XP
+  // is earned, and is debited by redemptions. Spending never lowers total_xp,
+  // levels, or titles — status and currency are kept separate.
+  spendable_xp: model.number().default(0),
+
   // === Aggregate stats snapshot (DERIVED — recomputed from source modules) ===
   // Value (cents) of food/goods produced and sold — from producer impact.
   food_produced_cents: model.bigNumber().default(0),

--- a/backend/src/modules/progression/models/index.ts
+++ b/backend/src/modules/progression/models/index.ts
@@ -1,3 +1,5 @@
 export { default as CharacterSheet } from "./character-sheet"
 export { default as XpEvent } from "./xp-event"
 export { default as ProgressionTitle } from "./progression-title"
+export { default as XpRedemption } from "./xp-redemption"
+export { XpRedemptionStatus, XpRewardKind } from "./xp-redemption"

--- a/backend/src/modules/progression/models/xp-redemption.ts
+++ b/backend/src/modules/progression/models/xp-redemption.ts
@@ -1,0 +1,65 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * XP Redemption
+ *
+ * Append-only ledger of spendable-XP redemptions. Complements `xp_event`
+ * (which records *earning*) by recording every *spend*: when a customer trades
+ * spendable XP for a reward, a row is written here and `character_sheet.
+ * spendable_xp` is decremented. Lifetime `total_xp` is never touched — status
+ * and balance are deliberately separate ("dual balance").
+ *
+ * Lifecycle: a redemption is created `pending`, marked `fulfilled` once the
+ * reward is granted, or `refunded` (with the XP credited back) if granting
+ * fails. This mirrors the volunteer module's earn→redeem audit pattern.
+ */
+
+export enum XpRedemptionStatus {
+  PENDING = "pending",
+  FULFILLED = "fulfilled",
+  REFUNDED = "refunded",
+}
+
+/** What a redemption grants. */
+export enum XpRewardKind {
+  // An entitlement perk (theme, emoji pack, access pass, featured slot, …).
+  ENTITLEMENT = "entitlement",
+  // A digital-product download, unlocked via an entitlement of kind=digital.
+  DIGITAL_DOWNLOAD = "digital_download",
+}
+
+const XpRedemption = model.define("xp_redemption", {
+  id: model.id().primaryKey(),
+
+  customer_id: model.text(),
+
+  // Catalog key of the redeemed reward (see rewards.ts).
+  reward_key: model.text(),
+  // Human-readable snapshot of the reward name at redemption time.
+  reward_name: model.text(),
+  reward_kind: model.enum(Object.values(XpRewardKind)),
+
+  // XP debited for this redemption (positive integer).
+  xp_cost: model.number(),
+
+  // The entitlement feature_key this redemption grants / gates.
+  feature_key: model.text().nullable(),
+
+  status: model
+    .enum(Object.values(XpRedemptionStatus))
+    .default(XpRedemptionStatus.PENDING),
+
+  // Reference to the granted entitlement, once fulfilled.
+  entitlement_id: model.text().nullable(),
+
+  fulfilled_at: model.dateTime().nullable(),
+
+  metadata: model.json().nullable(),
+})
+  .indexes([
+    { on: ["customer_id"], name: "IDX_xp_redemption_customer_id" },
+    { on: ["reward_key"], name: "IDX_xp_redemption_reward_key" },
+    { on: ["status"], name: "IDX_xp_redemption_status" },
+  ])
+
+export default XpRedemption

--- a/backend/src/modules/progression/rewards.ts
+++ b/backend/src/modules/progression/rewards.ts
@@ -1,0 +1,92 @@
+import { XpRewardKind } from "./models/xp-redemption"
+
+/**
+ * Catalog of rewards a customer can redeem with spendable XP.
+ *
+ * Kept as a static table (like `DEFAULT_TITLES`) so the economy is auditable at
+ * a glance and easy to tune. Every reward grants an *entitlement*:
+ *  - ENTITLEMENT rewards unlock a perk (theme, emoji pack, access pass, …).
+ *  - DIGITAL_DOWNLOAD rewards unlock a digital-product download (the actual
+ *    file delivery is handled by the digital-product module, gated on the
+ *    entitlement granted here).
+ *
+ * `feature_key` is the entitlement key granted on redemption. `entitlementKind`
+ * is the entitlement module's `EntitlementKind` value (kept as a string here to
+ * avoid coupling the two modules).
+ */
+export type XpReward = {
+  key: string
+  name: string
+  description: string
+  /** XP price. Must be a positive integer. */
+  xpCost: number
+  kind: XpRewardKind
+  /** Entitlement feature_key granted on redemption. */
+  featureKey: string
+  /** Entitlement module `EntitlementKind` string. */
+  entitlementKind: string
+  /** Optional access duration; omit for a permanent grant. */
+  durationDays?: number
+  icon?: string
+}
+
+export const XP_REWARDS: XpReward[] = [
+  {
+    key: "theme-solarpunk-dusk",
+    name: "Solarpunk Dusk Theme",
+    description: "A warm dusk color theme for your storefront profile.",
+    xpCost: 500,
+    kind: XpRewardKind.ENTITLEMENT,
+    featureKey: "theme.solarpunk-dusk",
+    entitlementKind: "theme",
+    icon: "palette",
+  },
+  {
+    key: "emoji-pack-harvest",
+    name: "Harvest Emoji Pack",
+    description: "A set of seasonal harvest emojis for community chat.",
+    xpCost: 750,
+    kind: XpRewardKind.ENTITLEMENT,
+    featureKey: "emoji_pack.harvest",
+    entitlementKind: "emoji_pack",
+    icon: "smile",
+  },
+  {
+    key: "access-pass-market-day",
+    name: "Market Day Access Pass",
+    description: "30 days of early access to market-day drops and events.",
+    xpCost: 1500,
+    kind: XpRewardKind.ENTITLEMENT,
+    featureKey: "access_pass.market-day",
+    entitlementKind: "access_pass",
+    durationDays: 30,
+    icon: "ticket",
+  },
+  {
+    key: "download-growers-handbook",
+    name: "Grower's Handbook (PDF)",
+    description: "A downloadable handbook on cooperative small-scale growing.",
+    xpCost: 1000,
+    kind: XpRewardKind.DIGITAL_DOWNLOAD,
+    featureKey: "download.growers-handbook",
+    entitlementKind: "digital",
+    icon: "book",
+  },
+  {
+    key: "download-seasonal-recipes",
+    name: "Seasonal Recipes Pack (PDF)",
+    description: "A downloadable pack of seasonal, local-first recipes.",
+    xpCost: 600,
+    kind: XpRewardKind.DIGITAL_DOWNLOAD,
+    featureKey: "download.seasonal-recipes",
+    entitlementKind: "digital",
+    icon: "book",
+  },
+]
+
+const REWARD_BY_KEY = new Map(XP_REWARDS.map((r) => [r.key, r]))
+
+/** Look up a reward by catalog key. Returns undefined for unknown keys. */
+export function getXpReward(key: string): XpReward | undefined {
+  return REWARD_BY_KEY.get(key)
+}

--- a/backend/src/modules/progression/service.ts
+++ b/backend/src/modules/progression/service.ts
@@ -1,7 +1,9 @@
 import { MedusaService } from "@medusajs/framework/utils"
-import { CharacterSheet, XpEvent, ProgressionTitle } from "./models"
+import { CharacterSheet, XpEvent, ProgressionTitle, XpRedemption } from "./models"
+import { XpRedemptionStatus } from "./models/xp-redemption"
 import { Stance, isStance } from "./stance"
 import { levelForXp, levelProgress, ROLE_XP_WEIGHTS } from "./leveling"
+import { getXpReward, XP_REWARDS, type XpReward } from "./rewards"
 
 /**
  * Per-role XP column names on the character sheet, keyed by stance.
@@ -42,10 +44,19 @@ export const DEFAULT_TITLES: Array<{
 
 export type EarnedTitle = { title_slug: string; role: string; earned_at: Date }
 
+/** Raised when a redemption is attempted with insufficient spendable XP. */
+export class InsufficientXpError extends Error {
+  constructor(public required: number, public available: number) {
+    super(`Insufficient spendable XP: need ${required}, have ${available}`)
+    this.name = "InsufficientXpError"
+  }
+}
+
 class ProgressionModuleService extends MedusaService({
   CharacterSheet,
   XpEvent,
   ProgressionTitle,
+  XpRedemption,
 }) {
   /**
    * Get or create the character sheet for a customer.
@@ -94,11 +105,20 @@ class ProgressionModuleService extends MedusaService({
     const newRoleXp = Math.max(0, currentRoleXp + weighted)
     const newTotalXp = Math.max(0, Number(sheet.total_xp ?? 0) + weighted)
 
+    // Spendable balance accrues alongside lifetime XP. Earning lifts both;
+    // a clawback (negative amount) also reduces the spendable balance, floored
+    // at 0 so it can never go negative from an earn event.
+    const newSpendableXp = Math.max(
+      0,
+      Number(sheet.spendable_xp ?? 0) + weighted
+    )
+
     await this.updateCharacterSheets({
       id: sheet.id,
       [col.xp]: newRoleXp,
       [col.level]: levelForXp(newRoleXp),
       total_xp: newTotalXp,
+      spendable_xp: newSpendableXp,
     })
 
     await this.checkAndGrantTitles(data.customer_id)
@@ -248,6 +268,111 @@ class ProgressionModuleService extends MedusaService({
     return newlyEarned
   }
 
+  /** The current spendable-XP balance for a customer. */
+  async getSpendableXp(customerId: string): Promise<number> {
+    const sheet = await this.getOrCreateCharacterSheet(customerId)
+    return Number(sheet.spendable_xp ?? 0)
+  }
+
+  /** The redeemable reward catalog, annotated with affordability for a balance. */
+  listRewards(balance = 0): Array<XpReward & { affordable: boolean }> {
+    return XP_REWARDS.map((r) => ({ ...r, affordable: balance >= r.xpCost }))
+  }
+
+  /**
+   * Debit spendable XP and open a `pending` redemption for a catalog reward.
+   *
+   * This is the money-movement half of a redemption; the caller (an API route
+   * or workflow) is responsible for granting the entitlement and then calling
+   * `completeRedemption` — or `refundRedemption` if granting fails. Splitting
+   * it this way keeps the cross-module entitlement grant out of this module
+   * while guaranteeing XP is never spent without an audit row.
+   *
+   * @throws InsufficientXpError when the balance can't cover the reward.
+   */
+  async beginRedemption(customerId: string, rewardKey: string) {
+    const reward = getXpReward(rewardKey)
+    if (!reward) {
+      throw new Error(`Unknown reward: ${rewardKey}`)
+    }
+
+    const sheet = await this.getOrCreateCharacterSheet(customerId)
+    const balance = Number(sheet.spendable_xp ?? 0)
+    if (balance < reward.xpCost) {
+      throw new InsufficientXpError(reward.xpCost, balance)
+    }
+
+    // Debit first, then write the audit row, so concurrent reads never see the
+    // balance before it has been reduced.
+    await this.updateCharacterSheets({
+      id: sheet.id,
+      spendable_xp: balance - reward.xpCost,
+    })
+
+    const [redemption] = await this.createXpRedemptions([
+      {
+        customer_id: customerId,
+        reward_key: reward.key,
+        reward_name: reward.name,
+        reward_kind: reward.kind,
+        xp_cost: reward.xpCost,
+        feature_key: reward.featureKey,
+        status: XpRedemptionStatus.PENDING,
+        metadata: { entitlement_kind: reward.entitlementKind },
+      },
+    ])
+
+    return { redemption, reward }
+  }
+
+  /** Mark a redemption fulfilled and record the granted entitlement. */
+  async completeRedemption(redemptionId: string, entitlementId?: string) {
+    const [updated] = await this.updateXpRedemptions([
+      {
+        id: redemptionId,
+        status: XpRedemptionStatus.FULFILLED,
+        entitlement_id: entitlementId ?? null,
+        fulfilled_at: new Date(),
+      },
+    ])
+    return updated
+  }
+
+  /**
+   * Refund a redemption: credit the XP back and mark it refunded. Used when the
+   * downstream entitlement grant fails so XP is never lost.
+   */
+  async refundRedemption(redemptionId: string) {
+    const [redemption] = await this.listXpRedemptions({ id: redemptionId })
+    if (!redemption) {
+      throw new Error(`Unknown redemption: ${redemptionId}`)
+    }
+    if (redemption.status === XpRedemptionStatus.REFUNDED) {
+      return redemption
+    }
+
+    const sheet = await this.getOrCreateCharacterSheet(redemption.customer_id)
+    await this.updateCharacterSheets({
+      id: sheet.id,
+      spendable_xp: Number(sheet.spendable_xp ?? 0) + Number(redemption.xp_cost),
+    })
+
+    const [updated] = await this.updateXpRedemptions([
+      { id: redemptionId, status: XpRedemptionStatus.REFUNDED },
+    ])
+    return updated
+  }
+
+  /** A customer's redemption history, newest first. */
+  async listRedemptionsForCustomer(customerId: string) {
+    const items = await this.listXpRedemptions({ customer_id: customerId })
+    return items.sort(
+      (a, b) =>
+        new Date(b.created_at as unknown as string).getTime() -
+        new Date(a.created_at as unknown as string).getTime()
+    )
+  }
+
   /**
    * Display shape for the storefront `/character` page and `/store/character`.
    */
@@ -291,6 +416,7 @@ class ProgressionModuleService extends MedusaService({
       customerId: sheet.customer_id,
       activeStance: sheet.active_stance,
       totalXp: Number(sheet.total_xp ?? 0),
+      spendableXp: Number(sheet.spendable_xp ?? 0),
       tracks,
       stats: {
         foodProducedCents: Number(sheet.food_produced_cents ?? 0),

--- a/docs/BLACKOUT_EXPERIENCE_LAYER.md
+++ b/docs/BLACKOUT_EXPERIENCE_LAYER.md
@@ -61,18 +61,45 @@ Rendered on `/start` for authenticated members; steps derived from real account 
 Cover the pure earcon acoustics (intervals, attack/release, frequency band, retuning) and the
 preferences normalization (defaults-on, validation/clamping).
 
-## Deferred — Stage 2 (XP economy; NOT yet built)
+## Stage 2 — XP economy (dual balance + redemption) — IMPLEMENTED
 
-Design decisions already made with the product owner, recorded here for continuity:
+### Dual balance
+- `character_sheet.spendable_xp` (new column) holds the **spendable** balance, kept separate
+  from the lifetime status `total_xp`. `recordXpEvent` lifts both when XP is earned; a clawback
+  reduces spendable too (floored at 0). **Spending never lowers `total_xp`, levels, or titles.**
+- Migration: `progression/migrations/Migration20260622AddXpEconomy.ts`.
 
-- **Dual balance.** Keep `total_xp` as non-spendable lifetime *status* (drives levels/titles).
-  Add a separate **spendable** balance — either a `spendable_xp` column on `character_sheet`
-  or a dedicated `xp_wallet` reusing the append-only `XpEvent`/ledger pattern. Spending never
-  lowers a member's level.
-- **Redemption** for **both** entitlement perks (themes, emoji packs, access passes, featured
-  slots — via the `entitlement` module) **and** digital-product downloads (via
-  `digital-product` fulfillment). Follow the `volunteer/TimeCredit` earn→redeem precedent.
-- **Accrual wiring.** Call `progression.recordXpEvent` from the blackout/FBM subscribers
-  (`backend/src/subscribers/emit-blackout-*`) so XP accrues from both platforms.
-- Threshold gating via `entitlement`; anti-speculation guaranteed because XP is
-  non-transferable by construction.
+### Redemption ledger
+- New `xp_redemption` model (append-only spend ledger): `pending → fulfilled | refunded`.
+- Service methods (`progression/service.ts`): `getSpendableXp`, `listRewards(balance)`,
+  `beginRedemption` (validates + debits, throws `InsufficientXpError`), `completeRedemption`,
+  `refundRedemption` (credits XP back if granting fails), `listRedemptionsForCustomer`.
+
+### Reward catalog — `progression/rewards.ts`
+- Static, auditable price list. Every reward grants an **entitlement**:
+  - `ENTITLEMENT` perks (theme, emoji pack, access pass) → entitlement kinds theme/emoji_pack/
+    access_pass.
+  - `DIGITAL_DOWNLOAD` rewards → entitlement kind `digital` (file delivery gated on the grant,
+    handled by the `digital-product` module).
+
+### API — `backend/src/api/store/xp/`
+- `GET /store/xp/rewards` → `{ balance, rewards (with affordability), history }`.
+- `POST /store/xp/redeem { reward_key }` → orchestrates debit → `entitlement.grant` →
+  complete; refunds XP and returns 502 if the grant fails; 409 (`InsufficientXpError`) when
+  the balance is too low; 404 for unknown rewards. The cross-module entitlement grant lives in
+  the route, keeping `progression` decoupled from `entitlement`.
+
+### Storefront
+- `lib/data/progression.ts`: `spendableXp` on the sheet, `getXpRewards`, `redeemXpReward`.
+- `/rewards` page + `XpRewardsList` client component (redeem, history, calm milestone
+  celebration on success, server refresh). Spendable balance + link surfaced on `/character`.
+
+### Accrual & anti-speculation
+- Accrual is automatic: spendable XP rises wherever `recordXpEvent` is already called (FBM +
+  Blackout-bridged award paths), so no new subscribers were required.
+- Anti-speculation guaranteed because XP is non-transferable by construction (no wallet→wallet
+  transfer exists); redemption only ever debits the owner's own balance against the catalog.
+
+### Tests — `progression/__tests__/rewards.unit.spec.ts`
+Cover catalog integrity (unique keys, positive integer costs, every reward grants an
+entitlement, both kinds offered, downloads map to the `digital` kind).

--- a/storefront/src/app/[locale]/(main)/character/page.tsx
+++ b/storefront/src/app/[locale]/(main)/character/page.tsx
@@ -5,6 +5,7 @@ import { getCharacterSheet } from "@/lib/data/progression"
 import { RoleTrackBar } from "@/components/organisms/CharacterSheet/RoleTrackBar"
 import { TitleBadge } from "@/components/organisms/CharacterSheet/TitleBadge"
 import { ProgressWatcher } from "@/components/organisms/CharacterSheet/ProgressWatcher"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
 
 export const metadata: Metadata = {
   title: "Character",
@@ -62,6 +63,17 @@ export default async function CharacterPage() {
             {STANCE_LABEL[character?.activeStance ?? "consumer"]} stance ·{" "}
             {character?.totalXp ?? 0} total XP
           </p>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <span className="badge-accent">
+              {(character?.spendableXp ?? 0).toLocaleString()} spendable XP
+            </span>
+            <LocalizedClientLink
+              href="/rewards"
+              className="link-solarpunk text-sm font-medium"
+            >
+              Spend XP on rewards →
+            </LocalizedClientLink>
+          </div>
         </header>
 
         {/* Role tracks */}

--- a/storefront/src/app/[locale]/(main)/rewards/page.tsx
+++ b/storefront/src/app/[locale]/(main)/rewards/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next"
+import { AccountLoadingState, LoginForm } from "@/components/molecules"
+import { retrieveCustomerContext } from "@/lib/data/customer"
+import { getXpRewards } from "@/lib/data/progression"
+import { XpRewardsList } from "@/components/sections/XpRewards/XpRewardsList"
+
+export const metadata: Metadata = {
+  title: "XP Rewards",
+  description:
+    "Spend your earned XP on perks and downloads. Your level and titles stay yours.",
+}
+
+export default async function RewardsPage() {
+  const { customer, isAuthenticated } = await retrieveCustomerContext()
+
+  if (!customer) {
+    if (!isAuthenticated) return <LoginForm />
+    return <AccountLoadingState title="XP Rewards" />
+  }
+
+  const data = await getXpRewards()
+
+  return (
+    <main className="container">
+      <div className="mt-6 space-y-6">
+        <header>
+          <h1 className="heading-lg">XP Rewards</h1>
+          <p className="text-secondary mt-1">
+            Trade spendable XP for perks and downloads.
+          </p>
+        </header>
+        <XpRewardsList
+          balance={data?.balance ?? 0}
+          rewards={data?.rewards ?? []}
+          history={data?.history ?? []}
+        />
+      </div>
+    </main>
+  )
+}

--- a/storefront/src/components/sections/XpRewards/XpRewardsList.tsx
+++ b/storefront/src/components/sections/XpRewards/XpRewardsList.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+
+import { useBlackoutEffects } from "@/components/providers"
+import {
+  redeemXpReward,
+  type XpRedemption,
+  type XpReward,
+} from "@/lib/data/progression"
+
+type Feedback = { kind: "success" | "error"; message: string } | null
+
+/**
+ * Spendable-XP storefront: shows the balance and lets a member redeem catalog
+ * rewards. A successful redemption plays a calm milestone celebration and
+ * refreshes the server data so the balance / history stay truthful.
+ */
+export function XpRewardsList({
+  balance,
+  rewards,
+  history,
+}: {
+  balance: number
+  rewards: XpReward[]
+  history: XpRedemption[]
+}) {
+  const router = useRouter()
+  const { celebrate } = useBlackoutEffects()
+  const [pending, startTransition] = useTransition()
+  const [redeemingKey, setRedeemingKey] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState<Feedback>(null)
+
+  const handleRedeem = (reward: XpReward) => {
+    setRedeemingKey(reward.key)
+    setFeedback(null)
+    startTransition(async () => {
+      const result = await redeemXpReward(reward.key)
+      if (result.ok) {
+        celebrate("milestone")
+        setFeedback({
+          kind: "success",
+          message: `Redeemed “${reward.name}”. Enjoy!`,
+        })
+        router.refresh()
+      } else {
+        setFeedback({
+          kind: "error",
+          message:
+            result.required != null && result.available != null
+              ? `Not enough XP — needs ${result.required}, you have ${result.available}.`
+              : result.error,
+        })
+      }
+      setRedeemingKey(null)
+    })
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="rounded-lg border border-tertiary bg-amber-50 p-6">
+        <p className="text-secondary text-sm uppercase tracking-wide">
+          Spendable Balance
+        </p>
+        <p className="heading-lg">{balance.toLocaleString()} XP</p>
+        <p className="text-secondary mt-1 text-sm">
+          Spend earned XP on perks and downloads. Spending never lowers your
+          level or titles — those are yours for good.
+        </p>
+      </header>
+
+      {feedback && (
+        <div
+          role="status"
+          className={`rounded-md border p-3 text-sm ${
+            feedback.kind === "success"
+              ? "border-green-300 bg-green-50 text-green-800"
+              : "border-red-300 bg-red-50 text-red-800"
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-5">
+        {rewards.map((reward) => {
+          const isThisRedeeming = pending && redeemingKey === reward.key
+          const disabled = pending || !reward.affordable
+          return (
+            <div
+              key={reward.key}
+              className="card-organic flex flex-col justify-between p-5"
+            >
+              <div>
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="heading-sm">{reward.name}</h3>
+                  <span className="badge-accent shrink-0">
+                    {reward.kind === "digital_download" ? "Download" : "Perk"}
+                  </span>
+                </div>
+                <p className="text-secondary text-sm mt-2">
+                  {reward.description}
+                </p>
+              </div>
+              <div className="mt-4 flex items-center justify-between">
+                <span className="label-lg">
+                  {reward.xpCost.toLocaleString()} XP
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRedeem(reward)}
+                  disabled={disabled}
+                  className="button-filled px-4 py-2 label-md disabled:opacity-50"
+                >
+                  {isThisRedeeming
+                    ? "Redeeming…"
+                    : reward.affordable
+                      ? "Redeem"
+                      : "Not enough XP"}
+                </button>
+              </div>
+            </div>
+          )
+        })}
+      </section>
+
+      {history.length > 0 && (
+        <section className="rounded-lg border border-tertiary p-6">
+          <h2 className="heading-sm uppercase mb-4">Redemption History</h2>
+          <ul className="divide-y divide-[rgba(var(--neutral-200),0.6)]">
+            {history.map((r) => (
+              <li
+                key={r.id}
+                className="flex items-center justify-between py-2 text-sm"
+              >
+                <span className="text-primary">{r.reward_name}</span>
+                <span className="text-secondary">
+                  −{r.xp_cost.toLocaleString()} XP · {r.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/storefront/src/lib/data/progression.ts
+++ b/storefront/src/lib/data/progression.ts
@@ -35,6 +35,8 @@ export type CharacterSheet = {
   customerId: string
   activeStance: Stance
   totalXp: number
+  /** Spendable XP balance (separate from lifetime status `totalXp`). */
+  spendableXp: number
   tracks: RoleTrack[]
   stats: {
     foodProducedCents: number
@@ -117,4 +119,94 @@ export const getStanceCookie = async (): Promise<Stance> => {
     "creator",
   ]
   return valid.includes(value as Stance) ? (value as Stance) : "consumer"
+}
+
+// ─── XP economy: spendable balance + reward redemption ─────────────────────
+
+export type XpRewardKind = "entitlement" | "digital_download"
+
+export type XpReward = {
+  key: string
+  name: string
+  description: string
+  xpCost: number
+  kind: XpRewardKind
+  featureKey: string
+  entitlementKind: string
+  durationDays?: number
+  icon?: string
+  /** Whether the current balance can afford this reward. */
+  affordable: boolean
+}
+
+export type XpRedemption = {
+  id: string
+  reward_key: string
+  reward_name: string
+  reward_kind: XpRewardKind
+  xp_cost: number
+  status: "pending" | "fulfilled" | "refunded"
+  feature_key?: string | null
+  entitlement_id?: string | null
+  created_at?: string
+  fulfilled_at?: string | null
+}
+
+export type XpRewardsResponse = {
+  balance: number
+  rewards: XpReward[]
+  history: XpRedemption[]
+}
+
+/**
+ * Fetch the spendable-XP balance, reward catalog, and redemption history.
+ * Returns null when logged out.
+ */
+export const getXpRewards = async (): Promise<XpRewardsResponse | null> => {
+  const authHeaders = await getAuthHeaders()
+  if (!authHeaders) return null
+
+  try {
+    return await medusaFetch<XpRewardsResponse>("/store/xp/rewards", {
+      method: "GET",
+      headers: authHeaders,
+      cache: "no-store",
+    })
+  } catch {
+    return null
+  }
+}
+
+export type RedeemResult =
+  | { ok: true; balance: number; redemption: XpRedemption }
+  | { ok: false; error: string; required?: number; available?: number }
+
+/** Redeem spendable XP for a catalog reward. */
+export const redeemXpReward = async (
+  rewardKey: string
+): Promise<RedeemResult> => {
+  const authHeaders = await getAuthHeaders()
+  if (!authHeaders) return { ok: false, error: "Authentication required" }
+
+  try {
+    const data = await medusaFetch<{
+      success: boolean
+      balance: number
+      redemption: XpRedemption
+    }>("/store/xp/redeem", {
+      method: "POST",
+      headers: authHeaders,
+      body: { reward_key: rewardKey },
+      cache: "no-store",
+    })
+    return { ok: true, balance: data.balance, redemption: data.redemption }
+  } catch (e) {
+    const err = e as { message?: string; status?: number; required?: number; available?: number }
+    return {
+      ok: false,
+      error: err?.message ?? "Failed to redeem reward",
+      required: err?.required,
+      available: err?.available,
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Stage 2 of the Blackout experience initiative: the **XP economy** — a spendable XP balance and reward redemption — building on the Stage 1 experience layer (merged in #707). Reuses the existing `progression` and `entitlement` modules; **lifetime status is never affected by spending.**

## Backend

- **Dual balance** — new `character_sheet.spendable_xp`, separate from lifetime `total_xp`. `recordXpEvent` accrues spendable XP alongside `total_xp` when earned; clawbacks reduce it (floored at 0). Spending never lowers `total_xp`, levels, or titles.
- **Redemption ledger** — new append-only `xp_redemption` model (`pending → fulfilled | refunded`) + migration `Migration20260622AddXpEconomy`.
- **Reward catalog** (`progression/rewards.ts`) — static, auditable price list. Every reward grants an entitlement: perks (theme / emoji pack / access pass) and digital downloads (entitlement kind `digital`, file delivery handled by the `digital-product` module).
- **Service methods** — `getSpendableXp`, `listRewards(balance)`, `beginRedemption` (validate + debit, throws `InsufficientXpError`), `completeRedemption`, `refundRedemption` (credits XP back if granting fails), `listRedemptionsForCustomer`.
- **API** — `GET /store/xp/rewards` (`{ balance, rewards w/ affordability, history }`) and `POST /store/xp/redeem` (debit → `entitlement.grant` → complete; refund + 502 on grant failure; 409 for insufficient XP; 404 for unknown reward). The cross-module grant lives in the route so `progression` stays decoupled from `entitlement`.

## Storefront

- `lib/data/progression.ts`: `spendableXp` on the sheet, `getXpRewards`, `redeemXpReward`.
- New `/rewards` page + `XpRewardsList` client component (redeem, history, calm milestone celebration on success via the Stage 1 effects layer, server refresh). Spendable balance + link surfaced on `/character`.

## Anti-speculation

XP is **non-transferable by construction** (no wallet→wallet transfer exists); redemption only ever debits the owner's own balance against the fixed catalog. Accrual is automatic wherever `recordXpEvent` is already called, so no new subscribers were needed.

## Verification

- Backend: `tsc --noEmit` clean; unit tests **35/35** (incl. new reward-catalog tests).
- Storefront: `tsc --noEmit` clean, `next lint` clean, vitest **87/87**.
- Full `pnpm build` not run (its `wait` step blocks on a running backend); typecheck covers compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdDwSpqTV77uuzyk1c8f7Q)_