### PR TITLE
feat(connect): connect.js commerce embed network

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -202,6 +202,24 @@ FBM_BLACKSTAR_API_KEY=
 # PUBLIC_STOREFRONT_URL=https://freeblackmarket.com
 
 # =============================================================================
+# 🔌 CONNECT.JS COMMERCE EMBED NETWORK
+# =============================================================================
+# Per-vendor publishable keys (pk_live_…) authenticate connect.js embeds and
+# are validated against each vendor's connect_domains origin allow-list. No
+# global secret is required — keys are generated per vendor from the panel.
+#
+# Storefront base used to build embed checkout/booking deep links.
+# STOREFRONT_URL=https://freeblackmarket.com
+#
+# Embed chat bridges to Blackout/Matrix when configured (see MATRIX_* above);
+# BLACKOUT_BASE_URL is used to build the in-iframe chat widget URL. Falls back
+# to emailing the vendor when Matrix is unavailable.
+# BLACKOUT_BASE_URL=https://theblackout.app
+#
+# Post-purchase review-request emails (daily job). Off unless explicitly enabled.
+# ENABLE_REVIEW_REQUESTS=false
+
+# =============================================================================
 # 🐛 BUG REPORTER - In-app "Report a bug" → creates GitHub issues
 # =============================================================================
 # When configured, users submitting the in-app bug report form will have

--- a/backend/medusa-config.ts
+++ b/backend/medusa-config.ts
@@ -174,6 +174,11 @@ const commerceModules = [
   { resolve: './src/modules/rental' },
   { resolve: './src/modules/wishlist' },
   { resolve: './src/modules/woocommerce-import' },
+  // connect.js commerce embed network
+  { resolve: './src/modules/embed-keys' },
+  { resolve: './src/modules/booking' },
+  { resolve: './src/modules/reviews' },
+  { resolve: './src/modules/embed-analytics' },
 ]
 
 // Financial/ledger modules

--- a/backend/src/api/middlewares.ts
+++ b/backend/src/api/middlewares.ts
@@ -19,6 +19,7 @@ import {
   authSessionRateLimiter,
   bugReportAnonymousRateLimiter,
   bugReportAuthRateLimiter,
+  embedKeyRateLimiter,
   publicCatalogRateLimiter,
   standardRateLimiter,
   strictAuthRateLimiter,
@@ -35,6 +36,11 @@ import { enforceListingTypeAllowed } from "../shared/listing-type-guard";
 import { enforceSameOriginForCookieAuth } from "../shared/csrf-guard";
 import { sanitizedErrorHandler } from "../shared/error-sanitizer";
 import { requireStorefrontContext } from "./middlewares/tenancy-context";
+import {
+  embedCorsMiddleware,
+  requireEmbedKey,
+  optionalEmbedKey,
+} from "./middlewares/embed-key";
 import {
   inventoryLedgerEventSchema,
   pickPackBatchSchema,
@@ -608,8 +614,32 @@ export default defineMiddlewares({
       middlewares: [publicStoreCorsMiddleware, publicCatalogRateLimiter],
     },
     {
+      // Keyless fallback stays public + IP rate-limited. When a connect.js
+      // publishable key IS present, optionalEmbedKey validates it and enforces
+      // the vendor's connect_domains origin allow-list (401/403 on failure).
       matcher: "/store/vendors/**",
-      middlewares: [publicStoreCorsMiddleware, publicCatalogRateLimiter],
+      middlewares: [
+        publicStoreCorsMiddleware,
+        publicCatalogRateLimiter,
+        optionalEmbedKey,
+      ],
+    },
+    // ============================================================
+    // connect.js embed network — key-required write/runtime endpoints
+    // ============================================================
+    // Bookings, reviews, chat-start, and analytics ingestion. Open CORS
+    // (reflect origin) so connect.js can call from any vendor site; every
+    // request is gated by a valid publishable key from an allowed origin and
+    // rate-limited per key.
+    {
+      matcher: "/store/embed/**",
+      middlewares: [embedCorsMiddleware, requireEmbedKey, embedKeyRateLimiter],
+    },
+    {
+      // Verified-purchase reviews — require a logged-in customer.
+      matcher: "/store/reviews",
+      method: "POST",
+      middlewares: [authenticate("customer", ["bearer", "session"])],
     },
     // ============================================================
     // CSRF: reject forged cross-site, cookie-authenticated writes

--- a/backend/src/api/middlewares/embed-key.ts
+++ b/backend/src/api/middlewares/embed-key.ts
@@ -1,0 +1,165 @@
+import type {
+  MedusaRequest,
+  MedusaResponse,
+  MedusaNextFunction,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import cors from "cors"
+import { createLogger } from "../../shared/logger"
+import { extractEmbedKey, originAllowed } from "../../shared/embed-auth"
+import { EMBED_KEYS_MODULE } from "../../modules/embed-keys"
+import type EmbedKeysService from "../../modules/embed-keys/service"
+
+const log = createLogger("api/middlewares/embed-key")
+
+/**
+ * Request fields populated by the embed-key middleware. Consumed by the
+ * `/store/embed/*` handlers and the per-key rate limiter.
+ */
+export type EmbedRequest = MedusaRequest & {
+  embed_seller_id?: string
+  embed_key_id?: string
+  embed_origin?: string | null
+}
+
+/**
+ * Open CORS for embed endpoints.
+ *
+ * connect.js runs on arbitrary third-party sites and sends an `Authorization`
+ * header, so we reflect any origin and allow the header. This is NOT the
+ * security boundary — every real request is still gated by `requireEmbedKey`,
+ * which validates the publishable key AND that the request Origin is in the
+ * vendor's `connect_domains` allow-list. CORS only governs what the browser
+ * lets the page read back.
+ */
+export function embedCorsMiddleware(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  return cors({
+    origin: true, // reflect any origin
+    credentials: false,
+    methods: ["GET", "POST", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    maxAge: 86400,
+  })(req, res, next)
+}
+
+/** Resolve a request's publishable key to a seller, enforcing the origin allow-list. */
+async function resolveEmbedContext(
+  req: MedusaRequest
+): Promise<
+  | { ok: true; seller_id: string; key_id: string }
+  | { ok: false; status: 401 | 403; message: string }
+  | { ok: "absent" }
+> {
+  const plaintext = extractEmbedKey(req.headers.authorization)
+  if (!plaintext) {
+    return { ok: "absent" }
+  }
+
+  const embedKeys = req.scope.resolve(EMBED_KEYS_MODULE) as EmbedKeysService
+  const resolution = await embedKeys.verifyKey(plaintext)
+  if (!resolution) {
+    return { ok: false, status: 401, message: "Invalid or revoked embed key" }
+  }
+
+  // Origin must be whitelisted in the vendor's connect_domains. The Origin
+  // header is the trustworthy signal for browser requests; fall back to Referer.
+  const origin =
+    (req.headers.origin as string | undefined) ||
+    (req.headers.referer as string | undefined) ||
+    ""
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: metaRows } = await query.graph({
+    entity: "seller_metadata",
+    fields: ["connect_domains"],
+    filters: { seller_id: resolution.seller_id },
+  })
+  const domains = (metaRows?.[0]?.connect_domains as unknown) ?? []
+
+  if (!originAllowed(origin, domains)) {
+    return {
+      ok: false,
+      status: 403,
+      message: "Origin not allowed for this embed key",
+    }
+  }
+
+  return { ok: true, seller_id: resolution.seller_id, key_id: resolution.id }
+}
+
+/**
+ * Hard gate for `/store/embed/*`: a valid publishable key from an allowed
+ * origin is required. Attaches `embed_seller_id`/`embed_key_id`/`embed_origin`.
+ */
+export async function requireEmbedKey(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  if (req.method === "OPTIONS") return next()
+
+  try {
+    const ctx = await resolveEmbedContext(req)
+    if (ctx.ok === "absent") {
+      return res.status(401).json({
+        message: "Missing embed key (Authorization: PublishableKey pk_live_…)",
+        type: "unauthorized",
+      })
+    }
+    if (ctx.ok === false) {
+      return res
+        .status(ctx.status)
+        .json({ message: ctx.message, type: ctx.status === 401 ? "unauthorized" : "not_allowed" })
+    }
+    const r = req as EmbedRequest
+    r.embed_seller_id = ctx.seller_id
+    r.embed_key_id = ctx.key_id
+    r.embed_origin =
+      (req.headers.origin as string | undefined) ?? null
+    return next()
+  } catch (err) {
+    log.error("requireEmbedKey failed", err)
+    return res
+      .status(500)
+      .json({ message: "Embed authentication failed", type: "server_error" })
+  }
+}
+
+/**
+ * Soft gate for `/store/vendors/:handle`: keeps the keyless public path working
+ * (cacheable, IP rate-limited) while validating the key + origin when one is
+ * present. An invalid key or disallowed origin is still rejected so a key, once
+ * used, is held to the same contract as the hard path.
+ */
+export async function optionalEmbedKey(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  if (req.method === "OPTIONS") return next()
+
+  try {
+    const ctx = await resolveEmbedContext(req)
+    if (ctx.ok === "absent") {
+      return next() // keyless fallback — unchanged public behavior
+    }
+    if (ctx.ok === false) {
+      return res
+        .status(ctx.status)
+        .json({ message: ctx.message, type: ctx.status === 401 ? "unauthorized" : "not_allowed" })
+    }
+    const r = req as EmbedRequest
+    r.embed_seller_id = ctx.seller_id
+    r.embed_key_id = ctx.key_id
+    r.embed_origin = (req.headers.origin as string | undefined) ?? null
+    return next()
+  } catch (err) {
+    // Never break the public catalog because key resolution hiccuped.
+    log.warn("optionalEmbedKey soft-failed; continuing keyless", err)
+    return next()
+  }
+}

--- a/backend/src/api/store/embed/bookings/route.ts
+++ b/backend/src/api/store/embed/bookings/route.ts
@@ -1,0 +1,131 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../../shared/logger"
+import { BOOKING_MODULE } from "../../../../modules/booking"
+import type BookingService from "../../../../modules/booking/service"
+import type { EmbedRequest } from "../../../middlewares/embed-key"
+
+const log = createLogger("api/store/embed/bookings")
+
+const DEFAULT_REGION = (
+  process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
+).toLowerCase()
+
+function storefrontBase(): string {
+  const explicit = process.env.STOREFRONT_URL || process.env.NEXT_PUBLIC_BASE_URL
+  if (explicit) return explicit.replace(/\/$/, "")
+  return "https://freeblackmarket.com"
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * POST /store/embed/bookings  (publishable key required)
+ *
+ * Creates a pending booking for a bookable product after re-validating the
+ * requested slot is still free. Returns the booking id plus a checkout deep
+ * link the embed can redirect to for paid services (the booking id rides along
+ * so the order → booking link can be made on payment). Free/request-only
+ * services simply stay "pending" until the vendor confirms from the panel.
+ *
+ * Body: { product_id, variant_id?, starts_at(ISO), customer_email,
+ *         customer_name?, notes? }
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as EmbedRequest).embed_seller_id
+  if (!sellerId) {
+    return res
+      .status(401)
+      .json({ message: "Missing embed context", type: "unauthorized" })
+  }
+
+  const body = (req.body ?? {}) as {
+    product_id?: string
+    variant_id?: string
+    starts_at?: string
+    customer_email?: string
+    customer_name?: string
+    notes?: string
+  }
+
+  const product_id = String(body.product_id || "")
+  const starts_at = String(body.starts_at || "")
+  const customer_email = String(body.customer_email || "").trim().toLowerCase()
+
+  if (!product_id || !starts_at || !customer_email) {
+    return res.status(400).json({
+      message: "product_id, starts_at and customer_email are required",
+      type: "invalid_data",
+    })
+  }
+  if (!EMAIL_RE.test(customer_email)) {
+    return res
+      .status(400)
+      .json({ message: "Invalid customer_email", type: "invalid_data" })
+  }
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+
+    // The product must be bookable AND owned by the key's seller — a key can
+    // never create bookings against another vendor's product.
+    const config = await booking.getConfigForProduct(product_id)
+    if (!config || config.seller_id !== sellerId) {
+      return res.status(404).json({
+        message: "Product is not bookable for this vendor",
+        type: "not_found",
+      })
+    }
+
+    const created = await booking.requestBooking({
+      seller_id: sellerId,
+      product_id,
+      variant_id: body.variant_id ?? null,
+      starts_at,
+      customer_email,
+      customer_name: body.customer_name?.slice(0, 120) ?? null,
+      notes: body.notes?.slice(0, 1000) ?? null,
+    })
+
+    if (!created) {
+      return res.status(409).json({
+        message: "That time is no longer available",
+        type: "conflict",
+      })
+    }
+
+    // Resolve the product handle for the checkout deep link (best effort).
+    let handle: string | null = null
+    try {
+      const query = req.scope.resolve("query")
+      const { data: products } = await query.graph({
+        entity: "product",
+        fields: ["handle"],
+        filters: { id: product_id } as any,
+      })
+      handle = products?.[0]?.handle ?? null
+    } catch {
+      /* non-fatal */
+    }
+
+    const checkout_url = handle
+      ? `${storefrontBase()}/${DEFAULT_REGION}/products/${handle}?booking_id=${created.id}`
+      : null
+
+    return res.status(201).json({
+      booking: {
+        id: created.id,
+        product_id,
+        starts_at: created.starts_at,
+        ends_at: created.ends_at,
+        status: created.status,
+      },
+      checkout_url,
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[POST /store/embed/bookings] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to create booking", type: "server_error" })
+  }
+}

--- a/backend/src/api/store/embed/chat/start/route.ts
+++ b/backend/src/api/store/embed/chat/start/route.ts
@@ -1,0 +1,142 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../../../shared/logger"
+import { getMatrixService } from "../../../../../shared/matrix-service"
+import type { EmbedRequest } from "../../../../middlewares/embed-key"
+
+const log = createLogger("api/store/embed/chat/start")
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function blackoutBase(): string {
+  return (process.env.BLACKOUT_BASE_URL || "https://theblackout.app").replace(
+    /\/$/,
+    ""
+  )
+}
+
+/**
+ * POST /store/embed/chat/start  (publishable key required)
+ *
+ * Opens a conversation between a website visitor and the vendor. Preferred
+ * path: create a private Matrix room, invite the vendor's mxid, and post the
+ * visitor's first message — returning a widget URL the embed can iframe. If
+ * Matrix is unconfigured/unreachable or the vendor has no mxid, we gracefully
+ * fall back to emailing the vendor and still return a usable response.
+ *
+ * Body: { customer_email, message, customer_name? }
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const sellerId = (req as EmbedRequest).embed_seller_id
+  if (!sellerId) {
+    return res
+      .status(401)
+      .json({ message: "Missing embed context", type: "unauthorized" })
+  }
+
+  const body = (req.body ?? {}) as {
+    customer_email?: string
+    customer_name?: string
+    message?: string
+  }
+  const customer_email = String(body.customer_email || "").trim().toLowerCase()
+  const message = String(body.message || "").trim().slice(0, 4000)
+  const customer_name = body.customer_name?.trim().slice(0, 120) || null
+
+  if (!customer_email || !EMAIL_RE.test(customer_email) || !message) {
+    return res.status(400).json({
+      message: "customer_email and message are required",
+      type: "invalid_data",
+    })
+  }
+
+  try {
+    const query = req.scope.resolve("query")
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: ["id", "name", "handle", "email"],
+      filters: { id: sellerId } as any,
+    })
+    const seller = sellers?.[0]
+    if (!seller) {
+      return res
+        .status(404)
+        .json({ message: "Vendor not found", type: "not_found" })
+    }
+
+    let vendorMxid: string | null = null
+    try {
+      const { data: metaRows } = await query.graph({
+        entity: "seller_metadata",
+        fields: ["mxid"],
+        filters: { seller_id: sellerId } as any,
+      })
+      vendorMxid = metaRows?.[0]?.mxid ?? null
+    } catch {
+      /* non-fatal */
+    }
+
+    const matrix = getMatrixService()
+    const intro = `New website message from ${customer_name || "a visitor"} (${customer_email}):\n\n${message}`
+
+    // ── Preferred: Matrix room ────────────────────────────────────────────
+    if (matrix && vendorMxid) {
+      // Stable-ish alias per visitor+vendor so repeat messages reuse a room.
+      const localpart = customer_email.split("@")[0]
+      const alias = matrix.sanitizeLocalpart(
+        `embed-${seller.handle || sellerId}-${localpart}`
+      )
+      const roomId = await matrix.ensureRoom({
+        alias,
+        name: `${seller.name || "Vendor"} ↔ ${customer_name || customer_email}`,
+        topic: `Embed chat with ${customer_email}`,
+        invite: [vendorMxid],
+      })
+
+      if (roomId) {
+        await matrix.invite(roomId, vendorMxid)
+        await matrix.sendMessage(roomId, intro)
+        return res.status(201).json({
+          channel: "matrix",
+          room_id: roomId,
+          widget_url: `${blackoutBase()}/embed/room/${encodeURIComponent(roomId)}`,
+        })
+      }
+      log.warn(`[embed/chat] room creation failed for ${sellerId}; emailing`)
+    }
+
+    // ── Fallback: email the vendor ────────────────────────────────────────
+    const to = seller.email
+    if (to) {
+      try {
+        const notification = req.scope.resolve("notification") as any
+        await notification.createNotifications({
+          to,
+          channel: "email",
+          template: "embed-chat-message",
+          data: {
+            vendor_name: seller.name ?? null,
+            customer_email,
+            customer_name,
+            message,
+          },
+        })
+      } catch (err) {
+        log.warn(`[embed/chat] email fallback failed for ${sellerId}`, err)
+      }
+    }
+
+    return res.status(201).json({
+      channel: "email",
+      room_id: null,
+      widget_url: null,
+      message:
+        "Your message was sent to the vendor — they'll reply to your email.",
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[POST /store/embed/chat/start] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to start chat", type: "server_error" })
+  }
+}

--- a/backend/src/api/store/embed/events/route.ts
+++ b/backend/src/api/store/embed/events/route.ts
@@ -1,0 +1,76 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../../shared/logger"
+import { EMBED_ANALYTICS_MODULE } from "../../../../modules/embed-analytics"
+import type EmbedAnalyticsService from "../../../../modules/embed-analytics/service"
+import type { EmbedRequest } from "../../../middlewares/embed-key"
+
+const log = createLogger("api/store/embed/events")
+
+const MAX_BATCH = 50
+const MAX_TYPE_LEN = 64
+
+type IncomingEvent = {
+  event_type?: string
+  product_id?: string
+  order_id?: string
+  session_id?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * POST /store/embed/events  (publishable key required)
+ *
+ * Fire-and-forget analytics ingestion. Accepts `{ events: [...] }` (or a bare
+ * array). seller_id/key_id/origin are taken from the validated embed context,
+ * never the body. Always returns 202 quickly; bad rows are skipped.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const r = req as EmbedRequest
+  const sellerId = r.embed_seller_id
+  if (!sellerId) {
+    return res
+      .status(401)
+      .json({ message: "Missing embed context", type: "unauthorized" })
+  }
+
+  const raw = req.body as { events?: IncomingEvent[] } | IncomingEvent[]
+  const incoming = Array.isArray(raw) ? raw : raw?.events
+  if (!Array.isArray(incoming) || !incoming.length) {
+    return res.status(202).json({ accepted: 0 })
+  }
+
+  const rows = incoming
+    .slice(0, MAX_BATCH)
+    .map((e) => {
+      const type = String(e?.event_type || "").trim().slice(0, MAX_TYPE_LEN)
+      if (!type) return null
+      return {
+        seller_id: sellerId,
+        key_id: r.embed_key_id ?? null,
+        origin: r.embed_origin ?? null,
+        session_id: e.session_id ? String(e.session_id).slice(0, 64) : null,
+        event_type: type,
+        product_id: e.product_id ? String(e.product_id).slice(0, 64) : null,
+        order_id: e.order_id ? String(e.order_id).slice(0, 64) : null,
+        metadata:
+          e.metadata && typeof e.metadata === "object" ? e.metadata : null,
+      }
+    })
+    .filter(Boolean) as Record<string, unknown>[]
+
+  if (!rows.length) {
+    return res.status(202).json({ accepted: 0 })
+  }
+
+  // Respond immediately; persist without blocking the beacon.
+  res.status(202).json({ accepted: rows.length })
+
+  try {
+    const analytics = req.scope.resolve(
+      EMBED_ANALYTICS_MODULE
+    ) as EmbedAnalyticsService
+    await analytics.createEmbedEvents(rows)
+  } catch (err) {
+    log.warn(`[embed/events] persist failed for ${sellerId}`, err)
+  }
+}

--- a/backend/src/api/store/products/[id]/reviews/route.ts
+++ b/backend/src/api/store/products/[id]/reviews/route.ts
@@ -1,0 +1,53 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../../../shared/logger"
+import { REVIEWS_MODULE } from "../../../../../modules/reviews"
+import { ReviewStatus } from "../../../../../modules/reviews/models/product-review"
+import type ReviewsService from "../../../../../modules/reviews/service"
+
+const log = createLogger("api/store/products/reviews")
+
+/**
+ * GET /store/products/:id/reviews?limit=&offset=
+ *
+ * Public, paginated published reviews for a single product.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const productId = req.params.id
+  const take = Math.min(Number(req.query.limit) || 20, 100)
+  const skip = Number(req.query.offset) || 0
+
+  try {
+    const reviews = req.scope.resolve(REVIEWS_MODULE) as ReviewsService
+    const [rows, count] = await reviews.listAndCountProductReviews(
+      { product_id: productId, status: ReviewStatus.PUBLISHED },
+      { order: { created_at: "DESC" }, take, skip }
+    )
+    const aggregate = await reviews.getProductAggregate(productId)
+
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
+    )
+    return res.json({
+      summary: aggregate,
+      reviews: rows.map((r) => ({
+        id: r.id,
+        rating: r.rating,
+        title: r.title ?? null,
+        body: r.body ?? null,
+        author: r.customer_display_name ?? "Verified buyer",
+        verified: !!r.is_verified,
+        created_at: r.created_at,
+      })),
+      count,
+      limit: take,
+      offset: skip,
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error(`[GET product reviews] failed for ${productId}:`, msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load reviews", type: "server_error" })
+  }
+}

--- a/backend/src/api/store/reviews/route.ts
+++ b/backend/src/api/store/reviews/route.ts
@@ -1,0 +1,180 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../shared/logger"
+import { REVIEWS_MODULE } from "../../../modules/reviews"
+import type ReviewsService from "../../../modules/reviews/service"
+import { updateSellerMetadataRecord } from "../../../modules/seller-extension/metadata-service"
+import type SellerExtensionService from "../../../modules/seller-extension/service"
+
+const log = createLogger("api/store/reviews")
+
+/** "Jordan Rivera" → "Jordan R."  (privacy-safe public display name) */
+function displayName(
+  first?: string | null,
+  last?: string | null
+): string | null {
+  const f = (first || "").trim()
+  const l = (last || "").trim()
+  if (!f && !l) return null
+  return l ? `${f} ${l[0]}.`.trim() : f
+}
+
+/**
+ * POST /store/reviews  (authenticated customer)
+ *
+ * Creates a verified-purchase review. Accepted ONLY when the referenced order
+ * belongs to the authenticated customer and actually contains the product.
+ * Recomputes the seller's rating/review_count afterward.
+ *
+ * Body: { order_id, product_id, rating(1-5), title?, body? }
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const authContext = (req as any).auth_context as
+    | { actor_id?: string; actor_type?: string }
+    | undefined
+  const customerId = authContext?.actor_id
+  if (!customerId || !customerId.startsWith("cus_")) {
+    return res
+      .status(401)
+      .json({ message: "Customer authentication required", type: "unauthorized" })
+  }
+
+  const body = (req.body ?? {}) as {
+    order_id?: string
+    product_id?: string
+    rating?: number
+    title?: string
+    body?: string
+  }
+  const order_id = String(body.order_id || "")
+  const product_id = String(body.product_id || "")
+  const rating = Math.round(Number(body.rating))
+
+  if (!order_id || !product_id) {
+    return res
+      .status(400)
+      .json({ message: "order_id and product_id are required", type: "invalid_data" })
+  }
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    return res
+      .status(400)
+      .json({ message: "rating must be an integer 1-5", type: "invalid_data" })
+  }
+
+  try {
+    const query = req.scope.resolve("query")
+
+    // 1) The order must belong to this customer and contain the product.
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: ["id", "customer_id", "items.product_id"],
+      filters: { id: order_id } as any,
+    })
+    const order = orders?.[0]
+    if (!order || order.customer_id !== customerId) {
+      return res
+        .status(403)
+        .json({ message: "Order does not belong to you", type: "not_allowed" })
+    }
+    const productIds = (order.items || [])
+      .map((i: any) => i.product_id)
+      .filter(Boolean)
+    if (!productIds.includes(product_id)) {
+      return res.status(400).json({
+        message: "Product was not part of this order",
+        type: "invalid_data",
+      })
+    }
+
+    // 2) Resolve the product's seller for aggregation + scoping.
+    const { data: products } = await query.graph({
+      entity: "product",
+      fields: ["id", "seller.id"],
+      filters: { id: product_id } as any,
+    })
+    const sellerId = (products?.[0] as any)?.seller?.id
+    if (!sellerId) {
+      return res
+        .status(404)
+        .json({ message: "Product seller not found", type: "not_found" })
+    }
+
+    // 3) Privacy-safe display name from the customer record.
+    let author: string | null = null
+    try {
+      const { data: customers } = await query.graph({
+        entity: "customer",
+        fields: ["first_name", "last_name"],
+        filters: { id: customerId } as any,
+      })
+      author = displayName(customers?.[0]?.first_name, customers?.[0]?.last_name)
+    } catch {
+      /* non-fatal */
+    }
+
+    const reviews = req.scope.resolve(REVIEWS_MODULE) as ReviewsService
+
+    // Guard the one-review-per-order-product rule before hitting the unique idx.
+    const existing = await reviews.listProductReviews(
+      { order_id, product_id },
+      { take: 1 }
+    )
+    if (existing?.length) {
+      return res.status(409).json({
+        message: "You already reviewed this product for this order",
+        type: "conflict",
+      })
+    }
+
+    const created = await reviews.createProductReviews({
+      product_id,
+      seller_id: sellerId,
+      order_id,
+      customer_id: customerId,
+      rating,
+      title: body.title?.slice(0, 120) ?? null,
+      body: body.body?.slice(0, 4000) ?? null,
+      customer_display_name: author,
+      is_verified: true,
+    })
+
+    // 4) Recompute the seller's denormalized rating/review_count.
+    try {
+      const aggregate = await reviews.getSellerAggregate(sellerId)
+      const { data: metaRows } = await query.graph({
+        entity: "seller_metadata",
+        fields: ["id"],
+        filters: { seller_id: sellerId } as any,
+      })
+      const metaId = metaRows?.[0]?.id
+      if (metaId) {
+        const sellerExtension = req.scope.resolve(
+          "sellerExtension"
+        ) as SellerExtensionService
+        await updateSellerMetadataRecord(sellerExtension, [
+          { id: metaId, rating: aggregate.average, review_count: aggregate.count },
+        ])
+      }
+    } catch (err) {
+      log.warn(`rating recompute failed for seller ${sellerId}`, err)
+    }
+
+    return res.status(201).json({
+      review: {
+        id: created.id,
+        product_id,
+        rating,
+        title: created.title ?? null,
+        body: created.body ?? null,
+        author: created.customer_display_name ?? "Verified buyer",
+        verified: true,
+        created_at: created.created_at,
+      },
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[POST /store/reviews] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to submit review", type: "server_error" })
+  }
+}

--- a/backend/src/api/store/vendors/[handle]/availability/route.ts
+++ b/backend/src/api/store/vendors/[handle]/availability/route.ts
@@ -1,0 +1,67 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../../../shared/logger"
+import { BOOKING_MODULE } from "../../../../../modules/booking"
+import type BookingService from "../../../../../modules/booking/service"
+
+const log = createLogger("api/store/vendors/availability")
+
+/**
+ * GET /store/vendors/:handle/availability?product_id=&date=YYYY-MM-DD
+ *
+ * Public (key-optional) bookable-slot lookup for a vendor's service product.
+ * Returns absolute UTC instants; the embed renders them in the visitor's local
+ * time. Cacheable briefly — availability changes only as bookings land.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const handle = req.params.handle
+  const productId = String(req.query.product_id || "")
+  const date = String(req.query.date || "")
+
+  if (!productId || !date) {
+    return res.status(400).json({
+      message: "product_id and date (YYYY-MM-DD) are required",
+      type: "invalid_data",
+    })
+  }
+
+  try {
+    const query = req.scope.resolve("query")
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: ["id", "handle"],
+      filters: { handle } as any,
+    })
+    const seller = sellers?.[0]
+    if (!seller) {
+      return res
+        .status(404)
+        .json({ message: `No vendor found for handle "${handle}"`, type: "not_found" })
+    }
+
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const config = await booking.getConfigForProduct(productId)
+    const slots = await booking.generateSlots({
+      seller_id: seller.id,
+      product_id: productId,
+      date,
+    })
+
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
+    )
+    return res.json({
+      product_id: productId,
+      date,
+      timezone: config?.timezone ?? null,
+      duration_minutes: config?.duration_minutes ?? null,
+      slots,
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error(`[GET availability] failed for ${handle}:`, msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load availability", type: "server_error" })
+  }
+}

--- a/backend/src/api/store/vendors/[handle]/reviews/route.ts
+++ b/backend/src/api/store/vendors/[handle]/reviews/route.ts
@@ -1,0 +1,68 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createLogger } from "../../../../../shared/logger"
+import { REVIEWS_MODULE } from "../../../../../modules/reviews"
+import { ReviewStatus } from "../../../../../modules/reviews/models/product-review"
+import type ReviewsService from "../../../../../modules/reviews/service"
+
+const log = createLogger("api/store/vendors/reviews")
+
+/**
+ * GET /store/vendors/:handle/reviews?limit=&offset=
+ *
+ * Public, paginated published reviews for a vendor. Exposes only the
+ * privacy-safe display name (never email or full name).
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const handle = req.params.handle
+  const take = Math.min(Number(req.query.limit) || 20, 100)
+  const skip = Number(req.query.offset) || 0
+
+  try {
+    const query = req.scope.resolve("query")
+    const { data: sellers } = await query.graph({
+      entity: "seller",
+      fields: ["id"],
+      filters: { handle } as any,
+    })
+    const seller = sellers?.[0]
+    if (!seller) {
+      return res
+        .status(404)
+        .json({ message: `No vendor found for handle "${handle}"`, type: "not_found" })
+    }
+
+    const reviews = req.scope.resolve(REVIEWS_MODULE) as ReviewsService
+    const [rows, count] = await reviews.listAndCountProductReviews(
+      { seller_id: seller.id, status: ReviewStatus.PUBLISHED },
+      { order: { created_at: "DESC" }, take, skip }
+    )
+    const aggregate = await reviews.getSellerAggregate(seller.id)
+
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
+    )
+    return res.json({
+      summary: aggregate,
+      reviews: rows.map((r) => ({
+        id: r.id,
+        product_id: r.product_id,
+        rating: r.rating,
+        title: r.title ?? null,
+        body: r.body ?? null,
+        author: r.customer_display_name ?? "Verified buyer",
+        verified: !!r.is_verified,
+        created_at: r.created_at,
+      })),
+      count,
+      limit: take,
+      offset: skip,
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error(`[GET vendor reviews] failed for ${handle}:`, msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load reviews", type: "server_error" })
+  }
+}

--- a/backend/src/api/store/vendors/[handle]/route.ts
+++ b/backend/src/api/store/vendors/[handle]/route.ts
@@ -1,6 +1,8 @@
 import { createLogger } from "../../../../shared/logger";
 const log = createLogger("api/store/vendors/handle");
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { BOOKING_MODULE } from "../../../../modules/booking";
+import type BookingService from "../../../../modules/booking/service";
 
 /**
  * GET /store/vendors/:handle  —  FBM Store API (public, website-agnostic)
@@ -125,6 +127,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
           "review_count",
           "website_url",
           "social_links",
+          "mxid",
+          "blackout_user_id",
         ],
         filters: { seller_id: seller.id },
       });
@@ -132,6 +136,9 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     } catch (err) {
       log.warn(`seller_metadata lookup failed for ${seller.id}`, err);
     }
+
+    // Chat is offered when the vendor has a reachable Blackout/Matrix identity.
+    const chatEnabled = Boolean(meta?.mxid || meta?.blackout_user_id);
 
     const vendor = wantVendor
       ? {
@@ -193,11 +200,82 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
             price: cheapestPrice([v], currency_code),
           })),
           url: productUrl(p.handle),
+          // Classified below; defaults to "physical" when no listing-type link.
+          type: "physical" as string,
         }));
+
+        // Classify products by their linked listing-type so connect.js can
+        // render dedicated digital/services grids. Done as a separate, isolated
+        // query so a missing link or schema change can never break the catalog.
+        try {
+          const { data: typeRows } = await query.graph({
+            entity: "product",
+            fields: ["id", "listing_type.catalog_id"],
+            filters: {
+              "seller.id": seller.id,
+              status: "published",
+            } as any,
+            pagination: { take: limitProducts },
+          });
+          const catalogById = new Map<string, string>();
+          for (const r of typeRows || []) {
+            const cid = (r as any)?.listing_type?.catalog_id;
+            if (cid) catalogById.set((r as any).id, String(cid));
+          }
+          for (const p of products) {
+            const cid = catalogById.get(p.id);
+            if (cid === "digital") p.type = "digital";
+            else if (cid === "bookable") p.type = "service";
+            else if (cid === "event") p.type = "event";
+            else if (cid === "physical_product") p.type = "physical";
+            else if (cid) p.type = cid;
+          }
+        } catch (err) {
+          log.warn(`listing-type classification failed for ${seller.id}`, err);
+        }
       } catch (err) {
         log.warn(`product lookup failed for ${seller.id}`, err);
       }
     }
+
+    // Attach booking config to bookable products so the embed can render a
+    // booking widget without a second round-trip. Isolated + best-effort.
+    if (products.length) {
+      try {
+        const bookingService = req.scope.resolve(
+          BOOKING_MODULE
+        ) as BookingService;
+        const configs = await bookingService.listProductBookingConfigs({
+          seller_id: seller.id,
+          is_active: true,
+        });
+        const configByProduct = new Map<string, any>();
+        for (const c of configs || []) configByProduct.set(c.product_id, c);
+        for (const p of products) {
+          const c = configByProduct.get(p.id);
+          if (c) {
+            p.type = "service";
+            (p as any).booking_config = {
+              duration_minutes: c.duration_minutes,
+              buffer_minutes: c.buffer_minutes,
+              timezone: c.timezone,
+              advance_days: c.advance_days,
+              min_notice_hours: c.min_notice_hours,
+            };
+          }
+        }
+      } catch (err) {
+        log.warn(`booking config lookup failed for ${seller.id}`, err);
+      }
+    }
+
+    // Grouped views for the specialized connect.js components. The flat
+    // `products` array above stays the back-compat contract; these are additive.
+    const productGroups = {
+      digital: products.filter((p) => p.type === "digital"),
+      services: products.filter((p) => p.type === "service"),
+      physical: products.filter((p) => p.type === "physical"),
+    };
 
     // 4) Events (ticket products) for this seller — best effort.
     let events: any[] = [];
@@ -269,7 +347,24 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     return res.json({
       vendor,
       products: wantProducts ? products : undefined,
+      // Additive grouped view; `events` stays its own top-level array for
+      // back-compat. Mirrors it under product_groups.events for symmetry.
+      product_groups: wantProducts
+        ? { ...productGroups, events: wantEvents ? events : [] }
+        : undefined,
       events: wantEvents ? events : undefined,
+      // Capability flags so an embed can decide which widgets to render without
+      // a second request. `booking_enabled` is finalized in the booking phase;
+      // it is true when any service product exists.
+      capabilities: {
+        chat_enabled: chatEnabled,
+        booking_enabled: productGroups.services.length > 0,
+        reviews_enabled: true,
+      },
+      reviews_summary: {
+        average: meta?.rating ?? null,
+        count: meta?.review_count ?? 0,
+      },
       _meta: {
         handle: seller.handle,
         currency_code,

--- a/backend/src/api/vendor/analytics/embed/route.ts
+++ b/backend/src/api/vendor/analytics/embed/route.ts
@@ -1,0 +1,37 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../../shared/logger"
+import { requireSellerId } from "../../../../shared"
+import { EMBED_ANALYTICS_MODULE } from "../../../../modules/embed-analytics"
+import type EmbedAnalyticsService from "../../../../modules/embed-analytics/service"
+
+const log = createLogger("api/vendor/analytics/embed")
+
+/**
+ * GET /vendor/analytics/embed?range=30
+ *
+ * Aggregated connect.js embed analytics for the authenticated vendor:
+ * funnel, traffic by domain, daily views/orders, and top products.
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const range = Math.min(Math.max(Number(req.query.range) || 30, 1), 365)
+
+  try {
+    const analytics = req.scope.resolve(
+      EMBED_ANALYTICS_MODULE
+    ) as EmbedAnalyticsService
+    const data = await analytics.aggregateForSeller(sellerId, range)
+    return res.json({ analytics: data })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[GET /vendor/analytics/embed] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load embed analytics", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/availability/route.ts
+++ b/backend/src/api/vendor/availability/route.ts
@@ -1,0 +1,111 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../shared/logger"
+import { requireSellerId } from "../../../shared"
+import { BOOKING_MODULE } from "../../../modules/booking"
+import type BookingService from "../../../modules/booking/service"
+import { parseTimeOfDay } from "../../../shared/timezone"
+
+const log = createLogger("api/vendor/availability")
+
+type WindowInput = {
+  day_of_week: number
+  start_time: string
+  end_time: string
+  is_active?: boolean
+}
+
+/** GET /vendor/availability — this vendor's recurring weekly windows. */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const rows = await booking.listVendorAvailabilities(
+      { seller_id: sellerId },
+      { order: { day_of_week: "ASC", start_time: "ASC" } }
+    )
+    return res.json({ availability: rows })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[GET /vendor/availability] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load availability", type: "server_error" })
+  }
+}
+
+/**
+ * POST /vendor/availability  { windows: WindowInput[] }
+ *
+ * Replaces the vendor's entire weekly availability set (full overwrite — the
+ * panel always sends the complete grid). Validates day-of-week and HH:MM and
+ * that start precedes end.
+ */
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const windows = ((req.body as { windows?: WindowInput[] })?.windows ?? []) as WindowInput[]
+  if (!Array.isArray(windows)) {
+    return res
+      .status(400)
+      .json({ message: "windows must be an array", type: "invalid_data" })
+  }
+
+  // Validate before mutating anything.
+  const cleaned: Required<WindowInput>[] = []
+  for (const w of windows) {
+    const dow = Number(w.day_of_week)
+    const start = parseTimeOfDay(String(w.start_time))
+    const end = parseTimeOfDay(String(w.end_time))
+    if (!Number.isInteger(dow) || dow < 0 || dow > 6 || !start || !end) {
+      return res.status(400).json({
+        message: "Each window needs day_of_week (0-6) and HH:MM start/end times",
+        type: "invalid_data",
+      })
+    }
+    if (start[0] * 60 + start[1] >= end[0] * 60 + end[1]) {
+      return res.status(400).json({
+        message: "start_time must be before end_time",
+        type: "invalid_data",
+      })
+    }
+    cleaned.push({
+      day_of_week: dow,
+      start_time: w.start_time,
+      end_time: w.end_time,
+      is_active: w.is_active !== false,
+    })
+  }
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+
+    // Full overwrite: delete existing windows, then insert the new set.
+    const existing = await booking.listVendorAvailabilities({ seller_id: sellerId })
+    if (existing.length) {
+      await booking.deleteVendorAvailabilities(existing.map((r) => r.id))
+    }
+    if (cleaned.length) {
+      await booking.createVendorAvailabilities(
+        cleaned.map((w) => ({ seller_id: sellerId, ...w }))
+      )
+    }
+
+    const rows = await booking.listVendorAvailabilities(
+      { seller_id: sellerId },
+      { order: { day_of_week: "ASC", start_time: "ASC" } }
+    )
+    return res.json({ availability: rows })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[POST /vendor/availability] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to save availability", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/bookings/[id]/route.ts
+++ b/backend/src/api/vendor/bookings/[id]/route.ts
@@ -1,0 +1,39 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../../shared/logger"
+import { requireSellerId } from "../../../../shared"
+import { BOOKING_MODULE } from "../../../../modules/booking"
+import type BookingService from "../../../../modules/booking/service"
+
+const log = createLogger("api/vendor/bookings/[id]")
+
+/**
+ * GET /vendor/bookings/:id — single booking, scoped to the owning seller.
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const rows = await booking.listBookings(
+      { id: req.params.id, seller_id: sellerId },
+      { take: 1 }
+    )
+    const row = rows?.[0]
+    if (!row) {
+      return res
+        .status(404)
+        .json({ message: "Booking not found", type: "not_found" })
+    }
+    return res.json({ booking: row })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[GET /vendor/bookings/:id] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load booking", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/bookings/[id]/status/route.ts
+++ b/backend/src/api/vendor/bookings/[id]/status/route.ts
@@ -1,0 +1,76 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../../../shared/logger"
+import { requireSellerId } from "../../../../../shared"
+import { BOOKING_MODULE } from "../../../../../modules/booking"
+import { BookingStatus } from "../../../../../modules/booking/models/booking"
+import type BookingService from "../../../../../modules/booking/service"
+import { notifyBookingConfirmed } from "../../../../../shared/booking-notify"
+
+const log = createLogger("api/vendor/bookings/[id]/status")
+
+const ALLOWED = new Set<string>(Object.values(BookingStatus))
+
+/**
+ * PATCH /vendor/bookings/:id/status  { status }
+ *
+ * Transitions a booking. Confirming sends the customer a confirmation email
+ * (best-effort). Scoped to the owning seller.
+ */
+export async function PATCH(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const status = String((req.body as { status?: string })?.status || "")
+  if (!ALLOWED.has(status)) {
+    return res.status(400).json({
+      message: `status must be one of: ${[...ALLOWED].join(", ")}`,
+      type: "invalid_data",
+    })
+  }
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const rows = await booking.listBookings(
+      { id: req.params.id, seller_id: sellerId },
+      { take: 1 }
+    )
+    const row = rows?.[0]
+    if (!row) {
+      return res
+        .status(404)
+        .json({ message: "Booking not found", type: "not_found" })
+    }
+
+    await booking.updateBookings({ id: row.id, status: status as BookingStatus })
+
+    if (status === BookingStatus.CONFIRMED && row.status !== BookingStatus.CONFIRMED) {
+      let vendorName: string | null = null
+      try {
+        const query = req.scope.resolve("query")
+        const { data: sellers } = await query.graph({
+          entity: "seller",
+          fields: ["name"],
+          filters: { id: sellerId },
+        })
+        vendorName = sellers?.[0]?.name ?? null
+      } catch {
+        /* non-fatal */
+      }
+      await notifyBookingConfirmed(req.scope, { ...row, status }, vendorName)
+    }
+
+    return res.json({ booking: { ...row, status } })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[PATCH /vendor/bookings/:id/status] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to update booking", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/bookings/config/route.ts
+++ b/backend/src/api/vendor/bookings/config/route.ts
@@ -1,0 +1,114 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../../shared/logger"
+import { requireSellerId } from "../../../../shared"
+import { BOOKING_MODULE } from "../../../../modules/booking"
+import type BookingService from "../../../../modules/booking/service"
+
+const log = createLogger("api/vendor/bookings/config")
+
+/**
+ * GET /vendor/bookings/config?product_id=  — read a product's booking config.
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const product_id = String(req.query.product_id || "")
+  if (!product_id) {
+    return res
+      .status(400)
+      .json({ message: "product_id is required", type: "invalid_data" })
+  }
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const rows = await booking.listProductBookingConfigs(
+      { product_id, seller_id: sellerId },
+      { take: 1 }
+    )
+    return res.json({ config: rows?.[0] ?? null })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[GET /vendor/bookings/config] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load booking config", type: "server_error" })
+  }
+}
+
+/**
+ * POST /vendor/bookings/config — create/update a product's booking config.
+ * Body: { product_id, duration_minutes?, buffer_minutes?, timezone?,
+ *         advance_days?, min_notice_hours?, is_active? }
+ */
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const product_id = String(body.product_id || "")
+  if (!product_id) {
+    return res
+      .status(400)
+      .json({ message: "product_id is required", type: "invalid_data" })
+  }
+
+  const num = (v: unknown, fallback: number, min: number, max: number) => {
+    const n = Number(v)
+    if (!Number.isFinite(n)) return fallback
+    return Math.min(max, Math.max(min, Math.round(n)))
+  }
+
+  // Validate timezone via Intl; reject unknown zones so slot math stays sane.
+  let timezone = "America/New_York"
+  if (typeof body.timezone === "string" && body.timezone) {
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: body.timezone })
+      timezone = body.timezone
+    } catch {
+      return res
+        .status(400)
+        .json({ message: "Invalid timezone", type: "invalid_data" })
+    }
+  }
+
+  const fields = {
+    seller_id: sellerId,
+    product_id,
+    duration_minutes: num(body.duration_minutes, 60, 5, 1440),
+    buffer_minutes: num(body.buffer_minutes, 0, 0, 1440),
+    timezone,
+    advance_days: num(body.advance_days, 30, 1, 365),
+    min_notice_hours: num(body.min_notice_hours, 24, 0, 8760),
+    is_active: body.is_active !== false,
+  }
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const existing = await booking.listProductBookingConfigs(
+      { product_id, seller_id: sellerId },
+      { take: 1 }
+    )
+
+    let config
+    if (existing?.[0]) {
+      config = await booking.updateProductBookingConfigs({
+        id: existing[0].id,
+        ...fields,
+      })
+    } else {
+      config = await booking.createProductBookingConfigs(fields)
+    }
+
+    return res.json({ config })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[POST /vendor/bookings/config] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to save booking config", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/bookings/route.ts
+++ b/backend/src/api/vendor/bookings/route.ts
@@ -1,0 +1,44 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../shared/logger"
+import { requireSellerId } from "../../../shared"
+import { BOOKING_MODULE } from "../../../modules/booking"
+import type BookingService from "../../../modules/booking/service"
+
+const log = createLogger("api/vendor/bookings")
+
+/**
+ * GET /vendor/bookings?status=&limit=&offset=
+ *
+ * Lists this vendor's bookings, newest first. Optional `status` filter.
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  try {
+    const booking = req.scope.resolve(BOOKING_MODULE) as BookingService
+    const status = req.query.status ? String(req.query.status) : undefined
+    const take = Math.min(Number(req.query.limit) || 50, 200)
+    const skip = Number(req.query.offset) || 0
+
+    const filters: Record<string, unknown> = { seller_id: sellerId }
+    if (status) filters.status = status
+
+    const [rows, count] = await booking.listAndCountBookings(filters, {
+      order: { starts_at: "DESC" },
+      take,
+      skip,
+    })
+
+    return res.json({ bookings: rows, count, limit: take, offset: skip })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[GET /vendor/bookings] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load bookings", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/embed-keys/[id]/route.ts
+++ b/backend/src/api/vendor/embed-keys/[id]/route.ts
@@ -1,0 +1,42 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../../shared/logger"
+import { requireSellerId } from "../../../../shared"
+import { EMBED_KEYS_MODULE } from "../../../../modules/embed-keys"
+import type EmbedKeysService from "../../../../modules/embed-keys/service"
+
+const log = createLogger("api/vendor/embed-keys/[id]")
+
+/**
+ * DELETE /vendor/embed-keys/:id — soft-revoke a key.
+ *
+ * Ownership is enforced in the service (the key must belong to this seller),
+ * so a vendor can never revoke another vendor's key by guessing an id.
+ */
+export async function DELETE(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  const id = req.params.id
+  try {
+    const embedKeys = req.scope.resolve(EMBED_KEYS_MODULE) as EmbedKeysService
+    const ok = await embedKeys.revokeKey(id, sellerId)
+    if (!ok) {
+      return res
+        .status(404)
+        .json({ message: "Embed key not found", type: "not_found" })
+    }
+    return res.json({ id, revoked: true })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[DELETE /vendor/embed-keys/:id] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to revoke embed key", type: "server_error" })
+  }
+}

--- a/backend/src/api/vendor/embed-keys/route.ts
+++ b/backend/src/api/vendor/embed-keys/route.ts
@@ -1,0 +1,94 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework"
+import { createLogger } from "../../../shared/logger"
+import { requireSellerId } from "../../../shared"
+import { EMBED_KEYS_MODULE } from "../../../modules/embed-keys"
+import type EmbedKeysService from "../../../modules/embed-keys/service"
+
+const log = createLogger("api/vendor/embed-keys")
+
+type EmbedKeyRow = {
+  id: string
+  last_four: string
+  label: string | null
+  revoked_at: Date | null
+  last_used_at: Date | null
+  created_at: Date
+}
+
+/** Public-safe view of a key (never includes the hash or plaintext). */
+function serializeKey(row: EmbedKeyRow) {
+  return {
+    id: row.id,
+    label: row.label ?? null,
+    masked: `pk_live_…${row.last_four}`,
+    last_used_at: row.last_used_at ?? null,
+    revoked_at: row.revoked_at ?? null,
+    created_at: row.created_at,
+    active: !row.revoked_at,
+  }
+}
+
+/**
+ * GET /vendor/embed-keys — list this vendor's publishable keys (masked).
+ */
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  try {
+    const embedKeys = req.scope.resolve(EMBED_KEYS_MODULE) as EmbedKeysService
+    const rows = (await embedKeys.listVendorEmbedKeys(
+      { seller_id: sellerId },
+      { order: { created_at: "DESC" } }
+    )) as unknown as EmbedKeyRow[]
+    return res.json({ keys: rows.map(serializeKey) })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[GET /vendor/embed-keys] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to load embed keys", type: "server_error" })
+  }
+}
+
+/**
+ * POST /vendor/embed-keys — create a key. The plaintext is returned ONCE.
+ * Body: { label?: string }
+ */
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const sellerId = await requireSellerId(req, res)
+  if (!sellerId) return
+
+  try {
+    const body = (req.body ?? {}) as { label?: string }
+    const label =
+      typeof body.label === "string" && body.label.trim()
+        ? body.label.trim().slice(0, 80)
+        : null
+
+    const embedKeys = req.scope.resolve(EMBED_KEYS_MODULE) as EmbedKeysService
+    const generated = await embedKeys.generateKey(sellerId, label)
+
+    return res.status(201).json({
+      // `key` is the plaintext — surfaced exactly once. The panel must prompt
+      // the vendor to copy it now; it is unrecoverable afterwards.
+      key: generated.key,
+      embed_key: {
+        id: generated.id,
+        label: generated.label,
+        masked: `pk_live_…${generated.last_four}`,
+        created_at: generated.created_at,
+        active: true,
+      },
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Unknown error"
+    log.error("[POST /vendor/embed-keys] failed:", msg)
+    return res
+      .status(500)
+      .json({ message: "Failed to create embed key", type: "server_error" })
+  }
+}

--- a/backend/src/jobs/review-request-emails.ts
+++ b/backend/src/jobs/review-request-emails.ts
@@ -1,0 +1,78 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const DEFAULT_REGION = (
+  process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
+).toLowerCase()
+
+function storefrontBase(): string {
+  const explicit = process.env.STOREFRONT_URL || process.env.NEXT_PUBLIC_BASE_URL
+  if (explicit) return explicit.replace(/\/$/, "")
+  return "https://freeblackmarket.com"
+}
+
+/**
+ * Post-purchase review request emails.
+ *
+ * Runs daily and targets orders placed 72–96h ago — a fixed 24h-wide window
+ * matching the daily cadence, so each order is emailed on exactly one run
+ * (natural idempotency without a "sent" marker). Off by default; enable with
+ * ENABLE_REVIEW_REQUESTS=true so it never spams unless a deployment opts in.
+ */
+export default async function reviewRequestEmailsJob(container: MedusaContainer) {
+  const logger = container.resolve("logger")
+  if (process.env.ENABLE_REVIEW_REQUESTS !== "true") {
+    return
+  }
+
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const notification = container.resolve("notification") as any
+
+  const now = Date.now()
+  const windowStart = new Date(now - 96 * 3_600_000)
+  const windowEnd = new Date(now - 72 * 3_600_000)
+
+  try {
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: ["id", "email", "created_at", "items.title", "customer.first_name"],
+      filters: {
+        created_at: { $gte: windowStart, $lt: windowEnd },
+      } as any,
+    })
+
+    if (!orders?.length) {
+      logger.info("[review-request-emails] no orders in window")
+      return
+    }
+
+    let sent = 0
+    for (const order of orders) {
+      if (!order.email) continue
+      const reviewUrl = `${storefrontBase()}/${DEFAULT_REGION}/review?order_id=${order.id}`
+      try {
+        await notification.createNotifications({
+          to: order.email,
+          channel: "email",
+          template: "review-request",
+          data: {
+            customer_name: (order as any).customer?.first_name ?? null,
+            product_title: (order as any).items?.[0]?.title ?? null,
+            review_url: reviewUrl,
+          },
+        })
+        sent++
+      } catch (err) {
+        logger.warn(`[review-request-emails] send failed for ${order.id}: ${err}`)
+      }
+    }
+    logger.info(`[review-request-emails] sent ${sent}/${orders.length}`)
+  } catch (error: any) {
+    logger.error(`[review-request-emails] job failed: ${error?.message || error}`)
+  }
+}
+
+export const config = {
+  name: "review-request-emails",
+  schedule: "0 14 * * *", // daily at 14:00 UTC
+}

--- a/backend/src/links/seller-embed-key.ts
+++ b/backend/src/links/seller-embed-key.ts
@@ -1,0 +1,29 @@
+import { defineLink } from "@medusajs/framework/utils"
+import EmbedKeysModule from "../modules/embed-keys"
+import { loadSellerModule, hasLinkable } from "./utils/load-seller-module"
+
+/**
+ * Link: Seller ↔ Vendor Embed Key (1:many)
+ *
+ * Links the MercurJS seller to its publishable connect.js keys so a seller's
+ * keys can be queried alongside the seller. The seller module is resolved via
+ * loadSellerModule() (MercurJS 1.5.0 no longer exports SellerModule from
+ * @mercurjs/framework). hasLinkable() guards prevent registering a link with
+ * an undefined target.
+ */
+
+const { SellerModule } = loadSellerModule("seller-embed-key")
+
+let sellerEmbedKeyLink: ReturnType<typeof defineLink> | null = null
+
+if (
+  hasLinkable(SellerModule, "seller") &&
+  hasLinkable(EmbedKeysModule, "vendorEmbedKey")
+) {
+  sellerEmbedKeyLink = defineLink(
+    { linkable: SellerModule.linkable.seller, isList: false },
+    { linkable: EmbedKeysModule.linkable.vendorEmbedKey, isList: true }
+  )
+}
+
+export default sellerEmbedKeyLink

--- a/backend/src/modules/booking/index.ts
+++ b/backend/src/modules/booking/index.ts
@@ -1,0 +1,10 @@
+import { Module } from "@medusajs/framework/utils"
+import BookingService from "./service"
+
+export const BOOKING_MODULE = "booking"
+
+export default Module(BOOKING_MODULE, {
+  service: BookingService,
+})
+
+export * from "./models"

--- a/backend/src/modules/booking/migrations/Migration20260624CreateBooking.ts
+++ b/backend/src/modules/booking/migrations/Migration20260624CreateBooking.ts
@@ -1,0 +1,98 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Create booking module tables.
+ *
+ *  - product_booking_config : per-product slot parameters (duration, buffer,
+ *                             timezone, lead times). Presence ⇒ bookable.
+ *  - vendor_availability    : recurring weekly windows (day_of_week + HH:MM).
+ *  - booking                : individual appointments (UTC instants + status).
+ */
+export class Migration20260624CreateBooking extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "product_booking_config" (
+        "id" TEXT NOT NULL,
+        "product_id" TEXT NOT NULL UNIQUE,
+        "seller_id" TEXT NOT NULL,
+        "duration_minutes" INTEGER NOT NULL DEFAULT 60,
+        "buffer_minutes" INTEGER NOT NULL DEFAULT 0,
+        "timezone" TEXT NOT NULL DEFAULT 'America/New_York',
+        "advance_days" INTEGER NOT NULL DEFAULT 30,
+        "min_notice_hours" INTEGER NOT NULL DEFAULT 24,
+        "is_active" BOOLEAN NOT NULL DEFAULT true,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "product_booking_config_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_product_booking_config_seller_id"
+      ON "product_booking_config" ("seller_id") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_product_booking_config_product_id"
+      ON "product_booking_config" ("product_id") WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "vendor_availability" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "day_of_week" INTEGER NOT NULL,
+        "start_time" TEXT NOT NULL,
+        "end_time" TEXT NOT NULL,
+        "is_active" BOOLEAN NOT NULL DEFAULT true,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "vendor_availability_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_vendor_availability_seller_day"
+      ON "vendor_availability" ("seller_id", "day_of_week") WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "booking" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "product_id" TEXT NOT NULL,
+        "variant_id" TEXT NULL,
+        "order_id" TEXT NULL,
+        "customer_id" TEXT NULL,
+        "customer_email" TEXT NOT NULL,
+        "customer_name" TEXT NULL,
+        "starts_at" TIMESTAMPTZ NOT NULL,
+        "ends_at" TIMESTAMPTZ NOT NULL,
+        "status" TEXT NOT NULL DEFAULT 'pending',
+        "notes" TEXT NULL,
+        "matrix_room_id" TEXT NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "booking_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_booking_seller_starts_at"
+      ON "booking" ("seller_id", "starts_at") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_booking_product_starts_at"
+      ON "booking" ("product_id", "starts_at") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_booking_order_id"
+      ON "booking" ("order_id") WHERE "deleted_at" IS NULL;
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "booking" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "vendor_availability" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "product_booking_config" CASCADE;')
+  }
+}

--- a/backend/src/modules/booking/models/booking.ts
+++ b/backend/src/modules/booking/models/booking.ts
@@ -1,0 +1,57 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Booking status lifecycle:
+ *   pending   — requested by a customer, not yet accepted/paid
+ *   confirmed — accepted by the vendor (or auto-confirmed on payment)
+ *   cancelled — cancelled by either party
+ *   completed — the appointment happened
+ *   no_show   — customer did not attend
+ */
+export enum BookingStatus {
+  PENDING = "pending",
+  CONFIRMED = "confirmed",
+  CANCELLED = "cancelled",
+  COMPLETED = "completed",
+  NO_SHOW = "no_show",
+}
+
+/**
+ * Booking
+ *
+ * A single appointment against a bookable product. `starts_at`/`ends_at` are
+ * absolute instants (UTC). `order_id` links the booking to the order that paid
+ * for it (best-effort, set when checkout completes); `matrix_room_id` links to
+ * a Blackout chat room when one is created.
+ */
+const Booking = model.define("booking", {
+  id: model.id().primaryKey(),
+
+  seller_id: model.text(),
+  product_id: model.text(),
+  variant_id: model.text().nullable(),
+
+  // Set once the booking is paid/linked to an order and customer.
+  order_id: model.text().nullable(),
+  customer_id: model.text().nullable(),
+
+  // Captured from the embed form so the vendor can reach the booker even
+  // before an account/order exists.
+  customer_email: model.text(),
+  customer_name: model.text().nullable(),
+
+  starts_at: model.dateTime(),
+  ends_at: model.dateTime(),
+
+  status: model.enum(Object.values(BookingStatus)).default(BookingStatus.PENDING),
+
+  notes: model.text().nullable(),
+  matrix_room_id: model.text().nullable(),
+})
+  .indexes([
+    { on: ["seller_id", "starts_at"], name: "IDX_booking_seller_starts_at" },
+    { on: ["product_id", "starts_at"], name: "IDX_booking_product_starts_at" },
+    { on: ["order_id"], name: "IDX_booking_order_id" },
+  ])
+
+export default Booking

--- a/backend/src/modules/booking/models/index.ts
+++ b/backend/src/modules/booking/models/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Booking Module Models
+ *
+ * Barrel export for booking models and types.
+ */
+
+export { default as ProductBookingConfig } from "./product-booking-config"
+export { default as VendorAvailability } from "./vendor-availability"
+export { default as Booking, BookingStatus } from "./booking"

--- a/backend/src/modules/booking/models/product-booking-config.ts
+++ b/backend/src/modules/booking/models/product-booking-config.ts
@@ -1,0 +1,35 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Product Booking Config
+ *
+ * Per-product booking parameters for "service"/"bookable" listings. A product
+ * with a config (and is_active) is considered bookable; the vendor's weekly
+ * `vendor_availability` windows are sliced into slots using these values.
+ */
+const ProductBookingConfig = model.define("product_booking_config", {
+  id: model.id().primaryKey(),
+
+  // The bookable product (1:1) and its owning seller.
+  product_id: model.text().unique(),
+  seller_id: model.text(),
+
+  // Slot length and gap between slots, in minutes.
+  duration_minutes: model.number().default(60),
+  buffer_minutes: model.number().default(0),
+
+  // IANA timezone the vendor's availability windows are expressed in.
+  timezone: model.text().default("America/New_York"),
+
+  // How far ahead a customer may book, and the minimum lead time.
+  advance_days: model.number().default(30),
+  min_notice_hours: model.number().default(24),
+
+  is_active: model.boolean().default(true),
+})
+  .indexes([
+    { on: ["seller_id"], name: "IDX_product_booking_config_seller_id" },
+    { on: ["product_id"], name: "IDX_product_booking_config_product_id" },
+  ])
+
+export default ProductBookingConfig

--- a/backend/src/modules/booking/models/vendor-availability.ts
+++ b/backend/src/modules/booking/models/vendor-availability.ts
@@ -1,0 +1,29 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Vendor Availability
+ *
+ * One recurring weekly window per row, in the vendor's timezone (the timezone
+ * lives on product_booking_config). `day_of_week` is 0=Sunday … 6=Saturday;
+ * `start_time`/`end_time` are "HH:MM" 24h wall-clock strings. A vendor may have
+ * multiple windows per day (e.g. morning + afternoon).
+ */
+const VendorAvailability = model.define("vendor_availability", {
+  id: model.id().primaryKey(),
+
+  seller_id: model.text(),
+
+  day_of_week: model.number(), // 0-6, Sunday-based
+  start_time: model.text(), // "HH:MM"
+  end_time: model.text(), // "HH:MM"
+
+  is_active: model.boolean().default(true),
+})
+  .indexes([
+    {
+      on: ["seller_id", "day_of_week"],
+      name: "IDX_vendor_availability_seller_day",
+    },
+  ])
+
+export default VendorAvailability

--- a/backend/src/modules/booking/service.ts
+++ b/backend/src/modules/booking/service.ts
@@ -1,0 +1,200 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import ProductBookingConfig from "./models/product-booking-config"
+import VendorAvailability from "./models/vendor-availability"
+import Booking, { BookingStatus } from "./models/booking"
+import {
+  parseDateOnly,
+  parseTimeOfDay,
+  weekdayOf,
+  zonedWallTimeToUtc,
+} from "../../shared/timezone"
+
+export type Slot = {
+  starts_at: string // ISO UTC
+  ends_at: string // ISO UTC
+}
+
+export type GenerateSlotsInput = {
+  seller_id: string
+  product_id: string
+  date: string // YYYY-MM-DD, interpreted in the product's timezone
+  now?: number // injectable for testing
+}
+
+const BLOCKING_STATUSES = [BookingStatus.PENDING, BookingStatus.CONFIRMED]
+
+class BookingService extends MedusaService({
+  ProductBookingConfig,
+  VendorAvailability,
+  Booking,
+}) {
+  /** The active booking config for a product, or null when not bookable. */
+  async getConfigForProduct(product_id: string) {
+    const rows = await this.listProductBookingConfigs(
+      { product_id, is_active: true },
+      { take: 1 }
+    )
+    return rows?.[0] ?? null
+  }
+
+  /**
+   * Available slots for a product on a given calendar date.
+   *
+   * Availability windows are wall-clock times in the product's timezone; we
+   * convert each candidate slot to a UTC instant, then drop slots that (a) fall
+   * inside the min-notice lead time or (b) overlap an existing pending/confirmed
+   * booking. Returns [] when the product isn't bookable or has no availability.
+   */
+  async generateSlots(input: GenerateSlotsInput): Promise<Slot[]> {
+    const parsed = parseDateOnly(input.date)
+    if (!parsed) return []
+    const [year, month, day] = parsed
+
+    const config = await this.getConfigForProduct(input.product_id)
+    if (!config) return []
+
+    const tz = config.timezone || "America/New_York"
+    const duration = Math.max(5, config.duration_minutes || 60)
+    const buffer = Math.max(0, config.buffer_minutes || 0)
+    const minNoticeHours = Math.max(0, config.min_notice_hours ?? 24)
+    const advanceDays = Math.max(0, config.advance_days ?? 30)
+
+    const now = input.now ?? Date.now()
+    const minStartMs = now + minNoticeHours * 3_600_000
+    const maxStartMs = now + advanceDays * 86_400_000
+
+    const dow = weekdayOf(year, month, day)
+    const windows = await this.listVendorAvailabilities({
+      seller_id: input.seller_id,
+      day_of_week: dow,
+      is_active: true,
+    })
+    if (!windows?.length) return []
+
+    // Existing bookings that could collide, bounded to this calendar day.
+    const dayStart = zonedWallTimeToUtc(year, month, day, 0, 0, tz).getTime()
+    const dayEnd = dayStart + 86_400_000
+    let existing: { starts_at: Date; ends_at: Date }[] = []
+    try {
+      existing = (await this.listBookings({
+        product_id: input.product_id,
+        status: BLOCKING_STATUSES,
+        starts_at: { $gte: new Date(dayStart), $lt: new Date(dayEnd) },
+      } as any)) as unknown as { starts_at: Date; ends_at: Date }[]
+    } catch {
+      // If operator filtering isn't supported, fall back to all blocking rows.
+      existing = (await this.listBookings({
+        product_id: input.product_id,
+        status: BLOCKING_STATUSES,
+      } as any)) as unknown as { starts_at: Date; ends_at: Date }[]
+    }
+
+    const taken = existing.map((b) => ({
+      start: new Date(b.starts_at).getTime(),
+      end: new Date(b.ends_at).getTime(),
+    }))
+    const overlaps = (s: number, e: number) =>
+      taken.some((t) => s < t.end && e > t.start)
+
+    const stepMs = (duration + buffer) * 60_000
+    const durationMs = duration * 60_000
+    const slots: Slot[] = []
+
+    for (const w of windows) {
+      const start = parseTimeOfDay(w.start_time)
+      const end = parseTimeOfDay(w.end_time)
+      if (!start || !end) continue
+
+      const windowStartMs = zonedWallTimeToUtc(
+        year,
+        month,
+        day,
+        start[0],
+        start[1],
+        tz
+      ).getTime()
+      const windowEndMs = zonedWallTimeToUtc(
+        year,
+        month,
+        day,
+        end[0],
+        end[1],
+        tz
+      ).getTime()
+
+      for (
+        let cursor = windowStartMs;
+        cursor + durationMs <= windowEndMs;
+        cursor += stepMs
+      ) {
+        const slotEnd = cursor + durationMs
+        if (cursor < minStartMs || cursor > maxStartMs) continue
+        if (overlaps(cursor, slotEnd)) continue
+        slots.push({
+          starts_at: new Date(cursor).toISOString(),
+          ends_at: new Date(slotEnd).toISOString(),
+        })
+      }
+    }
+
+    slots.sort((a, b) => a.starts_at.localeCompare(b.starts_at))
+    return slots
+  }
+
+  /**
+   * Re-validate that a requested instant is still a real, free slot, then
+   * create a pending booking. Returns null when the slot is no longer offered
+   * (taken, out of window, or past lead time) so the caller can 409.
+   */
+  async requestBooking(input: {
+    seller_id: string
+    product_id: string
+    variant_id?: string | null
+    starts_at: string // ISO
+    customer_email: string
+    customer_name?: string | null
+    notes?: string | null
+    now?: number
+  }) {
+    const startMs = Date.parse(input.starts_at)
+    if (Number.isNaN(startMs)) return null
+
+    const config = await this.getConfigForProduct(input.product_id)
+    if (!config) return null
+
+    // The requested instant must be one of the currently-offered slots for its
+    // own calendar day (computed in the product's timezone).
+    const tz = config.timezone || "America/New_York"
+    const dateStr = new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date(startMs))
+
+    const slots = await this.generateSlots({
+      seller_id: input.seller_id,
+      product_id: input.product_id,
+      date: dateStr,
+      now: input.now,
+    })
+    const match = slots.find((s) => Date.parse(s.starts_at) === startMs)
+    if (!match) return null
+
+    const created = await this.createBookings({
+      seller_id: input.seller_id,
+      product_id: input.product_id,
+      variant_id: input.variant_id ?? null,
+      customer_email: input.customer_email,
+      customer_name: input.customer_name ?? null,
+      starts_at: new Date(match.starts_at),
+      ends_at: new Date(match.ends_at),
+      status: BookingStatus.PENDING,
+      notes: input.notes ?? null,
+    })
+
+    return created
+  }
+}
+
+export default BookingService

--- a/backend/src/modules/embed-analytics/index.ts
+++ b/backend/src/modules/embed-analytics/index.ts
@@ -1,0 +1,10 @@
+import { Module } from "@medusajs/framework/utils"
+import EmbedAnalyticsService from "./service"
+
+export const EMBED_ANALYTICS_MODULE = "embedAnalytics"
+
+export default Module(EMBED_ANALYTICS_MODULE, {
+  service: EmbedAnalyticsService,
+})
+
+export * from "./models"

--- a/backend/src/modules/embed-analytics/migrations/Migration20260624CreateEmbedEvent.ts
+++ b/backend/src/modules/embed-analytics/migrations/Migration20260624CreateEmbedEvent.ts
@@ -1,0 +1,42 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Create embed_event (connect.js analytics ingestion).
+ */
+export class Migration20260624CreateEmbedEvent extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "embed_event" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "key_id" TEXT NULL,
+        "origin" TEXT NULL,
+        "session_id" TEXT NULL,
+        "event_type" TEXT NOT NULL,
+        "product_id" TEXT NULL,
+        "order_id" TEXT NULL,
+        "metadata" JSONB NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "embed_event_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_embed_event_seller_id"
+      ON "embed_event" ("seller_id") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_embed_event_seller_type"
+      ON "embed_event" ("seller_id", "event_type") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_embed_event_created_at"
+      ON "embed_event" ("created_at") WHERE "deleted_at" IS NULL;
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "embed_event" CASCADE;')
+  }
+}

--- a/backend/src/modules/embed-analytics/models/embed-event.ts
+++ b/backend/src/modules/embed-analytics/models/embed-event.ts
@@ -1,0 +1,32 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Embed Event
+ *
+ * A single analytics event emitted by connect.js (view, product view, add to
+ * cart, checkout start, order complete, booking open/confirm, chat open).
+ * Ingested in batches via `POST /store/embed/events`; `seller_id`/`key_id`/
+ * `origin` are stamped server-side from the validated embed key, never trusted
+ * from the client body.
+ */
+const EmbedEvent = model.define("embed_event", {
+  id: model.id().primaryKey(),
+
+  seller_id: model.text(),
+  key_id: model.text().nullable(),
+  origin: model.text().nullable(),
+  session_id: model.text().nullable(),
+
+  event_type: model.text(),
+  product_id: model.text().nullable(),
+  order_id: model.text().nullable(),
+
+  // Free-form client context (path, referrer, value, currency, …).
+  metadata: model.json().nullable(),
+})
+  .indexes([
+    { on: ["seller_id"], name: "IDX_embed_event_seller_id" },
+    { on: ["seller_id", "event_type"], name: "IDX_embed_event_seller_type" },
+  ])
+
+export default EmbedEvent

--- a/backend/src/modules/embed-analytics/models/index.ts
+++ b/backend/src/modules/embed-analytics/models/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Embed Analytics Module Models
+ */
+
+export { default as EmbedEvent } from "./embed-event"

--- a/backend/src/modules/embed-analytics/service.ts
+++ b/backend/src/modules/embed-analytics/service.ts
@@ -1,0 +1,108 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import EmbedEvent from "./models/embed-event"
+
+/** Event types connect.js emits. Free-form, but these drive the funnel. */
+export const EMBED_EVENT_TYPES = [
+  "view",
+  "product_view",
+  "add_to_cart",
+  "checkout_start",
+  "order_complete",
+  "booking_open",
+  "booking_confirm",
+  "chat_open",
+] as const
+
+export type EmbedAnalytics = {
+  range_days: number
+  totals: Record<string, number>
+  funnel: {
+    views: number
+    add_to_cart: number
+    checkout_start: number
+    orders: number
+  }
+  by_origin: { origin: string; count: number }[]
+  by_day: { date: string; views: number; orders: number }[]
+  top_products: { product_id: string; views: number }[]
+}
+
+class EmbedAnalyticsService extends MedusaService({
+  EmbedEvent,
+}) {
+  /**
+   * Aggregate a seller's embed events over the last `rangeDays`. Computed in
+   * memory from a bounded fetch — fine for per-vendor dashboards.
+   */
+  async aggregateForSeller(
+    seller_id: string,
+    rangeDays = 30,
+    now = Date.now()
+  ): Promise<EmbedAnalytics> {
+    const since = new Date(now - rangeDays * 86_400_000)
+    const rows = (await this.listEmbedEvents(
+      { seller_id, created_at: { $gte: since } } as any,
+      { take: 100_000, order: { created_at: "ASC" } }
+    )) as unknown as {
+      event_type: string
+      origin: string | null
+      product_id: string | null
+      created_at: Date
+    }[]
+
+    const totals: Record<string, number> = {}
+    const originCounts = new Map<string, number>()
+    const productViews = new Map<string, number>()
+    const dayMap = new Map<string, { views: number; orders: number }>()
+
+    for (const r of rows) {
+      totals[r.event_type] = (totals[r.event_type] || 0) + 1
+
+      if (r.origin) {
+        originCounts.set(r.origin, (originCounts.get(r.origin) || 0) + 1)
+      }
+      if (r.event_type === "product_view" && r.product_id) {
+        productViews.set(
+          r.product_id,
+          (productViews.get(r.product_id) || 0) + 1
+        )
+      }
+
+      const day = new Date(r.created_at).toISOString().slice(0, 10)
+      const bucket = dayMap.get(day) || { views: 0, orders: 0 }
+      if (r.event_type === "view") bucket.views++
+      if (r.event_type === "order_complete") bucket.orders++
+      dayMap.set(day, bucket)
+    }
+
+    const by_origin = [...originCounts.entries()]
+      .map(([origin, count]) => ({ origin, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 20)
+
+    const top_products = [...productViews.entries()]
+      .map(([product_id, views]) => ({ product_id, views }))
+      .sort((a, b) => b.views - a.views)
+      .slice(0, 10)
+
+    const by_day = [...dayMap.entries()]
+      .map(([date, v]) => ({ date, ...v }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+
+    return {
+      range_days: rangeDays,
+      totals,
+      funnel: {
+        views: totals["view"] || 0,
+        add_to_cart: totals["add_to_cart"] || 0,
+        checkout_start: totals["checkout_start"] || 0,
+        orders: totals["order_complete"] || 0,
+      },
+      by_origin,
+      by_day,
+      top_products,
+    }
+  }
+}
+
+export default EmbedAnalyticsService

--- a/backend/src/modules/embed-keys/index.ts
+++ b/backend/src/modules/embed-keys/index.ts
@@ -1,0 +1,10 @@
+import { Module } from "@medusajs/framework/utils"
+import EmbedKeysService from "./service"
+
+export const EMBED_KEYS_MODULE = "embedKeys"
+
+export default Module(EMBED_KEYS_MODULE, {
+  service: EmbedKeysService,
+})
+
+export * from "./models"

--- a/backend/src/modules/embed-keys/migrations/Migration20260624CreateVendorEmbedKey.ts
+++ b/backend/src/modules/embed-keys/migrations/Migration20260624CreateVendorEmbedKey.ts
@@ -1,0 +1,44 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Create vendor_embed_key
+ *
+ * Backs the per-vendor publishable keys used to authenticate connect.js
+ * embeds. Only the SHA-256 hash of each key is stored (`key_hash`, unique);
+ * the plaintext is shown to the vendor once at creation.
+ */
+export class Migration20260624CreateVendorEmbedKey extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "vendor_embed_key" (
+        "id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "key_hash" TEXT NOT NULL UNIQUE,
+        "last_four" TEXT NOT NULL,
+        "label" TEXT NULL,
+        "revoked_at" TIMESTAMPTZ NULL,
+        "last_used_at" TIMESTAMPTZ NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "vendor_embed_key_pkey" PRIMARY KEY ("id")
+      );
+    `)
+
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_vendor_embed_key_seller_id"
+      ON "vendor_embed_key" ("seller_id")
+      WHERE "deleted_at" IS NULL;
+    `)
+
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_vendor_embed_key_key_hash"
+      ON "vendor_embed_key" ("key_hash")
+      WHERE "deleted_at" IS NULL;
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "vendor_embed_key" CASCADE;')
+  }
+}

--- a/backend/src/modules/embed-keys/models/index.ts
+++ b/backend/src/modules/embed-keys/models/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Embed Keys Module Models
+ *
+ * Barrel export for embed-key models.
+ */
+
+export { default as VendorEmbedKey } from "./vendor-embed-key"

--- a/backend/src/modules/embed-keys/models/vendor-embed-key.ts
+++ b/backend/src/modules/embed-keys/models/vendor-embed-key.ts
@@ -1,0 +1,50 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Vendor Embed Key
+ *
+ * A per-vendor publishable key used to authenticate connect.js embeds.
+ *
+ * Security model:
+ *   - The plaintext key (`pk_live_…`) is shown to the vendor exactly ONCE,
+ *     at creation time. We persist only its SHA-256 hash (`key_hash`), so a
+ *     database leak never exposes usable keys.
+ *   - `last_four` is kept purely for display ("pk_live_…a1b2") so a vendor can
+ *     recognize which key is which without us storing the secret.
+ *   - Revocation is soft: `revoked_at` is stamped instead of deleting the row,
+ *     preserving the audit trail and keeping foreign references (analytics)
+ *     intact.
+ *
+ * Origin enforcement is NOT stored here — it reuses the vendor's existing
+ * `seller_metadata.connect_domains` allow-list so vendors manage one list.
+ */
+const VendorEmbedKey = model.define("vendor_embed_key", {
+  id: model.id().primaryKey(),
+
+  // MercurJS seller this key belongs to (linked via module link).
+  seller_id: model.text(),
+
+  // SHA-256 hex digest of the plaintext key. Unique so a hash collision or
+  // duplicate insert is rejected at the DB level.
+  key_hash: model.text().unique(),
+
+  // Last 4 chars of the plaintext key, for display only.
+  last_four: model.text(),
+
+  // Human-friendly label ("Squarespace site", "Staging").
+  label: model.text().nullable(),
+
+  // Soft-revocation timestamp; null while the key is active.
+  revoked_at: model.dateTime().nullable(),
+
+  // Best-effort "last seen" timestamp, updated fire-and-forget on use.
+  last_used_at: model.dateTime().nullable(),
+})
+  .indexes([
+    {
+      on: ["seller_id"],
+      name: "IDX_vendor_embed_key_seller_id",
+    },
+  ])
+
+export default VendorEmbedKey

--- a/backend/src/modules/embed-keys/service.ts
+++ b/backend/src/modules/embed-keys/service.ts
@@ -1,0 +1,98 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import crypto from "crypto"
+import VendorEmbedKey from "./models/vendor-embed-key"
+
+export const EMBED_KEY_PREFIX = "pk_live_"
+
+/** Hash a plaintext key into the form we persist and look up by. */
+export function hashEmbedKey(plaintext: string): string {
+  return crypto.createHash("sha256").update(plaintext).digest("hex")
+}
+
+export type GeneratedEmbedKey = {
+  id: string
+  /** Plaintext key — returned ONCE, never persisted. */
+  key: string
+  last_four: string
+  label: string | null
+  created_at: Date
+}
+
+export type EmbedKeyResolution = {
+  id: string
+  seller_id: string
+}
+
+class EmbedKeysService extends MedusaService({
+  VendorEmbedKey,
+}) {
+  /**
+   * Generate a new publishable key for a seller.
+   *
+   * Returns the plaintext key exactly once; only its hash is stored. The
+   * plaintext is `pk_live_` + 32 url-safe random characters.
+   */
+  async generateKey(
+    seller_id: string,
+    label?: string | null
+  ): Promise<GeneratedEmbedKey> {
+    const random = crypto.randomBytes(24).toString("base64url").slice(0, 32)
+    const plaintext = `${EMBED_KEY_PREFIX}${random}`
+    const key_hash = hashEmbedKey(plaintext)
+    const last_four = plaintext.slice(-4)
+
+    const created = await this.createVendorEmbedKeys({
+      seller_id,
+      key_hash,
+      last_four,
+      label: label ?? null,
+    })
+
+    return {
+      id: created.id,
+      key: plaintext,
+      last_four,
+      label: created.label ?? null,
+      created_at: created.created_at as unknown as Date,
+    }
+  }
+
+  /**
+   * Resolve a plaintext key to its owning seller, or null when the key is
+   * unknown or revoked. Updates `last_used_at` fire-and-forget.
+   */
+  async verifyKey(plaintext: string): Promise<EmbedKeyResolution | null> {
+    if (!plaintext || !plaintext.startsWith(EMBED_KEY_PREFIX)) {
+      return null
+    }
+
+    const key_hash = hashEmbedKey(plaintext)
+    const rows = await this.listVendorEmbedKeys(
+      { key_hash },
+      { take: 1 }
+    )
+    const row = rows?.[0]
+    if (!row || row.revoked_at) {
+      return null
+    }
+
+    // Best-effort "last seen" — never block the request on this write.
+    this.updateVendorEmbedKeys({ id: row.id, last_used_at: new Date() }).catch(
+      () => {}
+    )
+
+    return { id: row.id, seller_id: row.seller_id }
+  }
+
+  /** Soft-revoke a key. Returns false when the key does not belong to seller. */
+  async revokeKey(id: string, seller_id: string): Promise<boolean> {
+    const rows = await this.listVendorEmbedKeys({ id, seller_id }, { take: 1 })
+    if (!rows?.length) {
+      return false
+    }
+    await this.updateVendorEmbedKeys({ id, revoked_at: new Date() })
+    return true
+  }
+}
+
+export default EmbedKeysService

--- a/backend/src/modules/resend/__tests__/service.unit.spec.ts
+++ b/backend/src/modules/resend/__tests__/service.unit.spec.ts
@@ -6,6 +6,9 @@ jest.mock("../emails/user-invited", () => ({ userInvitedEmail: () => null }), { 
 jest.mock("../emails/password-reset", () => ({ passwordResetEmail: () => null }), { virtual: true })
 jest.mock("../emails/vendor-accepted", () => ({ vendorAcceptedEmail: () => null }), { virtual: true })
 jest.mock("../emails/customer-accepted", () => ({ customerAcceptedEmail: () => null }), { virtual: true })
+jest.mock("../emails/booking-confirmation", () => ({ bookingConfirmationEmail: () => null }), { virtual: true })
+jest.mock("../emails/review-request", () => ({ reviewRequestEmail: () => null }), { virtual: true })
+jest.mock("../emails/embed-chat-message", () => ({ embedChatMessageEmail: () => null }), { virtual: true })
 
 import ResendNotificationProviderService from "../service"
 

--- a/backend/src/modules/resend/emails/booking-confirmation.tsx
+++ b/backend/src/modules/resend/emails/booking-confirmation.tsx
@@ -1,0 +1,94 @@
+import {
+  Text,
+  Container,
+  Heading,
+  Html,
+  Section,
+  Tailwind,
+  Head,
+  Preview,
+  Body,
+} from "@react-email/components"
+
+type BookingConfirmationEmailProps = {
+  customer_name?: string | null
+  vendor_name?: string | null
+  starts_at: string | Date
+  ends_at?: string | Date
+}
+
+function formatWhen(value: string | Date | undefined): string {
+  if (!value) return ""
+  try {
+    const d = value instanceof Date ? value : new Date(value)
+    return d.toLocaleString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "short",
+    })
+  } catch {
+    return String(value)
+  }
+}
+
+function BookingConfirmationEmailComponent({
+  customer_name,
+  vendor_name,
+  starts_at,
+}: BookingConfirmationEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your booking is confirmed</Preview>
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[24px] max-w-[520px]">
+            <Section className="mt-[8px]">
+              <Heading className="text-black text-[24px] font-semibold text-center p-0 my-[16px] mx-0">
+                Booking confirmed
+              </Heading>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[14px] leading-[24px]">
+                Hi{customer_name ? ` ${customer_name}` : ""},
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">
+                Your booking with {vendor_name || "the vendor"} is confirmed.
+              </Text>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[16px] leading-[24px] font-semibold">
+                {formatWhen(starts_at)}
+              </Text>
+            </Section>
+
+            <Section className="mt-[24px]">
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                Need to reschedule or cancel? Reply to this email and the vendor
+                will help you out.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  )
+}
+
+export const bookingConfirmationEmail = (
+  props: BookingConfirmationEmailProps
+) => <BookingConfirmationEmailComponent {...props} />
+
+const mock: BookingConfirmationEmailProps = {
+  customer_name: "Jordan",
+  vendor_name: "Maple Grove Studio",
+  starts_at: "2026-07-01T15:00:00.000Z",
+}
+
+export default () => <BookingConfirmationEmailComponent {...mock} />

--- a/backend/src/modules/resend/emails/embed-chat-message.tsx
+++ b/backend/src/modules/resend/emails/embed-chat-message.tsx
@@ -1,0 +1,79 @@
+import {
+  Text,
+  Container,
+  Heading,
+  Html,
+  Section,
+  Tailwind,
+  Head,
+  Preview,
+  Body,
+} from "@react-email/components"
+
+type EmbedChatMessageEmailProps = {
+  vendor_name?: string | null
+  customer_email: string
+  customer_name?: string | null
+  message: string
+}
+
+function EmbedChatMessageEmailComponent({
+  vendor_name,
+  customer_email,
+  customer_name,
+  message,
+}: EmbedChatMessageEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>New message from your website</Preview>
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[24px] max-w-[520px]">
+            <Section className="mt-[8px]">
+              <Heading className="text-black text-[22px] font-semibold p-0 my-[16px] mx-0">
+                New message from your website
+              </Heading>
+            </Section>
+
+            <Section className="my-[12px]">
+              <Text className="text-black text-[14px] leading-[24px]">
+                Hi{vendor_name ? ` ${vendor_name}` : ""}, a visitor reached out
+                through your embedded FBM storefront.
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">
+                <strong>From:</strong>{" "}
+                {customer_name ? `${customer_name} ` : ""}({customer_email})
+              </Text>
+            </Section>
+
+            <Section className="my-[12px] bg-[#f6f6f6] rounded p-[16px]">
+              <Text className="text-black text-[14px] leading-[24px] whitespace-pre-wrap">
+                {message}
+              </Text>
+            </Section>
+
+            <Section className="mt-[16px]">
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                Reply directly to {customer_email} to continue the conversation.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  )
+}
+
+export const embedChatMessageEmail = (props: EmbedChatMessageEmailProps) => (
+  <EmbedChatMessageEmailComponent {...props} />
+)
+
+const mock: EmbedChatMessageEmailProps = {
+  vendor_name: "Maple Grove Studio",
+  customer_email: "shopper@example.com",
+  customer_name: "Jordan",
+  message: "Hi! Do you ship to Canada?",
+}
+
+export default () => <EmbedChatMessageEmailComponent {...mock} />

--- a/backend/src/modules/resend/emails/review-request.tsx
+++ b/backend/src/modules/resend/emails/review-request.tsx
@@ -1,0 +1,78 @@
+import {
+  Text,
+  Container,
+  Heading,
+  Html,
+  Section,
+  Tailwind,
+  Head,
+  Preview,
+  Body,
+  Button,
+} from "@react-email/components"
+
+type ReviewRequestEmailProps = {
+  customer_name?: string | null
+  vendor_name?: string | null
+  product_title?: string | null
+  review_url: string
+}
+
+function ReviewRequestEmailComponent({
+  customer_name,
+  vendor_name,
+  product_title,
+  review_url,
+}: ReviewRequestEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>How was your order? Leave a quick review</Preview>
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[24px] max-w-[520px]">
+            <Section className="mt-[8px]">
+              <Heading className="text-black text-[24px] font-semibold text-center p-0 my-[16px] mx-0">
+                How did we do?
+              </Heading>
+            </Section>
+
+            <Section className="my-[16px]">
+              <Text className="text-black text-[14px] leading-[24px]">
+                Hi{customer_name ? ` ${customer_name}` : ""},
+              </Text>
+              <Text className="text-black text-[14px] leading-[24px]">
+                Thanks for your recent order
+                {product_title ? ` of ${product_title}` : ""}
+                {vendor_name ? ` from ${vendor_name}` : ""}. A quick review helps
+                other shoppers and supports the vendor.
+              </Text>
+            </Section>
+
+            <Section className="text-center mt-[24px] mb-[24px]">
+              <Button
+                className="bg-[#000000] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+                href={review_url}
+              >
+                Leave a review
+              </Button>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  )
+}
+
+export const reviewRequestEmail = (props: ReviewRequestEmailProps) => (
+  <ReviewRequestEmailComponent {...props} />
+)
+
+const mock: ReviewRequestEmailProps = {
+  customer_name: "Jordan",
+  vendor_name: "Maple Grove Farms",
+  product_title: "Raw Wildflower Honey",
+  review_url: "https://freeblackmarket.com/review?token=demo",
+}
+
+export default () => <ReviewRequestEmailComponent {...mock} />

--- a/backend/src/modules/resend/service.ts
+++ b/backend/src/modules/resend/service.ts
@@ -16,6 +16,9 @@ import { userInvitedEmail } from "./emails/user-invited";
 import { passwordResetEmail } from "./emails/password-reset";
 import { vendorAcceptedEmail } from "./emails/vendor-accepted";
 import { customerAcceptedEmail } from "./emails/customer-accepted";
+import { bookingConfirmationEmail } from "./emails/booking-confirmation";
+import { reviewRequestEmail } from "./emails/review-request";
+import { embedChatMessageEmail } from "./emails/embed-chat-message";
 
 enum Templates {
   ORDER_PLACED = "order-placed",
@@ -23,6 +26,9 @@ enum Templates {
   PASSWORD_RESET = "password-reset",
   VENDOR_ACCEPTED = "vendor-accepted",
   CUSTOMER_ACCEPTED = "customer-accepted",
+  BOOKING_CONFIRMATION = "booking-confirmation",
+  REVIEW_REQUEST = "review-request",
+  EMBED_CHAT_MESSAGE = "embed-chat-message",
 }
 
 const templates: {[key in Templates]?: (props: unknown) => React.ReactNode} = {
@@ -31,6 +37,9 @@ const templates: {[key in Templates]?: (props: unknown) => React.ReactNode} = {
   [Templates.PASSWORD_RESET]: passwordResetEmail,
   [Templates.VENDOR_ACCEPTED]: vendorAcceptedEmail,
   [Templates.CUSTOMER_ACCEPTED]: customerAcceptedEmail,
+  [Templates.BOOKING_CONFIRMATION]: bookingConfirmationEmail,
+  [Templates.REVIEW_REQUEST]: reviewRequestEmail,
+  [Templates.EMBED_CHAT_MESSAGE]: embedChatMessageEmail,
 }
 
 /**
@@ -198,6 +207,12 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
         return "Your Free Black Market vendor access is ready"
       case Templates.CUSTOMER_ACCEPTED:
         return "Your account has been approved"
+      case Templates.BOOKING_CONFIRMATION:
+        return "Your booking is confirmed"
+      case Templates.REVIEW_REQUEST:
+        return "How was your order? Leave a review"
+      case Templates.EMBED_CHAT_MESSAGE:
+        return "New message from your website"
       default:
         return "New Email"
     }

--- a/backend/src/modules/reviews/index.ts
+++ b/backend/src/modules/reviews/index.ts
@@ -1,0 +1,10 @@
+import { Module } from "@medusajs/framework/utils"
+import ReviewsService from "./service"
+
+export const REVIEWS_MODULE = "reviews"
+
+export default Module(REVIEWS_MODULE, {
+  service: ReviewsService,
+})
+
+export * from "./models"

--- a/backend/src/modules/reviews/migrations/Migration20260624CreateProductReview.ts
+++ b/backend/src/modules/reviews/migrations/Migration20260624CreateProductReview.ts
@@ -9,7 +9,7 @@ import { Migration } from "@mikro-orm/migrations"
 export class Migration20260624CreateProductReview extends Migration {
   async up(): Promise<void> {
     this.addSql(`
-      CREATE TABLE IF NOT EXISTS "product_review" (
+      CREATE TABLE IF NOT EXISTS "embed_product_review" (
         "id" TEXT NOT NULL,
         "product_id" TEXT NOT NULL,
         "seller_id" TEXT NOT NULL,
@@ -24,24 +24,24 @@ export class Migration20260624CreateProductReview extends Migration {
         "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
         "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
         "deleted_at" TIMESTAMPTZ NULL,
-        CONSTRAINT "product_review_pkey" PRIMARY KEY ("id")
+        CONSTRAINT "embed_product_review_pkey" PRIMARY KEY ("id")
       );
     `)
     this.addSql(`
-      CREATE INDEX IF NOT EXISTS "IDX_product_review_product_id"
-      ON "product_review" ("product_id") WHERE "deleted_at" IS NULL;
+      CREATE INDEX IF NOT EXISTS "IDX_embed_product_review_product_id"
+      ON "embed_product_review" ("product_id") WHERE "deleted_at" IS NULL;
     `)
     this.addSql(`
-      CREATE INDEX IF NOT EXISTS "IDX_product_review_seller_id"
-      ON "product_review" ("seller_id") WHERE "deleted_at" IS NULL;
+      CREATE INDEX IF NOT EXISTS "IDX_embed_product_review_seller_id"
+      ON "embed_product_review" ("seller_id") WHERE "deleted_at" IS NULL;
     `)
     this.addSql(`
-      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_product_review_order_product"
-      ON "product_review" ("order_id", "product_id") WHERE "deleted_at" IS NULL;
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_embed_product_review_order_product"
+      ON "embed_product_review" ("order_id", "product_id") WHERE "deleted_at" IS NULL;
     `)
   }
 
   async down(): Promise<void> {
-    this.addSql('DROP TABLE IF EXISTS "product_review" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "embed_product_review" CASCADE;')
   }
 }

--- a/backend/src/modules/reviews/migrations/Migration20260624CreateProductReview.ts
+++ b/backend/src/modules/reviews/migrations/Migration20260624CreateProductReview.ts
@@ -1,0 +1,47 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * Migration: Create product_review.
+ *
+ * Verified-purchase reviews. UNIQUE(order_id, product_id) enforces one review
+ * per product per order at the DB level.
+ */
+export class Migration20260624CreateProductReview extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "product_review" (
+        "id" TEXT NOT NULL,
+        "product_id" TEXT NOT NULL,
+        "seller_id" TEXT NOT NULL,
+        "order_id" TEXT NOT NULL,
+        "customer_id" TEXT NULL,
+        "rating" INTEGER NOT NULL,
+        "title" TEXT NULL,
+        "body" TEXT NULL,
+        "customer_display_name" TEXT NULL,
+        "is_verified" BOOLEAN NOT NULL DEFAULT true,
+        "status" TEXT NOT NULL DEFAULT 'published',
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deleted_at" TIMESTAMPTZ NULL,
+        CONSTRAINT "product_review_pkey" PRIMARY KEY ("id")
+      );
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_product_review_product_id"
+      ON "product_review" ("product_id") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_product_review_seller_id"
+      ON "product_review" ("seller_id") WHERE "deleted_at" IS NULL;
+    `)
+    this.addSql(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_product_review_order_product"
+      ON "product_review" ("order_id", "product_id") WHERE "deleted_at" IS NULL;
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "product_review" CASCADE;')
+  }
+}

--- a/backend/src/modules/reviews/models/index.ts
+++ b/backend/src/modules/reviews/models/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Reviews Module Models
+ */
+
+export { default as ProductReview, ReviewStatus } from "./product-review"

--- a/backend/src/modules/reviews/models/product-review.ts
+++ b/backend/src/modules/reviews/models/product-review.ts
@@ -1,0 +1,43 @@
+import { model } from "@medusajs/framework/utils"
+
+export enum ReviewStatus {
+  PUBLISHED = "published",
+  HIDDEN = "hidden",
+}
+
+/**
+ * Product Review
+ *
+ * A verified-purchase review. Tied to the order that proves the purchase via
+ * `UNIQUE(order_id, product_id)` so a buyer can leave exactly one review per
+ * product per order. `customer_display_name` is the privacy-safe name shown
+ * publicly ("Jordan R."); the full customer is referenced by id only.
+ */
+const ProductReview = model.define("product_review", {
+  id: model.id().primaryKey(),
+
+  product_id: model.text(),
+  seller_id: model.text(),
+  order_id: model.text(),
+  customer_id: model.text().nullable(),
+
+  rating: model.number(), // 1-5
+  title: model.text().nullable(),
+  body: model.text().nullable(),
+
+  customer_display_name: model.text().nullable(),
+  is_verified: model.boolean().default(true),
+
+  status: model.enum(Object.values(ReviewStatus)).default(ReviewStatus.PUBLISHED),
+})
+  .indexes([
+    { on: ["product_id"], name: "IDX_product_review_product_id" },
+    { on: ["seller_id"], name: "IDX_product_review_seller_id" },
+    {
+      on: ["order_id", "product_id"],
+      name: "UQ_product_review_order_product",
+      unique: true,
+    },
+  ])
+
+export default ProductReview

--- a/backend/src/modules/reviews/models/product-review.ts
+++ b/backend/src/modules/reviews/models/product-review.ts
@@ -13,7 +13,7 @@ export enum ReviewStatus {
  * product per order. `customer_display_name` is the privacy-safe name shown
  * publicly ("Jordan R."); the full customer is referenced by id only.
  */
-const ProductReview = model.define("product_review", {
+const ProductReview = model.define("embed_product_review", {
   id: model.id().primaryKey(),
 
   product_id: model.text(),
@@ -31,11 +31,11 @@ const ProductReview = model.define("product_review", {
   status: model.enum(Object.values(ReviewStatus)).default(ReviewStatus.PUBLISHED),
 })
   .indexes([
-    { on: ["product_id"], name: "IDX_product_review_product_id" },
-    { on: ["seller_id"], name: "IDX_product_review_seller_id" },
+    { on: ["product_id"], name: "IDX_embed_product_review_product_id" },
+    { on: ["seller_id"], name: "IDX_embed_product_review_seller_id" },
     {
       on: ["order_id", "product_id"],
-      name: "UQ_product_review_order_product",
+      name: "UQ_embed_product_review_order_product",
       unique: true,
     },
   ])

--- a/backend/src/modules/reviews/service.ts
+++ b/backend/src/modules/reviews/service.ts
@@ -1,0 +1,40 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import ProductReview, { ReviewStatus } from "./models/product-review"
+
+export type SellerRatingAggregate = {
+  average: number | null
+  count: number
+}
+
+class ReviewsService extends MedusaService({
+  ProductReview,
+}) {
+  /** Average rating + count of published reviews for a seller. */
+  async getSellerAggregate(seller_id: string): Promise<SellerRatingAggregate> {
+    const rows = await this.listProductReviews(
+      { seller_id, status: ReviewStatus.PUBLISHED },
+      { select: ["rating"], take: 100_000 }
+    )
+    const count = rows.length
+    if (!count) return { average: null, count: 0 }
+    const sum = rows.reduce((acc, r) => acc + (Number(r.rating) || 0), 0)
+    // Round to one decimal place.
+    return { average: Math.round((sum / count) * 10) / 10, count }
+  }
+
+  /** Average rating + count of published reviews for a single product. */
+  async getProductAggregate(
+    product_id: string
+  ): Promise<SellerRatingAggregate> {
+    const rows = await this.listProductReviews(
+      { product_id, status: ReviewStatus.PUBLISHED },
+      { select: ["rating"], take: 100_000 }
+    )
+    const count = rows.length
+    if (!count) return { average: null, count: 0 }
+    const sum = rows.reduce((acc, r) => acc + (Number(r.rating) || 0), 0)
+    return { average: Math.round((sum / count) * 10) / 10, count }
+  }
+}
+
+export default ReviewsService

--- a/backend/src/shared/__tests__/timezone.unit.spec.ts
+++ b/backend/src/shared/__tests__/timezone.unit.spec.ts
@@ -1,0 +1,66 @@
+import {
+  tzOffsetMs,
+  zonedWallTimeToUtc,
+  weekdayOf,
+  parseDateOnly,
+  parseTimeOfDay,
+} from "../timezone"
+
+describe("timezone helpers", () => {
+  describe("tzOffsetMs", () => {
+    it("computes a negative offset for US Eastern in summer (DST, -4h)", () => {
+      // 2026-07-01 noon UTC — New York is UTC-4 in July.
+      const offset = tzOffsetMs("America/New_York", new Date("2026-07-01T12:00:00Z"))
+      expect(offset).toBe(-4 * 3_600_000)
+    })
+
+    it("computes -5h for US Eastern in winter (standard time)", () => {
+      const offset = tzOffsetMs("America/New_York", new Date("2026-01-15T12:00:00Z"))
+      expect(offset).toBe(-5 * 3_600_000)
+    })
+
+    it("returns 0 for UTC", () => {
+      expect(tzOffsetMs("UTC", new Date("2026-07-01T12:00:00Z"))).toBe(0)
+    })
+
+    it("returns 0 for an invalid zone instead of throwing", () => {
+      expect(tzOffsetMs("Not/AZone", new Date("2026-07-01T12:00:00Z"))).toBe(0)
+    })
+  })
+
+  describe("zonedWallTimeToUtc", () => {
+    it("maps 9:00 AM New York (summer) to 13:00 UTC", () => {
+      const utc = zonedWallTimeToUtc(2026, 7, 1, 9, 0, "America/New_York")
+      expect(utc.toISOString()).toBe("2026-07-01T13:00:00.000Z")
+    })
+
+    it("maps 9:00 AM New York (winter) to 14:00 UTC", () => {
+      const utc = zonedWallTimeToUtc(2026, 1, 15, 9, 0, "America/New_York")
+      expect(utc.toISOString()).toBe("2026-01-15T14:00:00.000Z")
+    })
+
+    it("is identity for UTC wall times", () => {
+      const utc = zonedWallTimeToUtc(2026, 7, 1, 9, 30, "UTC")
+      expect(utc.toISOString()).toBe("2026-07-01T09:30:00.000Z")
+    })
+  })
+
+  describe("weekdayOf", () => {
+    it("returns 3 (Wednesday) for 2026-07-01", () => {
+      expect(weekdayOf(2026, 7, 1)).toBe(3)
+    })
+  })
+
+  describe("parseDateOnly / parseTimeOfDay", () => {
+    it("parses valid values", () => {
+      expect(parseDateOnly("2026-07-01")).toEqual([2026, 7, 1])
+      expect(parseTimeOfDay("09:30")).toEqual([9, 30])
+    })
+
+    it("rejects malformed values", () => {
+      expect(parseDateOnly("2026/07/01")).toBeNull()
+      expect(parseTimeOfDay("25:00")).toBeNull()
+      expect(parseTimeOfDay("9:5")).toBeNull()
+    })
+  })
+})

--- a/backend/src/shared/booking-notify.ts
+++ b/backend/src/shared/booking-notify.ts
@@ -1,0 +1,41 @@
+import { createLogger } from "./logger"
+
+const log = createLogger("shared/booking-notify")
+
+type MinimalBooking = {
+  id: string
+  customer_email: string
+  customer_name?: string | null
+  starts_at: Date | string
+  ends_at: Date | string
+  status: string
+}
+
+/**
+ * Best-effort booking email. Never throws — a notification failure must not
+ * break the request or subscriber that triggered it. Uses the "email" channel
+ * (Resend/SMTP per env) with the `booking-confirmation` template.
+ */
+export async function notifyBookingConfirmed(
+  container: { resolve: (k: string) => any },
+  booking: MinimalBooking,
+  vendorName?: string | null
+): Promise<void> {
+  try {
+    const notification = container.resolve("notification")
+    await notification.createNotifications({
+      to: booking.customer_email,
+      channel: "email",
+      template: "booking-confirmation",
+      data: {
+        booking_id: booking.id,
+        customer_name: booking.customer_name ?? null,
+        starts_at: booking.starts_at,
+        ends_at: booking.ends_at,
+        vendor_name: vendorName ?? "the vendor",
+      },
+    })
+  } catch (err) {
+    log.warn(`booking-confirmation email failed for ${booking.id}`, err)
+  }
+}

--- a/backend/src/shared/embed-auth.ts
+++ b/backend/src/shared/embed-auth.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared helpers for connect.js embed authentication.
+ *
+ * The embed-key middleware and the embed routes both need to (a) pull the
+ * publishable key out of the Authorization header and (b) decide whether a
+ * request Origin is allowed by a vendor's `connect_domains` allow-list. Keeping
+ * the logic here ensures the middleware and any handler agree.
+ */
+
+/**
+ * Extract a `pk_live_…` publishable key from an Authorization header.
+ *
+ * Accepts both `PublishableKey pk_live_…` (canonical connect.js form) and a
+ * bare `pk_live_…` value. Returns null when absent or malformed.
+ */
+export function extractEmbedKey(
+  authorization: string | undefined | null
+): string | null {
+  if (!authorization || typeof authorization !== "string") return null
+  const trimmed = authorization.trim()
+  const match = trimmed.match(/^(?:PublishableKey\s+)?(pk_live_[A-Za-z0-9_-]+)$/)
+  return match ? match[1] : null
+}
+
+/** Reduce an Origin/Referer value to a bare, lowercased hostname (no www, no port). */
+export function originHostname(origin: string | undefined | null): string | null {
+  if (!origin || typeof origin !== "string") return null
+  try {
+    // Origin is normally a full URL ("https://shop.example.com"); Referer too.
+    const url = new URL(origin)
+    return url.hostname.toLowerCase().replace(/^www\./, "")
+  } catch {
+    // Fall back to treating it as a bare host.
+    const host = origin.trim().toLowerCase().replace(/^[a-z]+:\/\//, "")
+    return host.split("/")[0].split("?")[0].split(":")[0].replace(/^www\./, "") || null
+  }
+}
+
+/**
+ * True when `origin` is permitted by the vendor's `connect_domains` allow-list.
+ *
+ * `connect_domains` holds bare hostnames (possibly with a port) as produced by
+ * normalizeDomains(); we compare against the host with the port stripped so a
+ * vendor doesn't have to enumerate ports.
+ */
+export function originAllowed(
+  origin: string | undefined | null,
+  domains: unknown
+): boolean {
+  const host = originHostname(origin)
+  if (!host) return false
+  if (!Array.isArray(domains)) return false
+  for (const raw of domains) {
+    if (typeof raw !== "string") continue
+    const allowed = raw.trim().toLowerCase().split(":")[0].replace(/^www\./, "")
+    if (allowed && allowed === host) return true
+  }
+  return false
+}

--- a/backend/src/shared/matrix-service.ts
+++ b/backend/src/shared/matrix-service.ts
@@ -386,6 +386,30 @@ export class MatrixService {
   }
 
   /**
+   * Post a plain-text message into a room as the admin/bot user. Best-effort:
+   * returns false on failure rather than throwing, so callers (e.g. the embed
+   * chat bridge) can fall back to email.
+   */
+  async sendMessage(roomId: string, text: string): Promise<boolean> {
+    const txnId = `fbm-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    try {
+      await this.client.put(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(
+          roomId
+        )}/send/m.room.message/${encodeURIComponent(txnId)}`,
+        { msgtype: "m.text", body: text }
+      )
+      return true
+    } catch (error: any) {
+      log.error(
+        "[Matrix] sendMessage failed:",
+        error.response?.data || error.message
+      )
+      return false
+    }
+  }
+
+  /**
    * Alias for the community-wide room (`#general:server`).
    */
   generalRoomAlias(): string {

--- a/backend/src/shared/rate-limiter.ts
+++ b/backend/src/shared/rate-limiter.ts
@@ -270,6 +270,26 @@ export const publicCatalogRateLimiter = createRateLimiter({
   keyPrefix: "public-catalog",
 })
 
+/**
+ * Embed key rate limiter: 100 requests per minute per publishable key.
+ *
+ * Applied to key-authenticated embed endpoints (`/store/embed/*` and the
+ * optional keyed path of `/store/vendors/:handle`). Keyed by the resolved
+ * embed key id (set on the request by the embed-key middleware) so a single
+ * misbehaving site is throttled independently of others, falling back to IP
+ * when no key id is present.
+ */
+export const embedKeyRateLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 100,
+  keyPrefix: "embed-key",
+  keyGenerator: (req) => {
+    const keyId = (req as any).embed_key_id
+    if (keyId) return `key:${keyId}`
+    return req.ip || (req.headers["x-forwarded-for"] as string) || "unknown"
+  },
+})
+
 /** Auth rate limiter: 20 attempts per minute (login, register, etc.) */
 export const authRateLimiter = createRateLimiter({
   windowMs: 60_000,

--- a/backend/src/shared/timezone.ts
+++ b/backend/src/shared/timezone.ts
@@ -1,0 +1,92 @@
+/**
+ * Zero-dependency timezone helpers for booking slot generation.
+ *
+ * Vendor availability is expressed as wall-clock times in the vendor's IANA
+ * timezone (e.g. "09:00"–"17:00" in "America/New_York"). To compare those
+ * against absolute instants (now, existing bookings stored in UTC) we must
+ * convert a wall-clock time in a given zone to a UTC instant — handling the
+ * zone's current offset, including DST. We do this with `Intl.DateTimeFormat`
+ * (always available in Node) rather than pulling in a timezone library.
+ */
+
+/**
+ * Offset of `timeZone` from UTC at the instant `date`, in milliseconds
+ * (positive when the zone is ahead of UTC). Returns 0 for an invalid zone.
+ */
+export function tzOffsetMs(timeZone: string, date: Date): number {
+  try {
+    const dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+    const parts = dtf.formatToParts(date)
+    const m: Record<string, string> = {}
+    for (const p of parts) if (p.type !== "literal") m[p.type] = p.value
+    const asUTC = Date.UTC(
+      Number(m.year),
+      Number(m.month) - 1,
+      Number(m.day),
+      Number(m.hour),
+      Number(m.minute),
+      Number(m.second)
+    )
+    return asUTC - date.getTime()
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Convert a wall-clock time in `timeZone` to the corresponding UTC Date.
+ *
+ * Two-pass refinement handles DST boundaries: the first guess uses the offset
+ * at the naive UTC instant, then we re-evaluate the offset at the corrected
+ * instant in case the guess landed on the other side of a transition.
+ */
+export function zonedWallTimeToUtc(
+  year: number,
+  month: number, // 1-12
+  day: number,
+  hour: number,
+  minute: number,
+  timeZone: string
+): Date {
+  const guess = Date.UTC(year, month - 1, day, hour, minute, 0)
+  const offset1 = tzOffsetMs(timeZone, new Date(guess))
+  let utc = guess - offset1
+  const offset2 = tzOffsetMs(timeZone, new Date(utc))
+  if (offset2 !== offset1) {
+    utc = guess - offset2
+  }
+  return new Date(utc)
+}
+
+/** Day-of-week (0=Sun … 6=Sat) for a YYYY-MM-DD calendar date. */
+export function weekdayOf(year: number, month: number, day: number): number {
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay()
+}
+
+/** Parse "YYYY-MM-DD" into [year, month, day]; returns null when malformed. */
+export function parseDateOnly(
+  date: string
+): [number, number, number] | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(date || "").trim())
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
+}
+
+/** Parse "HH:MM" into [hour, minute]; returns null when malformed. */
+export function parseTimeOfDay(time: string): [number, number] | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(time || "").trim())
+  if (!m) return null
+  const h = Number(m[1])
+  const min = Number(m[2])
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null
+  return [h, min]
+}

--- a/backend/src/shared/website-config.ts
+++ b/backend/src/shared/website-config.ts
@@ -33,7 +33,7 @@ export function storefrontBase(): string {
 export function buildSnippet(handle: string): string {
   return [
     `<script src="${storefrontBase()}/connect.js"`,
-    `        data-fbm-handle="${handle}"`,
+    `        data-fbm-vendor="${handle}"`,
     `        data-fbm-api="${apiBase()}" async></script>`,
   ].join("\n");
 }

--- a/backend/src/subscribers/link-booking-on-order-placed.ts
+++ b/backend/src/subscribers/link-booking-on-order-placed.ts
@@ -1,0 +1,68 @@
+import { createLogger } from "../shared/logger"
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/medusa"
+import { BOOKING_MODULE } from "../modules/booking"
+import { BookingStatus } from "../modules/booking/models/booking"
+import type BookingService from "../modules/booking/service"
+import { notifyBookingConfirmed } from "../shared/booking-notify"
+
+const log = createLogger("subscribers/link-booking-on-order-placed")
+
+/**
+ * Best-effort: when an order carries a `booking_id` in its metadata (set by the
+ * embed checkout deep link), link the order to the booking, attach the customer,
+ * confirm it, and email the customer. No-ops for ordinary orders.
+ */
+export default async function linkBookingOnOrderPlaced({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  try {
+    const query = container.resolve("query")
+    const { data: [order] } = await query.graph({
+      entity: "order",
+      fields: ["id", "email", "customer_id", "metadata"],
+      filters: { id: data.id },
+    })
+    if (!order) return
+
+    const bookingId = (order.metadata as Record<string, unknown> | null)?.booking_id
+    if (!bookingId || typeof bookingId !== "string") return
+
+    const booking = container.resolve(BOOKING_MODULE) as BookingService
+    const rows = await booking.listBookings({ id: bookingId }, { take: 1 })
+    const row = rows?.[0]
+    if (!row || row.status === BookingStatus.CANCELLED) return
+
+    await booking.updateBookings({
+      id: row.id,
+      order_id: order.id,
+      customer_id: order.customer_id ?? row.customer_id ?? null,
+      status: BookingStatus.CONFIRMED,
+    })
+
+    let vendorName: string | null = null
+    try {
+      const { data: sellers } = await query.graph({
+        entity: "seller",
+        fields: ["name"],
+        filters: { id: row.seller_id } as any,
+      })
+      vendorName = sellers?.[0]?.name ?? null
+    } catch {
+      /* non-fatal */
+    }
+
+    await notifyBookingConfirmed(
+      container,
+      { ...row, status: BookingStatus.CONFIRMED },
+      vendorName
+    )
+  } catch (error) {
+    log.error(`[link-booking-on-order-placed] failed for ${data.id}:`, error)
+    // Never throw — must not break order processing.
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}

--- a/storefront/next.config.ts
+++ b/storefront/next.config.ts
@@ -79,6 +79,20 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      // FBM Connect SDK (connect.js): the single <script> any vendor drops on
+      // their own site. Open CORS + long, immutable-friendly caching so CDNs
+      // and browsers absorb the load; nosniff to lock the JS content type.
+      {
+        source: "/connect.js",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          {
+            key: "Cache-Control",
+            value: "public, max-age=600, s-maxage=3600, stale-while-revalidate=86400",
+          },
+        ],
+      },
     ]
   },
   async redirects() {

--- a/storefront/public/connect.js
+++ b/storefront/public/connect.js
@@ -369,12 +369,29 @@
   // ---------------------------------------------------------------------------
   var analyticsQueue = [];
   var flushTimer = null;
+  // Generate a random token using the Web Crypto API (CSPRNG). Falls back to a
+  // time-based id only if crypto is unavailable — never Math.random(), which is
+  // not cryptographically secure.
+  function randomToken() {
+    try {
+      var crypto = window.crypto || window.msCrypto;
+      var bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      var out = "";
+      for (var i = 0; i < bytes.length; i++) {
+        out += (bytes[i] + 0x100).toString(16).slice(1);
+      }
+      return out;
+    } catch (e) {
+      return Date.now().toString(36);
+    }
+  }
   var sessionId = (function () {
     try {
       var k = "fbm_sid";
       var v = window.sessionStorage.getItem(k);
       if (!v) {
-        v = "s_" + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        v = "s_" + randomToken();
         window.sessionStorage.setItem(k, v);
       }
       return v;

--- a/storefront/public/connect.js
+++ b/storefront/public/connect.js
@@ -3,28 +3,33 @@
  * https://freeblackmarket.com
  *
  * One <script> tag turns any site (Squarespace, Webflow, Wix, WordPress, raw
- * HTML, React — anything) into an FBM storefront. Three layers of integration,
- * pick the one that fits how much control you want:
+ * HTML, React — anything) into an FBM storefront. Pick your integration depth:
  *
  *   1. Zero JS — drop an element, it renders itself:
- *        <div data-fbm="products" data-fbm-limit="6"></div>
- *        <div data-fbm="events"></div>
- *        <div data-fbm="vendor"></div>
+ *        <div data-fbm="products"></div>     <div data-fbm="digital"></div>
+ *        <div data-fbm="services"></div>      <div data-fbm="events"></div>
+ *        <div data-fbm="reviews"></div>       <div data-fbm="vendor"></div>
+ *        <div data-fbm="booking" data-fbm-product="prod_123"></div>
+ *        <div data-fbm="chat"></div>
+ *        <button data-fbm-buy="prod_123">Buy</button>
  *
  *   2. Widgets — render styled UI into a container you choose:
  *        FBM.renderProducts('#shop', { limit: 6 })
- *        FBM.renderEvents('#events', { limit: 3 })
+ *        FBM.renderBooking('#book', { product: 'prod_123' })
  *
  *   3. Raw API — get enriched data, build your own UI:
  *        const products = await FBM.getProducts()
- *        // each item has _price ("$12.00"), _cartUrl, _meta pre-computed
+ *        const slots    = await FBM.getBookingSlots('prod_123', '2026-07-01')
  *
  * Configure via the script tag:
  *   <script src="https://freeblackmarket.com/connect.js"
- *           data-fbm-handle="your-handle"
+ *           data-fbm-vendor="your-handle"
+ *           data-fbm-key="pk_live_…"           (optional — unlocks booking/chat/analytics)
+ *           data-fbm-theme="light"             (light | dark | minimal)
  *           data-fbm-api="https://api.freeblackmarket.com" async></script>
  *
- * No keys, no build step, no dependencies. MIT-spirited, framework-agnostic.
+ * `data-fbm-handle` is still accepted as an alias for `data-fbm-vendor` so
+ * existing keyless embeds keep working unchanged. No build step, no deps.
  */
 (function (window, document) {
   "use strict";
@@ -39,7 +44,9 @@
   var currentScript =
     document.currentScript ||
     (function () {
-      var s = document.querySelectorAll("script[data-fbm-handle], script[src*='connect.js']");
+      var s = document.querySelectorAll(
+        "script[data-fbm-vendor], script[data-fbm-handle], script[src*='connect.js']"
+      );
       return s[s.length - 1] || null;
     })();
 
@@ -56,19 +63,35 @@
   }
 
   var config = {
-    handle: attr("handle", ""),
+    // `vendor` is the new canonical name; `handle` kept as an alias.
+    handle: attr("vendor", attr("handle", "")),
+    key: attr("key", ""),
     api: stripSlash(attr("api", "https://api.freeblackmarket.com")),
     storefront: stripSlash(attr("storefront", "")),
     region: attr("region", "us"),
     currency: attr("currency", "usd"),
     locale: attr("locale", "en-US"),
+    theme: attr("theme", "light"),
+    checkout: attr("checkout", "redirect"), // redirect | modal
   };
+  config.vendor = config.handle;
+
+  // ---------------------------------------------------------------------------
+  // Auth — send the publishable key when configured (keyless still works)
+  // ---------------------------------------------------------------------------
+  function authHeaders(extra) {
+    var h = { Accept: "application/json" };
+    if (extra) for (var k in extra) if (Object.prototype.hasOwnProperty.call(extra, k)) h[k] = extra[k];
+    if (config.key) h["Authorization"] = "PublishableKey " + config.key;
+    return h;
+  }
 
   // ---------------------------------------------------------------------------
   // Data fetching (one network call per handle+include set, then cached)
   // ---------------------------------------------------------------------------
   var cache = {};
   var lastMeta = null;
+  var lastData = null;
 
   function buildUrl(handle, opts) {
     var params = [];
@@ -82,14 +105,14 @@
   function getData(handle, opts) {
     handle = handle || config.handle;
     if (!handle) {
-      return Promise.reject(new Error("FBM: no vendor handle configured (set data-fbm-handle)."));
+      return Promise.reject(new Error("FBM: no vendor configured (set data-fbm-vendor)."));
     }
     var key = handle + "|" + ((opts && opts.include) || "all") + "|" + ((opts && opts.currency) || config.currency);
     if (cache[key]) return cache[key];
 
     var p = fetch(buildUrl(handle, opts), {
       method: "GET",
-      headers: { Accept: "application/json" },
+      headers: authHeaders(),
       credentials: "omit",
     })
       .then(function (res) {
@@ -98,6 +121,7 @@
       })
       .then(function (data) {
         lastMeta = data._meta || lastMeta;
+        lastData = data;
         return data;
       })
       .catch(function (err) {
@@ -171,6 +195,17 @@
     });
   }
 
+  function pickGroup(d, group) {
+    // Prefer the grouped view from the expanded catalog; fall back to the flat
+    // list filtered by `type` so older API responses still work.
+    if (d.product_groups && d.product_groups[group]) return d.product_groups[group];
+    var typeFor = { digital: "digital", services: "service", physical: "physical" };
+    var t = typeFor[group];
+    return (d.products || []).filter(function (p) {
+      return p.type === t;
+    });
+  }
+
   function getProducts(handle, opts) {
     var a = normalize(handle, opts);
     return getData(a.handle, {
@@ -185,6 +220,27 @@
     });
   }
 
+  function getGroup(group, handle, opts) {
+    var a = normalize(handle, opts);
+    return getData(a.handle, {
+      include: "vendor,products",
+      limitProducts: a.opts.limit,
+      currency: a.opts.currency,
+    }).then(function (d) {
+      var meta = d._meta;
+      return pickGroup(d, group).map(function (p) {
+        return enrichProduct(p, meta);
+      });
+    });
+  }
+
+  function getDigital(handle, opts) {
+    return getGroup("digital", handle, opts);
+  }
+  function getServices(handle, opts) {
+    return getGroup("services", handle, opts);
+  }
+
   function getEvents(handle, opts) {
     var a = normalize(handle, opts);
     return getData(a.handle, {
@@ -195,6 +251,74 @@
       var meta = d._meta;
       return (d.events || []).map(function (e) {
         return enrichEvent(e, meta);
+      });
+    });
+  }
+
+  function getReviews(handle, opts) {
+    var a = normalize(handle, opts);
+    var url =
+      config.api +
+      "/store/vendors/" +
+      encodeURIComponent(a.handle) +
+      "/reviews?limit=" +
+      (a.opts.limit || 20);
+    return fetch(url, { headers: authHeaders(), credentials: "omit" }).then(function (res) {
+      if (!res.ok) throw new Error("FBM: reviews request failed (" + res.status + ")");
+      return res.json();
+    });
+  }
+
+  function getBookingSlots(productId, date, handle) {
+    var h = handle || config.handle;
+    var url =
+      config.api +
+      "/store/vendors/" +
+      encodeURIComponent(h) +
+      "/availability?product_id=" +
+      encodeURIComponent(productId) +
+      "&date=" +
+      encodeURIComponent(date);
+    return fetch(url, { headers: authHeaders(), credentials: "omit" })
+      .then(function (res) {
+        if (!res.ok) throw new Error("FBM: availability request failed (" + res.status + ")");
+        return res.json();
+      })
+      .then(function (d) {
+        return d.slots || [];
+      });
+  }
+
+  function createBooking(payload) {
+    if (!config.key) {
+      return Promise.reject(new Error("FBM: a publishable key is required to book."));
+    }
+    return fetch(config.api + "/store/embed/bookings", {
+      method: "POST",
+      headers: authHeaders({ "Content-Type": "application/json" }),
+      credentials: "omit",
+      body: JSON.stringify(payload),
+    }).then(function (res) {
+      return res.json().then(function (body) {
+        if (!res.ok) throw new Error(body && body.message ? body.message : "Booking failed");
+        return body;
+      });
+    });
+  }
+
+  function startChat(payload) {
+    if (!config.key) {
+      return Promise.reject(new Error("FBM: a publishable key is required to chat."));
+    }
+    return fetch(config.api + "/store/embed/chat/start", {
+      method: "POST",
+      headers: authHeaders({ "Content-Type": "application/json" }),
+      credentials: "omit",
+      body: JSON.stringify(payload),
+    }).then(function (res) {
+      return res.json().then(function (body) {
+        if (!res.ok) throw new Error(body && body.message ? body.message : "Could not start chat");
+        return body;
       });
     });
   }
@@ -216,29 +340,140 @@
   }
 
   // ---------------------------------------------------------------------------
-  // Widgets — minimal, styled, overridable (.fbm-* classes)
+  // Event emitter — FBM.on('cart:open' | 'order:complete' | 'booking:confirmed', fn)
+  // ---------------------------------------------------------------------------
+  var listeners = {};
+  function on(name, fn) {
+    (listeners[name] = listeners[name] || []).push(fn);
+    return FBM;
+  }
+  function off(name, fn) {
+    if (!listeners[name]) return FBM;
+    listeners[name] = listeners[name].filter(function (f) {
+      return f !== fn;
+    });
+    return FBM;
+  }
+  function emit(name, detail) {
+    (listeners[name] || []).forEach(function (fn) {
+      try {
+        fn(detail);
+      } catch (e) {
+        if (window.console && console.warn) console.warn(e);
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Analytics — batched, flushed on a timer and on pagehide (keyed embeds only)
+  // ---------------------------------------------------------------------------
+  var analyticsQueue = [];
+  var flushTimer = null;
+  var sessionId = (function () {
+    try {
+      var k = "fbm_sid";
+      var v = window.sessionStorage.getItem(k);
+      if (!v) {
+        v = "s_" + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        window.sessionStorage.setItem(k, v);
+      }
+      return v;
+    } catch (e) {
+      return "s_" + Date.now().toString(36);
+    }
+  })();
+
+  function track(eventType, props) {
+    if (!config.key) return; // analytics ingestion is key-gated
+    analyticsQueue.push({
+      event_type: eventType,
+      product_id: (props && props.product_id) || undefined,
+      order_id: (props && props.order_id) || undefined,
+      session_id: sessionId,
+      metadata: props && props.metadata,
+    });
+    if (analyticsQueue.length >= 20) flushAnalytics();
+    else if (!flushTimer) {
+      flushTimer = window.setTimeout(flushAnalytics, 10000);
+    }
+  }
+
+  function flushAnalytics(useKeepalive) {
+    if (flushTimer) {
+      window.clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    if (!config.key || !analyticsQueue.length) return;
+    var batch = analyticsQueue.splice(0, analyticsQueue.length);
+    try {
+      // fetch+keepalive (NOT sendBeacon) because the endpoint needs the
+      // Authorization header, which sendBeacon cannot set.
+      fetch(config.api + "/store/embed/events", {
+        method: "POST",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        credentials: "omit",
+        keepalive: !!useKeepalive,
+        body: JSON.stringify({ events: batch }),
+      }).catch(function () {});
+    } catch (e) {
+      /* swallow — analytics must never break the host page */
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Styling — CSS custom properties + theme presets (overridable .fbm-*)
   // ---------------------------------------------------------------------------
   var STYLE_ID = "fbm-connect-styles";
+  var THEMES = {
+    light: { bg: "#fff", fg: "#111", muted: "#666", border: "#e5e5e5", accent: "#111", accentFg: "#fff" },
+    dark: { bg: "#161616", fg: "#f5f5f5", muted: "#a0a0a0", border: "#2c2c2c", accent: "#f5f5f5", accentFg: "#111" },
+    minimal: { bg: "transparent", fg: "#111", muted: "#888", border: "#ddd", accent: "#111", accentFg: "#fff" },
+  };
+
+  function themeVars(name) {
+    var t = THEMES[name] || THEMES.light;
+    return (
+      "--fbm-bg:" + t.bg + ";--fbm-fg:" + t.fg + ";--fbm-muted:" + t.muted +
+      ";--fbm-border:" + t.border + ";--fbm-accent:" + t.accent + ";--fbm-accent-fg:" + t.accentFg + ";"
+    );
+  }
+
   function injectStyles() {
     if (document.getElementById(STYLE_ID)) return;
     var css =
+      ":root{" + themeVars(config.theme) + "}" +
+      ".fbm-scope{color:var(--fbm-fg)}" +
       ".fbm-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:16px;margin:0;padding:0;list-style:none}" +
-      ".fbm-card{display:flex;flex-direction:column;border:1px solid #e5e5e5;border-radius:12px;overflow:hidden;background:#fff;text-decoration:none;color:inherit;transition:box-shadow .15s ease,transform .15s ease}" +
+      ".fbm-card{display:flex;flex-direction:column;border:1px solid var(--fbm-border);border-radius:12px;overflow:hidden;background:var(--fbm-bg);text-decoration:none;color:inherit;transition:box-shadow .15s ease,transform .15s ease}" +
       ".fbm-card:hover{box-shadow:0 6px 20px rgba(0,0,0,.08);transform:translateY(-2px)}" +
       ".fbm-card__img{aspect-ratio:1/1;width:100%;object-fit:cover;background:#f5f5f5;display:block}" +
       ".fbm-card__body{padding:12px 14px;display:flex;flex-direction:column;gap:4px}" +
       ".fbm-card__title{font-weight:600;font-size:14px;line-height:1.3;margin:0}" +
-      ".fbm-card__meta{font-size:13px;color:#666;margin:0}" +
+      ".fbm-card__meta{font-size:13px;color:var(--fbm-muted);margin:0}" +
       ".fbm-card__price{font-weight:600;font-size:14px;margin:2px 0 0}" +
-      ".fbm-cta{margin-top:auto;display:inline-block;padding:8px 12px;border-radius:8px;background:#111;color:#fff;font-size:13px;font-weight:600;text-align:center;text-decoration:none}" +
+      ".fbm-cta,.fbm-btn{margin-top:auto;display:inline-block;padding:8px 12px;border-radius:8px;background:var(--fbm-accent);color:var(--fbm-accent-fg);font-size:13px;font-weight:600;text-align:center;text-decoration:none;border:0;cursor:pointer}" +
+      ".fbm-btn[disabled]{opacity:.5;cursor:default}" +
       ".fbm-vendor{display:flex;align-items:center;gap:14px;padding:8px 0}" +
       ".fbm-vendor__avatar{width:56px;height:56px;border-radius:50%;object-fit:cover;background:#f0f0f0}" +
       ".fbm-vendor__name{font-weight:700;font-size:18px;margin:0;display:flex;align-items:center;gap:6px}" +
       ".fbm-vendor__verified{color:#1d9bf0;font-size:14px}" +
-      ".fbm-vendor__desc{color:#555;font-size:14px;margin:2px 0 0}" +
-      ".fbm-empty{color:#888;font-size:14px;padding:8px 0}" +
-      ".fbm-powered{font-size:11px;color:#aaa;margin-top:10px}" +
-      ".fbm-powered a{color:#888;text-decoration:none}";
+      ".fbm-vendor__desc{color:var(--fbm-muted);font-size:14px;margin:2px 0 0}" +
+      ".fbm-empty{color:var(--fbm-muted);font-size:14px;padding:8px 0}" +
+      ".fbm-stars{color:#f5a623;font-size:15px;letter-spacing:1px}" +
+      ".fbm-review{border:1px solid var(--fbm-border);border-radius:10px;padding:12px 14px;margin:0 0 10px;background:var(--fbm-bg)}" +
+      ".fbm-review__head{display:flex;justify-content:space-between;align-items:center;font-size:13px;color:var(--fbm-muted)}" +
+      ".fbm-review__body{font-size:14px;margin:6px 0 0}" +
+      ".fbm-field{display:flex;flex-direction:column;gap:4px;margin:0 0 10px;font-size:13px}" +
+      ".fbm-field input,.fbm-field textarea,.fbm-field select{padding:8px 10px;border:1px solid var(--fbm-border);border-radius:8px;font:inherit;background:var(--fbm-bg);color:var(--fbm-fg)}" +
+      ".fbm-slots{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0}" +
+      ".fbm-slot{padding:6px 10px;border:1px solid var(--fbm-border);border-radius:8px;background:var(--fbm-bg);color:var(--fbm-fg);cursor:pointer;font-size:13px}" +
+      ".fbm-slot.is-selected{background:var(--fbm-accent);color:var(--fbm-accent-fg)}" +
+      ".fbm-modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:2147483000}" +
+      ".fbm-modal__panel{background:var(--fbm-bg);color:var(--fbm-fg);width:min(560px,94vw);height:min(680px,92vh);border-radius:14px;overflow:hidden;position:relative;box-shadow:0 20px 60px rgba(0,0,0,.4)}" +
+      ".fbm-modal__close{position:absolute;top:8px;right:10px;background:rgba(0,0,0,.4);color:#fff;border:0;border-radius:50%;width:30px;height:30px;font-size:18px;cursor:pointer;z-index:2}" +
+      ".fbm-modal__panel iframe{width:100%;height:100%;border:0}" +
+      ".fbm-powered{font-size:11px;color:var(--fbm-muted);margin-top:10px}" +
+      ".fbm-powered a{color:var(--fbm-muted);text-decoration:none}";
     var style = document.createElement("style");
     style.id = STYLE_ID;
     style.textContent = css;
@@ -262,22 +497,65 @@
   }
 
   function poweredBy() {
-    return (
-      '<p class="fbm-powered">Powered by <a href="https://freeblackmarket.com" target="_blank" rel="noopener">Free Black Market</a></p>'
-    );
+    return '<p class="fbm-powered">Powered by <a href="https://freeblackmarket.com" target="_blank" rel="noopener">Free Black Market</a></p>';
   }
 
+  function scope(html) {
+    return '<div class="fbm-scope">' + html + "</div>";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cart / checkout
+  // ---------------------------------------------------------------------------
+  function openCart(target) {
+    var url = cartUrl(target);
+    emit("cart:open", { url: url, target: target });
+    track("checkout_start", { product_id: target && target.id });
+    if (config.checkout === "modal") {
+      openModal(url);
+    } else {
+      window.open(url, "_blank", "noopener");
+    }
+    return url;
+  }
+
+  function openModal(url) {
+    injectStyles();
+    var overlay = document.createElement("div");
+    overlay.className = "fbm-modal";
+    overlay.innerHTML =
+      '<div class="fbm-modal__panel"><button class="fbm-modal__close" aria-label="Close">×</button>' +
+      '<iframe src="' + escapeHtml(url) + '" allow="payment"></iframe></div>';
+    function close() {
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      document.removeEventListener("keydown", onKey);
+    }
+    function onKey(e) {
+      if (e.key === "Escape") close();
+    }
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) close();
+    });
+    overlay.querySelector(".fbm-modal__close").addEventListener("click", close);
+    document.addEventListener("keydown", onKey);
+    document.body.appendChild(overlay);
+    return close;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Card renderers
+  // ---------------------------------------------------------------------------
   function productCard(p) {
     var img = p.thumbnail
       ? '<img class="fbm-card__img" src="' + escapeHtml(p.thumbnail) + '" alt="' + escapeHtml(p.title) + '" loading="lazy">'
       : '<div class="fbm-card__img"></div>';
     return (
-      '<a class="fbm-card" href="' + escapeHtml(p._cartUrl) + '" target="_blank" rel="noopener">' +
+      '<a class="fbm-card" href="' + escapeHtml(p._cartUrl) + '" target="_blank" rel="noopener" data-fbm-pid="' + escapeHtml(p.id) + '">' +
       img +
       '<div class="fbm-card__body">' +
       '<p class="fbm-card__title">' + escapeHtml(p.title) + "</p>" +
       (p._price ? '<p class="fbm-card__price">' + escapeHtml(p._price) + "</p>" : "") +
-      '<span class="fbm-cta">Shop now</span>' +
+      '<span class="fbm-cta">' + (p.type === "digital" ? "Get it" : "Shop now") + "</span>" +
       "</div></a>"
     );
   }
@@ -302,6 +580,16 @@
     );
   }
 
+  function stars(rating) {
+    var r = Math.round(Number(rating) || 0);
+    var full = "★★★★★".slice(0, r);
+    var empty = "☆☆☆☆☆".slice(0, 5 - r);
+    return '<span class="fbm-stars">' + full + empty + "</span>";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Grid widgets
+  // ---------------------------------------------------------------------------
   function renderInto(node, fetcher, cardFn, emptyMsg) {
     injectStyles();
     node.innerHTML = '<p class="fbm-empty">Loading…</p>';
@@ -311,8 +599,10 @@
           setEmpty(node, emptyMsg);
           return;
         }
-        node.innerHTML =
-          '<div class="fbm-grid">' + items.map(cardFn).join("") + "</div>" + poweredBy();
+        node.innerHTML = scope(
+          '<div class="fbm-grid">' + items.map(cardFn).join("") + "</div>" + poweredBy()
+        );
+        track("view", { metadata: { kind: "grid", count: items.length } });
       })
       .catch(function (err) {
         setEmpty(node, "Unable to load right now.");
@@ -326,7 +616,18 @@
     opts = opts || {};
     return renderInto(node, getProducts(opts.handle, opts), productCard, "No products yet.");
   }
-
+  function renderDigital(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    opts = opts || {};
+    return renderInto(node, getDigital(opts.handle, opts), productCard, "No digital products yet.");
+  }
+  function renderServices(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    opts = opts || {};
+    return renderInto(node, getServices(opts.handle, opts), productCard, "No services yet.");
+  }
   function renderEvents(target, opts) {
     var node = resolveEl(target);
     if (!node) return Promise.resolve();
@@ -349,18 +650,269 @@
           ? '<img class="fbm-vendor__avatar" src="' + escapeHtml(v.photo) + '" alt="' + escapeHtml(v.name) + '">'
           : '<div class="fbm-vendor__avatar"></div>';
         var verified = v.verified ? '<span class="fbm-vendor__verified" title="Verified">✔</span>' : "";
-        node.innerHTML =
+        node.innerHTML = scope(
           '<div class="fbm-vendor">' +
-          avatar +
-          "<div>" +
-          '<p class="fbm-vendor__name">' + escapeHtml(v.name) + verified + "</p>" +
-          (v.description ? '<p class="fbm-vendor__desc">' + escapeHtml(v.description) + "</p>" : "") +
-          "</div></div>";
+            avatar +
+            "<div>" +
+            '<p class="fbm-vendor__name">' + escapeHtml(v.name) + verified + "</p>" +
+            (v.description ? '<p class="fbm-vendor__desc">' + escapeHtml(v.description) + "</p>" : "") +
+            "</div></div>"
+        );
       })
       .catch(function (err) {
         setEmpty(node, "Unable to load vendor.");
         if (window.console && console.warn) console.warn(err);
       });
+  }
+
+  function renderReviews(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    injectStyles();
+    opts = opts || {};
+    node.innerHTML = '<p class="fbm-empty">Loading…</p>';
+    return getReviews(opts.handle, opts)
+      .then(function (data) {
+        var reviews = (data && data.reviews) || [];
+        var summary = (data && data.summary) || {};
+        if (!reviews.length) {
+          setEmpty(node, "No reviews yet.");
+          return;
+        }
+        var head =
+          summary.average != null
+            ? '<p class="fbm-card__meta">' + stars(summary.average) + " " +
+              escapeHtml(summary.average) + " · " + escapeHtml(summary.count) + " reviews</p>"
+            : "";
+        var list = reviews
+          .map(function (r) {
+            return (
+              '<div class="fbm-review"><div class="fbm-review__head"><span>' +
+              stars(r.rating) +
+              " " +
+              escapeHtml(r.author || "Verified buyer") +
+              "</span>" +
+              (r.verified ? "<span>✔ Verified</span>" : "") +
+              "</div>" +
+              (r.title ? '<p class="fbm-card__title">' + escapeHtml(r.title) + "</p>" : "") +
+              (r.body ? '<p class="fbm-review__body">' + escapeHtml(r.body) + "</p>" : "") +
+              "</div>"
+            );
+          })
+          .join("");
+        node.innerHTML = scope(head + list + poweredBy());
+      })
+      .catch(function (err) {
+        setEmpty(node, "Unable to load reviews.");
+        if (window.console && console.warn) console.warn(err);
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Booking widget — month-free simple date input + slot picker + form
+  // ---------------------------------------------------------------------------
+  function todayInTz() {
+    try {
+      return new Date().toISOString().slice(0, 10);
+    } catch (e) {
+      return "";
+    }
+  }
+
+  function renderBooking(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    injectStyles();
+    opts = opts || {};
+    var productId = opts.product || opts.productId;
+    var handle = opts.handle || config.handle;
+    if (!productId) {
+      setEmpty(node, "Booking needs a product (data-fbm-product).");
+      return Promise.resolve();
+    }
+    track("booking_open", { product_id: productId });
+
+    var selected = null;
+    var date = todayInTz();
+
+    function shell(inner) {
+      node.innerHTML = scope(
+        '<div class="fbm-field"><label>Choose a date</label>' +
+          '<input type="date" class="fbm-date" value="' + escapeHtml(date) + '" min="' + escapeHtml(todayInTz()) + '"></label></div>' +
+          '<div class="fbm-slots-wrap">' + inner + "</div>" +
+          '<form class="fbm-book-form" style="display:none">' +
+          '<div class="fbm-field"><label>Your name</label><input type="text" name="name" required></div>' +
+          '<div class="fbm-field"><label>Email</label><input type="email" name="email" required></div>' +
+          '<div class="fbm-field"><label>Notes (optional)</label><textarea name="notes" rows="2"></textarea></div>' +
+          '<button type="submit" class="fbm-btn">Request booking</button>' +
+          "</form>" +
+          poweredBy()
+      );
+      wire();
+    }
+
+    function loadSlots() {
+      var wrap = node.querySelector(".fbm-slots-wrap");
+      if (wrap) wrap.innerHTML = '<p class="fbm-empty">Loading times…</p>';
+      return getBookingSlots(productId, date, handle)
+        .then(function (slots) {
+          if (!slots.length) {
+            if (wrap) wrap.innerHTML = '<p class="fbm-empty">No times available on this date.</p>';
+            return;
+          }
+          var html =
+            '<div class="fbm-slots">' +
+            slots
+              .map(function (s) {
+                var label = new Date(s.starts_at).toLocaleTimeString(config.locale, {
+                  hour: "numeric",
+                  minute: "2-digit",
+                });
+                return '<button type="button" class="fbm-slot" data-start="' + escapeHtml(s.starts_at) + '">' + escapeHtml(label) + "</button>";
+              })
+              .join("") +
+            "</div>";
+          if (wrap) wrap.innerHTML = html;
+          wireSlots();
+        })
+        .catch(function () {
+          if (wrap) wrap.innerHTML = '<p class="fbm-empty">Unable to load times.</p>';
+        });
+    }
+
+    function wireSlots() {
+      var btns = node.querySelectorAll(".fbm-slot");
+      Array.prototype.forEach.call(btns, function (b) {
+        b.addEventListener("click", function () {
+          selected = b.getAttribute("data-start");
+          Array.prototype.forEach.call(btns, function (x) {
+            x.classList.remove("is-selected");
+          });
+          b.classList.add("is-selected");
+          var form = node.querySelector(".fbm-book-form");
+          if (form) form.style.display = "block";
+        });
+      });
+    }
+
+    function wire() {
+      var dateEl = node.querySelector(".fbm-date");
+      if (dateEl) {
+        dateEl.addEventListener("change", function () {
+          date = dateEl.value;
+          selected = null;
+          var form = node.querySelector(".fbm-book-form");
+          if (form) form.style.display = "none";
+          loadSlots();
+        });
+      }
+      var form = node.querySelector(".fbm-book-form");
+      if (form) {
+        form.addEventListener("submit", function (e) {
+          e.preventDefault();
+          if (!selected) return;
+          var btn = form.querySelector("button[type=submit]");
+          if (btn) {
+            btn.setAttribute("disabled", "1");
+            btn.textContent = "Booking…";
+          }
+          createBooking({
+            product_id: productId,
+            starts_at: selected,
+            customer_email: form.email.value,
+            customer_name: form.name.value,
+            notes: form.notes.value,
+          })
+            .then(function (res) {
+              emit("booking:confirmed", res);
+              track("booking_confirm", { product_id: productId });
+              if (res.checkout_url && config.checkout !== "none") {
+                node.innerHTML = scope('<p class="fbm-empty">Booking created — taking you to checkout…</p>');
+                window.open(res.checkout_url, "_blank", "noopener");
+              } else {
+                node.innerHTML = scope('<p class="fbm-empty">✓ Booking requested! The vendor will confirm by email.</p>');
+              }
+            })
+            .catch(function (err) {
+              if (btn) {
+                btn.removeAttribute("disabled");
+                btn.textContent = "Request booking";
+              }
+              alert((err && err.message) || "Booking failed. Please try another time.");
+            });
+        });
+      }
+    }
+
+    shell('<p class="fbm-empty">Loading times…</p>');
+    return loadSlots();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Chat widget — button → form → Matrix widget (or email fallback)
+  // ---------------------------------------------------------------------------
+  function renderChat(target, opts) {
+    var node = resolveEl(target);
+    if (!node) return Promise.resolve();
+    injectStyles();
+    opts = opts || {};
+    var label = opts.label || "Message the vendor";
+
+    node.innerHTML = scope('<button type="button" class="fbm-btn fbm-chat-open">' + escapeHtml(label) + "</button>");
+    node.querySelector(".fbm-chat-open").addEventListener("click", function () {
+      track("chat_open", {});
+      node.innerHTML = scope(
+        '<form class="fbm-chat-form">' +
+          '<div class="fbm-field"><label>Email</label><input type="email" name="email" required></div>' +
+          '<div class="fbm-field"><label>Message</label><textarea name="message" rows="3" required></textarea></div>' +
+          '<button type="submit" class="fbm-btn">Send</button>' +
+          "</form>"
+      );
+      var form = node.querySelector(".fbm-chat-form");
+      form.addEventListener("submit", function (e) {
+        e.preventDefault();
+        var btn = form.querySelector("button[type=submit]");
+        if (btn) {
+          btn.setAttribute("disabled", "1");
+          btn.textContent = "Sending…";
+        }
+        startChat({
+          customer_email: form.email.value,
+          message: form.message.value,
+        })
+          .then(function (res) {
+            if (res.widget_url) {
+              node.innerHTML = scope('<p class="fbm-empty">Connecting you to the vendor…</p>');
+              openModal(res.widget_url);
+            } else {
+              node.innerHTML = scope('<p class="fbm-empty">✓ Sent! The vendor will reply to your email.</p>');
+            }
+          })
+          .catch(function (err) {
+            if (btn) {
+              btn.removeAttribute("disabled");
+              btn.textContent = "Send";
+            }
+            alert((err && err.message) || "Couldn't send your message.");
+          });
+      });
+    });
+    return Promise.resolve();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Buy buttons — [data-fbm-buy="prod_or_handle"]
+  // ---------------------------------------------------------------------------
+  function wireBuyButtons(root) {
+    var nodes = (root || document).querySelectorAll("[data-fbm-buy]");
+    Array.prototype.forEach.call(nodes, function (node) {
+      if (node.getAttribute("data-fbm-buy-wired")) return;
+      node.setAttribute("data-fbm-buy-wired", "1");
+      node.addEventListener("click", function (e) {
+        e.preventDefault();
+        openCart(node.getAttribute("data-fbm-buy"));
+      });
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -374,14 +926,22 @@
       node.setAttribute("data-fbm-mounted", "1");
       var kind = node.getAttribute("data-fbm");
       var opts = {
-        handle: node.getAttribute("data-fbm-handle") || config.handle,
+        handle: node.getAttribute("data-fbm-vendor") || node.getAttribute("data-fbm-handle") || config.handle,
         limit: parseInt(node.getAttribute("data-fbm-limit") || "", 10) || undefined,
         currency: node.getAttribute("data-fbm-currency") || undefined,
+        product: node.getAttribute("data-fbm-product") || undefined,
+        label: node.getAttribute("data-fbm-label") || undefined,
       };
       if (kind === "products") renderProducts(node, opts);
+      else if (kind === "digital") renderDigital(node, opts);
+      else if (kind === "services") renderServices(node, opts);
       else if (kind === "events") renderEvents(node, opts);
+      else if (kind === "reviews") renderReviews(node, opts);
       else if (kind === "vendor") renderVendor(node, opts);
+      else if (kind === "booking") renderBooking(node, opts);
+      else if (kind === "chat") renderChat(node, opts);
     });
+    wireBuyButtons(root);
   }
 
   function ready(fn) {
@@ -397,26 +957,57 @@
   // ---------------------------------------------------------------------------
   var FBM = {
     __loaded: true,
-    version: "1.0.0",
+    version: "2.0.0",
     config: config,
     configure: function (o) {
       for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) config[k] = o[k];
+      if (o && (o.vendor || o.handle)) config.handle = config.vendor = o.vendor || o.handle;
       cache = {}; // config change invalidates cache
       return FBM;
     },
+    // raw data
     getData: getData,
     getVendor: getVendor,
     getProducts: getProducts,
+    getDigital: getDigital,
+    getServices: getServices,
     getEvents: getEvents,
+    getReviews: getReviews,
+    getBookingSlots: getBookingSlots,
+    createBooking: createBooking,
+    startChat: startChat,
+    // cart / checkout
     cartUrl: cartUrl,
+    openCart: openCart,
+    openModal: openModal,
     formatPrice: formatPrice,
+    // widgets
     renderProducts: renderProducts,
+    renderDigital: renderDigital,
+    renderServices: renderServices,
     renderEvents: renderEvents,
+    renderReviews: renderReviews,
     renderVendor: renderVendor,
+    renderBooking: renderBooking,
+    renderChat: renderChat,
+    openBooking: renderBooking,
+    openChat: renderChat,
     mount: autoMount,
+    // events + analytics
+    on: on,
+    off: off,
+    track: track,
   };
 
   window.FBM = FBM;
+
+  // Flush any queued analytics when the page is hidden/unloaded.
+  window.addEventListener("pagehide", function () {
+    flushAnalytics(true);
+  });
+  document.addEventListener("visibilitychange", function () {
+    if (document.visibilityState === "hidden") flushAnalytics(true);
+  });
 
   ready(function () {
     injectStyles();

--- a/vendor-panel/src/hooks/api/booking.tsx
+++ b/vendor-panel/src/hooks/api/booking.tsx
@@ -1,0 +1,117 @@
+import {
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { FetchError } from "@medusajs/js-sdk"
+import { fetchQuery } from "../../lib/client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const AVAILABILITY_QUERY_KEY = "vendor_availability" as const
+export const availabilityQueryKeys = queryKeysFactory(AVAILABILITY_QUERY_KEY)
+const BOOKINGS_QUERY_KEY = "vendor_bookings" as const
+export const bookingsQueryKeys = queryKeysFactory(BOOKINGS_QUERY_KEY)
+
+export type AvailabilityWindow = {
+  id?: string
+  day_of_week: number
+  start_time: string
+  end_time: string
+  is_active?: boolean
+}
+
+export type Booking = {
+  id: string
+  product_id: string
+  customer_email: string
+  customer_name: string | null
+  starts_at: string
+  ends_at: string
+  status: string
+  notes: string | null
+}
+
+/** GET /vendor/availability */
+export const useAvailability = (
+  options?: Omit<
+    UseQueryOptions<{ availability: AvailabilityWindow[] }, FetchError>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () => fetchQuery("/vendor/availability", { method: "GET" }),
+    queryKey: availabilityQueryKeys.list(),
+    ...options,
+  })
+  return { availability: (data?.availability ?? []) as AvailabilityWindow[], ...rest }
+}
+
+/** POST /vendor/availability — full overwrite of the weekly grid. */
+export const useSaveAvailability = (
+  options?: UseMutationOptions<
+    { availability: AvailabilityWindow[] },
+    FetchError,
+    AvailabilityWindow[]
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (windows: AvailabilityWindow[]) =>
+      fetchQuery("/vendor/availability", { method: "POST", body: { windows } }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.list() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+/** GET /vendor/bookings */
+export const useBookings = (
+  status?: string,
+  options?: Omit<
+    UseQueryOptions<{ bookings: Booking[]; count: number }, FetchError>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      fetchQuery(
+        `/vendor/bookings${status ? `?status=${encodeURIComponent(status)}` : ""}`,
+        { method: "GET" }
+      ),
+    queryKey: bookingsQueryKeys.list({ status }),
+    ...options,
+  })
+  return {
+    bookings: (data?.bookings ?? []) as Booking[],
+    count: data?.count ?? 0,
+    ...rest,
+  }
+}
+
+/** PATCH /vendor/bookings/:id/status */
+export const useUpdateBookingStatus = (
+  options?: UseMutationOptions<
+    { booking: Booking },
+    FetchError,
+    { id: string; status: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, status }: { id: string; status: string }) =>
+      fetchQuery(`/vendor/bookings/${id}/status`, {
+        method: "PATCH",
+        body: { status },
+      }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}

--- a/vendor-panel/src/hooks/api/embed-analytics.tsx
+++ b/vendor-panel/src/hooks/api/embed-analytics.tsx
@@ -1,0 +1,39 @@
+import { UseQueryOptions, useQuery } from "@tanstack/react-query"
+
+import { FetchError } from "@medusajs/js-sdk"
+import { fetchQuery } from "../../lib/client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const EMBED_ANALYTICS_QUERY_KEY = "embed_analytics" as const
+export const embedAnalyticsQueryKeys = queryKeysFactory(EMBED_ANALYTICS_QUERY_KEY)
+
+export type EmbedAnalytics = {
+  range_days: number
+  totals: Record<string, number>
+  funnel: {
+    views: number
+    add_to_cart: number
+    checkout_start: number
+    orders: number
+  }
+  by_origin: { origin: string; count: number }[]
+  by_day: { date: string; views: number; orders: number }[]
+  top_products: { product_id: string; views: number }[]
+}
+
+/** GET /vendor/analytics/embed?range= */
+export const useEmbedAnalytics = (
+  range = 30,
+  options?: Omit<
+    UseQueryOptions<{ analytics: EmbedAnalytics }, FetchError>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      fetchQuery(`/vendor/analytics/embed?range=${range}`, { method: "GET" }),
+    queryKey: embedAnalyticsQueryKeys.list({ range }),
+    ...options,
+  })
+  return { analytics: data?.analytics as EmbedAnalytics | undefined, ...rest }
+}

--- a/vendor-panel/src/hooks/api/embed-keys.tsx
+++ b/vendor-panel/src/hooks/api/embed-keys.tsx
@@ -1,0 +1,83 @@
+import {
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { FetchError } from "@medusajs/js-sdk"
+import { fetchQuery } from "../../lib/client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const EMBED_KEYS_QUERY_KEY = "embed_keys" as const
+export const embedKeysQueryKeys = queryKeysFactory(EMBED_KEYS_QUERY_KEY)
+
+export type EmbedKey = {
+  id: string
+  label: string | null
+  masked: string
+  last_used_at: string | null
+  revoked_at: string | null
+  created_at: string
+  active: boolean
+}
+
+export type EmbedKeysResponse = { keys: EmbedKey[] }
+
+export type CreateEmbedKeyResponse = {
+  // Plaintext — surfaced exactly once at creation time.
+  key: string
+  embed_key: Omit<EmbedKey, "last_used_at" | "revoked_at">
+}
+
+/** GET /vendor/embed-keys — this vendor's publishable keys (masked). */
+export const useEmbedKeys = (
+  options?: Omit<
+    UseQueryOptions<EmbedKeysResponse, FetchError>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () => fetchQuery("/vendor/embed-keys", { method: "GET" }),
+    queryKey: embedKeysQueryKeys.list(),
+    ...options,
+  })
+  return { keys: (data?.keys ?? []) as EmbedKey[], ...rest }
+}
+
+/** POST /vendor/embed-keys — create a key; returns plaintext once. */
+export const useCreateEmbedKey = (
+  options?: UseMutationOptions<
+    CreateEmbedKeyResponse,
+    FetchError,
+    { label?: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: { label?: string }) =>
+      fetchQuery("/vendor/embed-keys", { method: "POST", body }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: embedKeysQueryKeys.list() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+/** DELETE /vendor/embed-keys/:id — revoke a key. */
+export const useRevokeEmbedKey = (
+  options?: UseMutationOptions<{ id: string; revoked: boolean }, FetchError, string>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchQuery(`/vendor/embed-keys/${id}`, { method: "DELETE" }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: embedKeysQueryKeys.list() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}

--- a/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
+++ b/vendor-panel/src/hooks/navigation/use-vendor-navigation.tsx
@@ -104,6 +104,18 @@ function getVendorNavigationConfig({
       // Always visible — embed FBM on your own site, or launch a hosted one.
     },
     {
+      icon: <CalendarMini />,
+      label: "Bookings",
+      to: "/bookings",
+      // Availability + appointment requests from the embedded booking widget.
+    },
+    {
+      icon: <ChartBar />,
+      label: "Embed Analytics",
+      to: "/embed-analytics",
+      // Funnel + traffic for the connect.js embed across vendor sites.
+    },
+    {
       icon: <Star />,
       label: "Creator Studio",
       to: "/creator-studio",

--- a/vendor-panel/src/providers/router-provider/route-map.tsx
+++ b/vendor-panel/src/providers/router-provider/route-map.tsx
@@ -86,6 +86,22 @@ export const RouteMap: RouteObject[] = [
             lazy: () => import("../../routes/my-website"),
           },
           {
+            path: "bookings",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Bookings",
+            },
+            lazy: () => import("../../routes/bookings"),
+          },
+          {
+            path: "embed-analytics",
+            errorElement: <ErrorBoundary />,
+            handle: {
+              breadcrumb: () => "Embed Analytics",
+            },
+            lazy: () => import("../../routes/embed-analytics"),
+          },
+          {
             path: "programs",
             errorElement: <ErrorBoundary />,
             handle: {

--- a/vendor-panel/src/routes/bookings/bookings.tsx
+++ b/vendor-panel/src/routes/bookings/bookings.tsx
@@ -1,0 +1,194 @@
+import { Badge, Button, Container, Heading, Input, Switch, Text, toast } from "@medusajs/ui"
+import { useEffect, useState } from "react"
+import {
+  AvailabilityWindow,
+  useAvailability,
+  useBookings,
+  useSaveAvailability,
+  useUpdateBookingStatus,
+} from "../../hooks/api/booking"
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+type DayRow = { active: boolean; start: string; end: string }
+
+const STATUS_COLORS: Record<string, "green" | "orange" | "red" | "grey"> = {
+  confirmed: "green",
+  pending: "orange",
+  cancelled: "red",
+  completed: "green",
+  no_show: "grey",
+}
+
+/** Weekly availability editor — one window per day (covers the common case). */
+const AvailabilityEditor = () => {
+  const { availability, isPending } = useAvailability()
+  const { mutate: save, isPending: saving } = useSaveAvailability()
+
+  const [rows, setRows] = useState<DayRow[]>(
+    DAYS.map(() => ({ active: false, start: "09:00", end: "17:00" }))
+  )
+
+  useEffect(() => {
+    if (!availability.length) return
+    const next: DayRow[] = DAYS.map(() => ({
+      active: false,
+      start: "09:00",
+      end: "17:00",
+    }))
+    for (const w of availability) {
+      if (w.day_of_week >= 0 && w.day_of_week < 7) {
+        next[w.day_of_week] = {
+          active: w.is_active !== false,
+          start: w.start_time,
+          end: w.end_time,
+        }
+      }
+    }
+    setRows(next)
+  }, [availability])
+
+  const update = (i: number, patch: Partial<DayRow>) => {
+    setRows((cur) => cur.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+  }
+
+  const onSave = () => {
+    const windows: AvailabilityWindow[] = rows
+      .map((r, i) => ({ ...r, i }))
+      .filter((r) => r.active)
+      .map((r) => ({
+        day_of_week: r.i,
+        start_time: r.start,
+        end_time: r.end,
+        is_active: true,
+      }))
+    save(windows, {
+      onSuccess: () => toast.success("Availability saved"),
+      onError: () => toast.error("Could not save availability"),
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      {DAYS.map((day, i) => (
+        <div key={day} className="flex items-center gap-3">
+          <div className="flex w-32 items-center gap-2">
+            <Switch
+              checked={rows[i].active}
+              onCheckedChange={(v) => update(i, { active: !!v })}
+            />
+            <Text size="small">{day}</Text>
+          </div>
+          <Input
+            type="time"
+            value={rows[i].start}
+            disabled={!rows[i].active}
+            onChange={(e) => update(i, { start: e.target.value })}
+            className="w-32"
+          />
+          <Text size="small" className="text-ui-fg-muted">
+            to
+          </Text>
+          <Input
+            type="time"
+            value={rows[i].end}
+            disabled={!rows[i].active}
+            onChange={(e) => update(i, { end: e.target.value })}
+            className="w-32"
+          />
+        </div>
+      ))}
+      <div>
+        <Button size="small" onClick={onSave} isLoading={saving || isPending} type="button">
+          Save availability
+        </Button>
+      </div>
+      <Text size="xsmall" className="text-ui-fg-muted">
+        Times are in your booking timezone (set per-product). Customers see slots
+        converted to their own local time.
+      </Text>
+    </div>
+  )
+}
+
+/** Upcoming bookings with confirm / cancel actions. */
+const BookingsList = () => {
+  const { bookings, isPending } = useBookings()
+  const { mutate: setStatus } = useUpdateBookingStatus()
+
+  const act = (id: string, status: string) => {
+    setStatus(
+      { id, status },
+      {
+        onSuccess: () => toast.success(`Booking ${status}`),
+        onError: () => toast.error("Could not update booking"),
+      }
+    )
+  }
+
+  if (isPending) {
+    return <Text size="small" className="text-ui-fg-muted">Loading…</Text>
+  }
+  if (!bookings.length) {
+    return <Text size="small" className="text-ui-fg-muted">No bookings yet.</Text>
+  }
+
+  return (
+    <div className="border-ui-border-base divide-ui-border-base divide-y rounded-lg border">
+      {bookings.map((b) => (
+        <div key={b.id} className="flex items-center justify-between gap-3 p-3">
+          <div className="flex flex-col gap-0.5">
+            <Text size="small" className="font-medium">
+              {new Date(b.starts_at).toLocaleString()}
+            </Text>
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {b.customer_name ? `${b.customer_name} · ` : ""}
+              {b.customer_email}
+            </Text>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge size="2xsmall" color={STATUS_COLORS[b.status] || "grey"}>
+              {b.status}
+            </Badge>
+            {b.status === "pending" && (
+              <>
+                <Button size="small" variant="secondary" onClick={() => act(b.id, "confirmed")} type="button">
+                  Confirm
+                </Button>
+                <Button size="small" variant="transparent" onClick={() => act(b.id, "cancelled")} type="button">
+                  Decline
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export const Bookings = () => {
+  return (
+    <Container className="p-0">
+      <div className="px-6 py-4">
+        <Heading>Bookings</Heading>
+        <Text className="text-ui-fg-subtle mt-1" size="small">
+          Set your weekly availability and manage appointment requests from your
+          embedded booking widget.
+        </Text>
+      </div>
+      <div className="flex flex-col gap-y-8 px-6 pb-6">
+        <div>
+          <Heading level="h2" className="mb-3">Weekly availability</Heading>
+          <AvailabilityEditor />
+        </div>
+        <div>
+          <Heading level="h2" className="mb-3">Upcoming bookings</Heading>
+          <BookingsList />
+        </div>
+      </div>
+    </Container>
+  )
+}
+
+export const Component = Bookings

--- a/vendor-panel/src/routes/bookings/index.ts
+++ b/vendor-panel/src/routes/bookings/index.ts
@@ -1,0 +1,1 @@
+export { Bookings as Component } from "./bookings"

--- a/vendor-panel/src/routes/embed-analytics/embed-analytics.tsx
+++ b/vendor-panel/src/routes/embed-analytics/embed-analytics.tsx
@@ -1,0 +1,146 @@
+import { Container, Heading, Select, Text } from "@medusajs/ui"
+import { useState } from "react"
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import { useEmbedAnalytics } from "../../hooks/api/embed-analytics"
+
+const Stat = ({ label, value }: { label: string; value: number | string }) => (
+  <div className="border-ui-border-base bg-ui-bg-subtle flex flex-col gap-1 rounded-lg border p-4">
+    <Text size="xsmall" className="text-ui-fg-muted">
+      {label}
+    </Text>
+    <Text className="text-ui-fg-base text-2xl font-semibold">{value}</Text>
+  </div>
+)
+
+export const EmbedAnalytics = () => {
+  const [range, setRange] = useState(30)
+  const { analytics, isPending } = useEmbedAnalytics(range)
+
+  const funnel = analytics?.funnel
+  const conv =
+    funnel && funnel.views > 0
+      ? Math.round((funnel.orders / funnel.views) * 1000) / 10
+      : 0
+
+  return (
+    <Container className="p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading>Embed Analytics</Heading>
+          <Text className="text-ui-fg-subtle mt-1" size="small">
+            How your connect.js embed performs across the sites you've placed it
+            on.
+          </Text>
+        </div>
+        <div className="w-40">
+          <Select value={String(range)} onValueChange={(v) => setRange(Number(v))}>
+            <Select.Trigger>
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="7">Last 7 days</Select.Item>
+              <Select.Item value="30">Last 30 days</Select.Item>
+              <Select.Item value="90">Last 90 days</Select.Item>
+            </Select.Content>
+          </Select>
+        </div>
+      </div>
+
+      {isPending || !analytics ? (
+        <div className="px-6 py-10">
+          <Text className="text-ui-fg-subtle" size="small">
+            Loading…
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-8 px-6 pb-6">
+          {/* Funnel summary */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <Stat label="Views" value={funnel?.views ?? 0} />
+            <Stat label="Add to cart" value={funnel?.add_to_cart ?? 0} />
+            <Stat label="Checkout" value={funnel?.checkout_start ?? 0} />
+            <Stat label="Orders" value={funnel?.orders ?? 0} />
+            <Stat label="Conversion" value={`${conv}%`} />
+          </div>
+
+          {/* Daily views & orders */}
+          <div>
+            <Heading level="h2" className="mb-3">
+              Daily activity
+            </Heading>
+            {analytics.by_day.length ? (
+              <ResponsiveContainer width="100%" height={260}>
+                <LineChart data={analytics.by_day}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" fontSize={11} />
+                  <YAxis fontSize={11} allowDecimals={false} />
+                  <Tooltip />
+                  <Legend />
+                  <Line type="monotone" dataKey="views" stroke="#6366f1" name="Views" />
+                  <Line type="monotone" dataKey="orders" stroke="#16a34a" name="Orders" />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <Text size="small" className="text-ui-fg-muted">
+                No activity in this range yet.
+              </Text>
+            )}
+          </div>
+
+          {/* Traffic by domain */}
+          <div>
+            <Heading level="h2" className="mb-3">
+              Traffic by domain
+            </Heading>
+            {analytics.by_origin.length ? (
+              <ResponsiveContainer width="100%" height={Math.max(120, analytics.by_origin.length * 36)}>
+                <BarChart data={analytics.by_origin} layout="vertical">
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis type="number" fontSize={11} allowDecimals={false} />
+                  <YAxis type="category" dataKey="origin" width={160} fontSize={11} />
+                  <Tooltip />
+                  <Bar dataKey="count" fill="#6366f1" name="Events" />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <Text size="small" className="text-ui-fg-muted">
+                No domain data yet. Add a publishable key to your embed to start
+                collecting analytics.
+              </Text>
+            )}
+          </div>
+
+          {/* Top products */}
+          {analytics.top_products.length > 0 && (
+            <div>
+              <Heading level="h2" className="mb-3">
+                Most-viewed products
+              </Heading>
+              <div className="border-ui-border-base divide-ui-border-base divide-y rounded-lg border">
+                {analytics.top_products.map((p) => (
+                  <div key={p.product_id} className="flex items-center justify-between p-3">
+                    <code className="text-ui-fg-subtle text-xs">{p.product_id}</code>
+                    <Text size="small">{p.views} views</Text>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const Component = EmbedAnalytics

--- a/vendor-panel/src/routes/embed-analytics/index.ts
+++ b/vendor-panel/src/routes/embed-analytics/index.ts
@@ -1,0 +1,1 @@
+export { EmbedAnalytics as Component } from "./embed-analytics"

--- a/vendor-panel/src/routes/my-website/components/connect-panel.tsx
+++ b/vendor-panel/src/routes/my-website/components/connect-panel.tsx
@@ -8,9 +8,11 @@ import {
   Text,
   toast,
 } from "@medusajs/ui"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { FbmWebsite, useUpdateWebsiteDomains } from "../../../hooks/api/website"
 import { CodeBlock, Step } from "./shared"
+import { KeysSection } from "./keys-section"
+import { EmbedPreview } from "./embed-preview"
 
 /** Bare-hostname validation that mirrors the backend normalizer. */
 function cleanHost(input: string): string | null {
@@ -40,9 +42,37 @@ const SDK_METHODS: Array<{ call: string; desc: string }> = [
   { call: "FBM.renderEvents('#events')", desc: "Inject a styled events list." },
   { call: "FBM.renderVendor('#me')", desc: "Inject your profile header." },
   {
+    call: "FBM.renderReviews('#reviews')",
+    desc: "Inject your verified-purchase reviews.",
+  },
+  {
+    call: "FBM.renderBooking('#book', { product })",
+    desc: "Calendar + slot picker for a bookable service (needs a key).",
+  },
+  {
+    call: "FBM.openChat('#chat')",
+    desc: "Message button that opens a Blackout chat (needs a key).",
+  },
+  {
     call: "FBM.cartUrl(product)",
     desc: "Deep-link into FBM checkout for a product.",
   },
+  {
+    call: "FBM.on('booking:confirmed', fn)",
+    desc: "Listen for cart, order, and booking events.",
+  },
+]
+
+/** Component catalog for the picker / preview. */
+const COMPONENTS: Array<{ kind: string; label: string; needsKey?: boolean; attrs?: string }> = [
+  { kind: "vendor", label: "Profile header" },
+  { kind: "products", label: "Product grid", attrs: ' data-fbm-limit="6"' },
+  { kind: "digital", label: "Digital products" },
+  { kind: "services", label: "Services" },
+  { kind: "events", label: "Events" },
+  { kind: "reviews", label: "Reviews" },
+  { kind: "booking", label: "Booking", needsKey: true, attrs: ' data-fbm-product="prod_…"' },
+  { kind: "chat", label: "Chat", needsKey: true },
 ]
 
 export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
@@ -56,16 +86,21 @@ export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
     setDomains(website.connect_domains || [])
   }, [website.connect_domains])
 
-  const zeroJsExample = [
-    "<!-- Your profile header -->",
-    '<div data-fbm="vendor"></div>',
-    "",
-    "<!-- A grid of your products -->",
-    '<div data-fbm="products" data-fbm-limit="6"></div>',
-    "",
-    "<!-- Your upcoming events -->",
-    '<div data-fbm="events"></div>',
-  ].join("\n")
+  const [picked, setPicked] = useState<string[]>(["vendor", "products"])
+
+  const togglePicked = (kind: string) => {
+    setPicked((cur) =>
+      cur.includes(kind) ? cur.filter((k) => k !== kind) : [...cur, kind]
+    )
+  }
+
+  // Build the component markup from the picker, preserving catalog order.
+  const componentSnippet = useMemo(() => {
+    const lines = COMPONENTS.filter((c) => picked.includes(c.kind)).map(
+      (c) => `<div data-fbm="${c.kind}"${c.attrs || ""}></div>`
+    )
+    return lines.length ? lines.join("\n") : '<div data-fbm="products"></div>'
+  }, [picked])
 
   const addDomain = () => {
     const host = cleanHost(draft)
@@ -114,15 +149,50 @@ export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
         </Text>
       </Step>
 
-      <Step n={2} title="Show your store — no code required">
-        <Text className="text-ui-fg-subtle mb-2" size="small">
-          Paste any of these where you want them to appear. They render
-          themselves and stay in sync with your catalog.
+      <Step
+        n={2}
+        title="Create a publishable key (for booking, chat & analytics)"
+      >
+        <Text className="text-ui-fg-subtle mb-3" size="small">
+          The catalog works keyless. Add a key to your snippet —{" "}
+          <code className="bg-ui-bg-subtle rounded px-1">
+            data-fbm-key="pk_live_…"
+          </code>{" "}
+          — to unlock bookings, chat, and analytics. Keys only work from the
+          domains you whitelist in step&nbsp;4.
         </Text>
-        <CodeBlock code={zeroJsExample} />
+        <KeysSection />
       </Step>
 
-      <Step n={3} title="Want full control? Use the JavaScript API">
+      <Step n={3} title="Pick what to show — then preview it live">
+        <Text className="text-ui-fg-subtle mb-2" size="small">
+          Choose the components you want, paste the markup where they should
+          appear, and watch the live preview update.
+        </Text>
+        <div className="mb-3 flex flex-wrap gap-2">
+          {COMPONENTS.map((c) => {
+            const on = picked.includes(c.kind)
+            return (
+              <Button
+                key={c.kind}
+                size="small"
+                variant={on ? "primary" : "secondary"}
+                onClick={() => togglePicked(c.kind)}
+                type="button"
+              >
+                {c.label}
+                {c.needsKey ? " 🔑" : ""}
+              </Button>
+            )
+          })}
+        </div>
+        <CodeBlock code={componentSnippet} />
+        <div className="mt-3">
+          <EmbedPreview website={website} components={picked} />
+        </div>
+      </Step>
+
+      <Step n={4} title="Want full control? Use the JavaScript API">
         <Text className="text-ui-fg-subtle mb-3" size="small">
           Every method returns enriched objects with{" "}
           <code className="bg-ui-bg-subtle rounded px-1">_price</code> and{" "}
@@ -146,7 +216,7 @@ export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
         </div>
       </Step>
 
-      <Step n={4} title="Whitelist your domains (optional)">
+      <Step n={5} title="Whitelist your domains (required for keys)">
         <Text className="text-ui-fg-subtle mb-3" size="small">
           The catalog API is public and read-only, so the snippet works
           everywhere immediately. Listing your domains here keeps a record of

--- a/vendor-panel/src/routes/my-website/components/embed-preview.tsx
+++ b/vendor-panel/src/routes/my-website/components/embed-preview.tsx
@@ -1,0 +1,60 @@
+import { Text } from "@medusajs/ui"
+import { useMemo } from "react"
+import { FbmWebsite } from "../../../hooks/api/website"
+
+/**
+ * Live, sandboxed preview of the vendor's embed. We render the real connect.js
+ * SDK against the public catalog API inside an isolated iframe (sandboxed to
+ * scripts only — no same-origin access to the panel). Booking/chat appear but
+ * stay inert here since no publishable key is injected into the preview.
+ */
+export const EmbedPreview = ({
+  website,
+  components,
+}: {
+  website: FbmWebsite
+  components: string[]
+}) => {
+  const srcDoc = useMemo(() => {
+    const blocks = (components.length ? components : ["products"])
+      .map((kind) => {
+        const attrs =
+          kind === "products"
+            ? ' data-fbm-limit="6"'
+            : kind === "booking"
+              ? ' data-fbm-product="preview"'
+              : ""
+        return `<div data-fbm="${kind}"${attrs}></div>`
+      })
+      .join("\n")
+
+    return `<!doctype html><html><head><meta charset="utf-8">
+<style>body{font-family:system-ui,sans-serif;margin:14px;color:#111}</style>
+</head><body>
+${blocks}
+<script src="${website.sdk_url}"
+        data-fbm-vendor="${website.handle}"
+        data-fbm-api="${website.api_base}"
+        data-fbm-storefront="${website.storefront_url}"></script>
+</body></html>`
+  }, [components, website])
+
+  return (
+    <div className="border-ui-border-base overflow-hidden rounded-lg border">
+      <div className="bg-ui-bg-subtle border-ui-border-base flex items-center justify-between border-b px-3 py-1.5">
+        <Text size="xsmall" className="text-ui-fg-muted">
+          Live preview
+        </Text>
+        <Text size="xsmall" className="text-ui-fg-muted">
+          {website.handle}
+        </Text>
+      </div>
+      <iframe
+        title="FBM embed preview"
+        sandbox="allow-scripts"
+        srcDoc={srcDoc}
+        className="h-[420px] w-full bg-white"
+      />
+    </div>
+  )
+}

--- a/vendor-panel/src/routes/my-website/components/keys-section.tsx
+++ b/vendor-panel/src/routes/my-website/components/keys-section.tsx
@@ -1,0 +1,169 @@
+import { Trash } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  IconButton,
+  Input,
+  Prompt,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useState } from "react"
+import {
+  useCreateEmbedKey,
+  useEmbedKeys,
+  useRevokeEmbedKey,
+} from "../../../hooks/api/embed-keys"
+import { CodeBlock } from "./shared"
+
+/**
+ * Publishable-key manager. Keys unlock the booking, chat, and analytics embed
+ * features (origin-validated against your whitelisted domains). The plaintext
+ * key is shown exactly once at creation — afterward only a masked form is kept.
+ */
+export const KeysSection = () => {
+  const { keys, isPending } = useEmbedKeys()
+  const { mutate: createKey, isPending: creating } = useCreateEmbedKey()
+  const { mutate: revokeKey } = useRevokeEmbedKey()
+
+  const [label, setLabel] = useState("")
+  const [revealKey, setRevealKey] = useState<string | null>(null)
+  const [revokeId, setRevokeId] = useState<string | null>(null)
+
+  const onCreate = () => {
+    createKey(
+      { label: label.trim() || undefined },
+      {
+        onSuccess: (data) => {
+          setRevealKey(data.key)
+          setLabel("")
+        },
+        onError: () => toast.error("Could not create key"),
+      }
+    )
+  }
+
+  const onRevoke = (id: string) => {
+    revokeKey(id, {
+      onSuccess: () => toast.success("Key revoked"),
+      onError: () => toast.error("Could not revoke key"),
+    })
+    setRevokeId(null)
+  }
+
+  return (
+    <div>
+      <div className="flex gap-2">
+        <Input
+          placeholder="Key label (e.g. Squarespace site)"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault()
+              onCreate()
+            }
+          }}
+        />
+        <Button
+          variant="secondary"
+          onClick={onCreate}
+          isLoading={creating}
+          type="button"
+        >
+          Create key
+        </Button>
+      </div>
+
+      {!isPending && keys.length === 0 && (
+        <Text className="text-ui-fg-muted mt-3" size="xsmall">
+          No keys yet. Create one to enable booking, chat, and analytics on your
+          embed.
+        </Text>
+      )}
+
+      {keys.length > 0 && (
+        <div className="border-ui-border-base divide-ui-border-base mt-3 divide-y rounded-lg border">
+          {keys.map((k) => (
+            <div
+              key={k.id}
+              className="flex items-center justify-between gap-3 p-3"
+            >
+              <div className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <code className="text-ui-fg-base bg-ui-bg-subtle rounded px-2 py-0.5 text-xs">
+                    {k.masked}
+                  </code>
+                  {k.label && (
+                    <Text className="text-ui-fg-subtle" size="xsmall">
+                      {k.label}
+                    </Text>
+                  )}
+                  {!k.active && (
+                    <Badge size="2xsmall" color="red">
+                      Revoked
+                    </Badge>
+                  )}
+                </div>
+                <Text className="text-ui-fg-muted" size="xsmall">
+                  {k.last_used_at
+                    ? `Last used ${new Date(k.last_used_at).toLocaleDateString()}`
+                    : "Never used"}
+                </Text>
+              </div>
+              {k.active && (
+                <IconButton
+                  size="small"
+                  variant="transparent"
+                  onClick={() => setRevokeId(k.id)}
+                  aria-label="Revoke key"
+                  type="button"
+                >
+                  <Trash />
+                </IconButton>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* One-time reveal of the plaintext key. */}
+      <Prompt open={!!revealKey} onOpenChange={(o) => !o && setRevealKey(null)}>
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>Copy your new key now</Prompt.Title>
+            <Prompt.Description>
+              This is the only time the full key is shown. Store it somewhere
+              safe — you can revoke it and create a new one anytime.
+            </Prompt.Description>
+          </Prompt.Header>
+          <div className="px-6 pb-2">
+            {revealKey && <CodeBlock code={revealKey} />}
+          </div>
+          <Prompt.Footer>
+            <Button onClick={() => setRevealKey(null)}>Done</Button>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
+
+      {/* Revoke confirmation. */}
+      <Prompt open={!!revokeId} onOpenChange={(o) => !o && setRevokeId(null)}>
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>Revoke this key?</Prompt.Title>
+            <Prompt.Description>
+              Any site using this key will immediately stop being able to take
+              bookings, chats, or report analytics. This cannot be undone.
+            </Prompt.Description>
+          </Prompt.Header>
+          <Prompt.Footer>
+            <Prompt.Cancel>Cancel</Prompt.Cancel>
+            <Prompt.Action onClick={() => revokeId && onRevoke(revokeId)}>
+              Revoke
+            </Prompt.Action>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
+    </div>
+  )
+}


### PR DESCRIPTION
Turn any vendor's website into an FBM storefront: catalog, bookings,
reviews, chat, and analytics from one <script> tag.

Backend
- embed-keys module: per-vendor publishable keys (pk_live_…), SHA-256
  hashed at rest, shown once; publishable-key middleware enforces the
  key + connect_domains origin allow-list (hard on /store/embed/*,
  soft/keyless-friendly on /store/vendors/*) with per-key rate limiting.
- catalog API expanded: grouped products (digital/services/physical),
  capabilities, reviews_summary, per-product booking_config.
- booking module: tz-aware slot generation (zero-dep Intl helpers),
  availability + per-product config, store/vendor routes, order-link
  subscriber, confirmation email.
- reviews module: verified-purchase reviews (ownership-validated),
  public read routes, seller rating aggregation, post-purchase request
  job (env-gated).
- embed chat bridge: Matrix room via shared matrix-service with email
  fallback when Blackout is unreachable.
- embed analytics: batched event ingestion + vendor aggregation route.

Embed (connect.js v2)
- data-fbm-vendor/data-fbm-key (keyless data-fbm-handle still works),
  new digital/services/reviews/booking/chat components + buy buttons,
  window.FBM API additions, on() emitter, CSS-variable theming,
  analytics batching via keepalive fetch. ~9.6KB gzipped.

Vendor panel
- My Website: key manager (create/copy-once/revoke), component picker
  with live sandboxed preview, keyed snippet guidance.
- new Bookings route (availability grid + requests) and Embed Analytics
  route (recharts funnel/traffic/top products).

Infra: open-CORS + cached /connect.js headers, env template additions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G9HHcw3terGaciN8mX7fcQ