### PR TITLE
feat(plant-network): wire seams to existing infra + add unit tests

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -275,3 +275,18 @@ MEDUSA_ADMIN_EMAIL=admin@yourmail.com
 # if MEDUSA_ADMIN_PASSWORD is empty or matches a banned placeholder.
 MEDUSA_ADMIN_PASSWORD=
 
+# =============================================================================
+# 🌱 PLANT NETWORK (BMC) - Optional
+# =============================================================================
+
+# Hub/coop seller that owns the WHOLESALE customer tier. Used as the default
+# tier owner when approving a wholesale application (POST
+# /admin/wholesale-application/:id/approve) if no seller_id is passed in the body.
+# HUB_SELLER_ID=sel_...
+
+# Shipping-label provider for grower node fulfillment. Defaults to "noop" (no
+# label purchased) when unset. A real provider (e.g. easypost/shippo/usps) must
+# be implemented in src/modules/agriculture/label-provider.ts and its carrier
+# credentials supplied before changing this.
+# PLANT_LABEL_PROVIDER=noop
+

--- a/backend/src/modules/agriculture/__tests__/node-fulfillment.unit.spec.ts
+++ b/backend/src/modules/agriculture/__tests__/node-fulfillment.unit.spec.ts
@@ -1,0 +1,43 @@
+import {
+  classifyPhytoRestrictions,
+  type PhytoItemInput,
+} from "../node-fulfillment"
+
+const live = (id: string, opts: Partial<PhytoItemInput> = {}): PhytoItemInput => ({
+  line_item_id: id,
+  title: opts.title ?? "Fig",
+  is_live_plant: opts.is_live_plant ?? true,
+  requires_phyto_cert: opts.requires_phyto_cert ?? false,
+})
+
+describe("node-fulfillment: classifyPhytoRestrictions", () => {
+  it("flags every live plant into a fully-restricted state", () => {
+    const out = classifyPhytoRestrictions("CA", [live("li_1"), live("li_2")])
+    expect(out).toHaveLength(2)
+    expect(out[0].reason).toMatch(/CA/)
+  })
+
+  it("flags only requires_phyto_cert items into a citrus-restricted state", () => {
+    const out = classifyPhytoRestrictions("TX", [
+      live("li_citrus", { requires_phyto_cert: true }),
+      live("li_plain", { requires_phyto_cert: false }),
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].item_id).toBe("li_citrus")
+  })
+
+  it("returns nothing for an unrestricted state", () => {
+    expect(classifyPhytoRestrictions("NY", [live("li_1")])).toEqual([])
+  })
+
+  it("returns nothing when there is no destination state", () => {
+    expect(classifyPhytoRestrictions(null, [live("li_1")])).toEqual([])
+  })
+
+  it("skips non-live items", () => {
+    const out = classifyPhytoRestrictions("CA", [
+      live("li_dry", { is_live_plant: false, requires_phyto_cert: false }),
+    ])
+    expect(out).toEqual([])
+  })
+})

--- a/backend/src/modules/agriculture/label-provider.ts
+++ b/backend/src/modules/agriculture/label-provider.ts
@@ -1,0 +1,67 @@
+/**
+ * Plant Network — provider-agnostic shipping-label seam (Section 6).
+ *
+ * Buying real postage requires a paid carrier relationship, so there is no OSS
+ * drop-in. Rather than hardcode one vendor, fulfillment dispatch talks to this
+ * `LabelProvider` interface. The default is a no-op (logs intent, buys nothing);
+ * a real EasyPost / Shippo / direct-USPS implementation can be added later and
+ * selected via the `PLANT_LABEL_PROVIDER` env var — no change to the fulfillment
+ * logic in `node-fulfillment.ts`.
+ */
+
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+export interface LabelRequest {
+  order_id: string
+  seller_id: string
+  stock_location_id: string | null
+  line_item_ids: string[]
+}
+
+export interface LabelResult {
+  provider: string
+  purchased: boolean
+  skipped: boolean
+  tracking_number: string | null
+  label_url: string | null
+  reason?: string
+}
+
+export interface LabelProvider {
+  readonly name: string
+  buyLabel(req: LabelRequest): Promise<LabelResult>
+}
+
+/**
+ * Default provider: buys nothing, records the intent. Lets the whole dispatch
+ * flow run end-to-end in environments without carrier credentials.
+ */
+export class NoopLabelProvider implements LabelProvider {
+  readonly name = "noop"
+  async buyLabel(_req: LabelRequest): Promise<LabelResult> {
+    return {
+      provider: this.name,
+      purchased: false,
+      skipped: true,
+      tracking_number: null,
+      label_url: null,
+      reason:
+        "no label provider configured (set PLANT_LABEL_PROVIDER + carrier credentials)",
+    }
+  }
+}
+
+/**
+ * Select the active label provider. Defaults to the no-op. Future real
+ * providers register their cases here keyed on PLANT_LABEL_PROVIDER.
+ */
+export function resolveLabelProvider(_container: MedusaContainer): LabelProvider {
+  const which = (process.env.PLANT_LABEL_PROVIDER || "noop").toLowerCase()
+  switch (which) {
+    // case "easypost": return new EasyPostLabelProvider(_container)
+    // case "shippo":   return new ShippoLabelProvider(_container)
+    // case "usps":     return new UspsLabelProvider(_container)
+    default:
+      return new NoopLabelProvider()
+  }
+}

--- a/backend/src/modules/agriculture/node-fulfillment.ts
+++ b/backend/src/modules/agriculture/node-fulfillment.ts
@@ -6,24 +6,67 @@
  * location, and gates dispatch on phytosanitary-cert requirements for live
  * plants shipping into restricted states.
  *
- * External SEAMS (need third-party creds): EasyPost label purchase and the S3
- * presigned cert-upload URL. All grouping/phyto logic is implemented here; the
- * seams are clearly marked and never crash the happy path before them.
+ * The cert-upload URL is generated via the existing MinIO File module
+ * (`Modules.FILE` presign). Carrier label purchase is delegated to a
+ * provider-agnostic `LabelProvider` (no-op by default) so EasyPost / Shippo /
+ * direct USPS can be dropped in without touching this logic.
  */
 
 import type { MedusaContainer } from "@medusajs/framework/types"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { emitBlackoutEvent } from "../../lib/blackout-emit"
 import {
   loadOrderNodeContext,
   type OrderNodeItem,
 } from "./plant-order-helpers"
+import { resolveLabelProvider, type LabelResult } from "./label-provider"
 import type { GrowerNode } from "../../types/plant"
 
 /** Destination states that restrict live-plant import outright. */
 export const RESTRICTED_STATES = ["CA", "AZ", "HI"]
 /** States that restrict specific (e.g. citrus) species rather than all plants. */
 export const CITRUS_RESTRICTED_STATES = ["TX", "FL"]
+
+/** Minimal item shape needed for phyto classification. */
+export interface PhytoItemInput {
+  line_item_id: string
+  title: string | null
+  is_live_plant: boolean
+  requires_phyto_cert: boolean
+}
+
+/**
+ * Pure phyto-restriction classifier (no I/O). Returns the items that need a
+ * phytosanitary certificate given the destination state. Extracted for testing.
+ */
+export function classifyPhytoRestrictions(
+  state: string | null,
+  items: PhytoItemInput[]
+): Array<{ item_id: string; species: string | null; reason: string }> {
+  const restricted: Array<{ item_id: string; species: string | null; reason: string }> = []
+  if (!state) return restricted
+
+  const fullyRestricted = RESTRICTED_STATES.includes(state)
+  const citrusRestricted = CITRUS_RESTRICTED_STATES.includes(state)
+  for (const item of items) {
+    const live = item.is_live_plant || item.requires_phyto_cert
+    if (!live) continue
+    if (fullyRestricted) {
+      restricted.push({
+        item_id: item.line_item_id,
+        species: item.title,
+        reason: `Live plant into ${state}: state requires phytosanitary certificate`,
+      })
+    } else if (citrusRestricted && item.requires_phyto_cert) {
+      restricted.push({
+        item_id: item.line_item_id,
+        species: item.title,
+        reason: `Restricted species into ${state}: phytosanitary certificate required`,
+      })
+    }
+  }
+  return restricted
+}
 
 export interface NodeFulfillmentGroup {
   grower_node: GrowerNode | null
@@ -120,36 +163,32 @@ export class NodeFulfillmentService {
     if (!ctx) return { required: false, restricted_items: [], cert_upload_url: null }
 
     const state = normState(ctx.ship_to_province)
-    const restricted: PhytoCertCheck["restricted_items"] = []
-
-    if (state) {
-      const fullyRestricted = RESTRICTED_STATES.includes(state)
-      const citrusRestricted = CITRUS_RESTRICTED_STATES.includes(state)
-      for (const item of ctx.items) {
-        const live = item.is_live_plant || item.requires_phyto_cert
-        if (!live) continue
-        if (fullyRestricted) {
-          restricted.push({
-            item_id: item.line_item_id,
-            species: item.title,
-            reason: `Live plant into ${state}: state requires phytosanitary certificate`,
-          })
-        } else if (citrusRestricted && item.requires_phyto_cert) {
-          restricted.push({
-            item_id: item.line_item_id,
-            species: item.title,
-            reason: `Restricted species into ${state}: phytosanitary certificate required`,
-          })
-        }
-      }
-    }
+    const restricted = classifyPhytoRestrictions(state, ctx.items)
 
     return {
       required: restricted.length > 0,
       restricted_items: restricted,
-      // SEAM: external — generate an S3 presigned PUT URL for the grower/admin to
-      // upload the signed cert document. Requires S3 creds; null until wired.
-      cert_upload_url: null,
+      cert_upload_url: restricted.length > 0 ? await this.presignCertUpload(orderId) : null,
+    }
+  }
+
+  /**
+   * Generate a presigned PUT URL for the cert document via the existing MinIO
+   * File module. Returns null when the active file provider doesn't support
+   * presign (e.g. the local dev provider) — never throws.
+   */
+  private async presignCertUpload(orderId: string): Promise<string | null> {
+    try {
+      const fileService = this.container.resolve(Modules.FILE) as {
+        getPresignedUploadUrl?: (d: { filename: string }) => Promise<{ url?: string }>
+      }
+      if (typeof fileService.getPresignedUploadUrl !== "function") return null
+      const result = await fileService.getPresignedUploadUrl({
+        filename: `phyto-cert-${orderId}-${Date.now()}.pdf`,
+      })
+      return result?.url ?? null
+    } catch {
+      return null
     }
   }
 
@@ -161,15 +200,31 @@ export class NodeFulfillmentService {
   async dispatchFulfillmentsToNodes(
     orderId: string,
     groups?: NodeFulfillmentGroup[]
-  ): Promise<{ dispatched: number; blocked: boolean; reason?: string }> {
+  ): Promise<{
+    dispatched: number
+    blocked: boolean
+    reason?: string
+    labels?: Array<{ seller_id: string; result: LabelResult }>
+  }> {
     const phyto = await this.checkPhytoCertRequirement(orderId)
     if (phyto.required) {
       return { dispatched: 0, blocked: true, reason: "phyto_cert_required" }
     }
 
     const resolved = groups ?? (await this.groupOrderByNode(orderId))
+    const labelProvider = resolveLabelProvider(this.container)
     let dispatched = 0
+    const labels: Array<{ seller_id: string; result: LabelResult }> = []
     for (const group of resolved) {
+      // Purchase the carrier label via the active provider (no-op by default).
+      const result = await labelProvider.buyLabel({
+        order_id: orderId,
+        seller_id: group.seller_id,
+        stock_location_id: group.stock_location_id,
+        line_item_ids: group.line_item_ids,
+      })
+      labels.push({ seller_id: group.seller_id, result })
+
       // Notify the grower a shipment is ready to pack/ship.
       await emitBlackoutEvent(
         this.container,
@@ -180,14 +235,13 @@ export class NodeFulfillmentService {
           growerNode: group.grower_node,
           stockLocationId: group.stock_location_id,
           lineItemIds: group.line_item_ids,
+          labelProvider: labelProvider.name,
+          trackingNumber: result.tracking_number,
         },
         { eventId: `node_fulfillment.dispatched:${orderId}:${group.seller_id}` }
       )
-      // SEAM: external — purchase the EasyPost shipping label for this group's
-      // stock location, create the Medusa fulfillment record, and email the
-      // label + packing slip PDF to the grower. Requires EasyPost creds.
       dispatched += 1
     }
-    return { dispatched, blocked: false }
+    return { dispatched, blocked: false, labels }
   }
 }

--- a/backend/src/modules/demand-pool/__tests__/plant-demand.unit.spec.ts
+++ b/backend/src/modules/demand-pool/__tests__/plant-demand.unit.spec.ts
@@ -1,0 +1,45 @@
+import { summarizeSpeciesDemand } from "../plant-demand"
+
+describe("plant-demand: summarizeSpeciesDemand", () => {
+  const post = {
+    id: "dp_1",
+    title: "Species demand: Jaboticaba",
+    committed_quantity: 0,
+    target_quantity: 50,
+    specs: {
+      species_name: "Jaboticaba",
+      zone_counts: { "7": 3, "9": 1, "10": 2 },
+      max_prices: [10, 20],
+    },
+  }
+
+  it("aggregates active participants, ignoring withdrawn", () => {
+    const summary = summarizeSpeciesDemand(post, [
+      { status: "COMMITTED", quantity_committed: 5 },
+      { status: "COMMITTED", quantity_committed: 10 },
+      { status: "WITHDRAWN", quantity_committed: 99 },
+    ])
+    expect(summary.total_expressions).toBe(2)
+    expect(summary.total_units_requested).toBe(15)
+    expect(summary.avg_max_price).toBe(15)
+    expect(summary.species_name).toBe("Jaboticaba")
+  })
+
+  it("returns the top 3 zones by count, descending", () => {
+    const summary = summarizeSpeciesDemand(post, [])
+    expect(summary.top_zones).toEqual([7, 10, 9])
+  })
+
+  it("flags the production threshold once committed >= target", () => {
+    expect(summarizeSpeciesDemand(post, []).production_threshold_met).toBe(false)
+    const met = summarizeSpeciesDemand({ ...post, committed_quantity: 50 }, [])
+    expect(met.production_threshold_met).toBe(true)
+  })
+
+  it("tolerates missing specs", () => {
+    const summary = summarizeSpeciesDemand({ id: "dp_2", title: "Lychee", specs: null }, [])
+    expect(summary.species_name).toBe("Lychee")
+    expect(summary.avg_max_price).toBe(0)
+    expect(summary.top_zones).toEqual([])
+  })
+})

--- a/backend/src/modules/demand-pool/plant-demand.ts
+++ b/backend/src/modules/demand-pool/plant-demand.ts
@@ -43,6 +43,41 @@ const speciesKey = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "-")
 
 const isEmail = (v: string) => /.+@.+\..+/.test(v)
 
+/**
+ * Pure species-demand aggregation (no I/O). Summarises a demand post + its
+ * participants into the report row. Extracted for testing.
+ */
+export function summarizeSpeciesDemand(
+  post: {
+    id: string
+    title?: string
+    committed_quantity?: number
+    target_quantity?: number
+    specs?: { species_name?: string; zone_counts?: Record<string, number>; max_prices?: number[] } | null
+  },
+  participants: Array<{ status?: string; quantity_committed?: number }>
+): SpeciesDemandSummary {
+  const active = participants.filter((p) => p.status !== "WITHDRAWN")
+  const totalUnits = active.reduce((s, p) => s + Number(p.quantity_committed ?? 0), 0)
+  const specs = post.specs ?? {}
+  const prices = specs.max_prices ?? []
+  const avgMax = prices.length ? prices.reduce((s, n) => s + n, 0) / prices.length : 0
+  const topZones = Object.entries(specs.zone_counts ?? {})
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([z]) => Number(z))
+  return {
+    species_name: specs.species_name ?? post.title ?? "",
+    demand_post_id: post.id,
+    total_expressions: active.length,
+    total_units_requested: totalUnits,
+    avg_max_price: Math.round(avgMax * 100) / 100,
+    top_zones: topZones,
+    production_threshold_met:
+      Number(post.committed_quantity ?? 0) >= Number(post.target_quantity ?? PRODUCTION_THRESHOLD),
+  }
+}
+
 type DemandService = {
   listDemandPosts: (filters: Record<string, unknown>) => Promise<any[]>
   createDemandPost: (input: Record<string, unknown>) => Promise<any>
@@ -137,28 +172,7 @@ export class PlantDemandService {
     const summaries: SpeciesDemandSummary[] = []
     for (const post of posts) {
       const participants = await this.demand.listDemandParticipants({ demand_post_id: post.id })
-      const active = participants.filter((p) => p.status !== "WITHDRAWN")
-      const totalUnits = active.reduce((s, p) => s + Number(p.quantity_committed ?? 0), 0)
-      const specs = (post.specs ?? {}) as {
-        species_name?: string
-        zone_counts?: Record<string, number>
-        max_prices?: number[]
-      }
-      const prices = specs.max_prices ?? []
-      const avgMax = prices.length ? prices.reduce((s, n) => s + n, 0) / prices.length : 0
-      const topZones = Object.entries(specs.zone_counts ?? {})
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 3)
-        .map(([z]) => Number(z))
-      summaries.push({
-        species_name: specs.species_name ?? post.title,
-        demand_post_id: post.id,
-        total_expressions: active.length,
-        total_units_requested: totalUnits,
-        avg_max_price: Math.round(avgMax * 100) / 100,
-        top_zones: topZones,
-        production_threshold_met: Number(post.committed_quantity ?? 0) >= Number(post.target_quantity ?? PRODUCTION_THRESHOLD),
-      })
+      summaries.push(summarizeSpeciesDemand(post, participants))
     }
     return summaries.sort((a, b) => b.total_units_requested - a.total_units_requested)
   }

--- a/backend/src/modules/order-cycle/__tests__/plant-ship-window.unit.spec.ts
+++ b/backend/src/modules/order-cycle/__tests__/plant-ship-window.unit.spec.ts
@@ -1,0 +1,55 @@
+import { evaluateShipWindow } from "../plant-ship-window"
+
+const NOW = new Date("2026-04-15T00:00:00Z")
+const past = new Date("2026-01-01T00:00:00Z")
+const future = new Date("2026-09-01T00:00:00Z")
+
+describe("plant-ship-window: evaluateShipWindow", () => {
+  it("is available inside the window with stock", () => {
+    const r = evaluateShipWindow(
+      { opensAt: past, closesAt: future, allowPreorder: false, inventoryKnownZero: false },
+      NOW
+    )
+    expect(r).toMatchObject({ orderable: true, reason: "available" })
+  })
+
+  it("blocks before the window opens (no preorder)", () => {
+    const r = evaluateShipWindow(
+      { opensAt: future, closesAt: null, allowPreorder: false, inventoryKnownZero: false },
+      NOW
+    )
+    expect(r).toMatchObject({ orderable: false, reason: "window_not_open", preorder_available: false })
+  })
+
+  it("allows preorder before the window opens when enabled", () => {
+    const r = evaluateShipWindow(
+      { opensAt: future, closesAt: null, allowPreorder: true, inventoryKnownZero: false },
+      NOW
+    )
+    expect(r).toMatchObject({ orderable: true, reason: "window_not_open", preorder_available: true })
+  })
+
+  it("blocks after the window closes", () => {
+    const r = evaluateShipWindow(
+      { opensAt: past, closesAt: past, allowPreorder: true, inventoryKnownZero: false },
+      NOW
+    )
+    expect(r).toMatchObject({ orderable: false, reason: "window_closed" })
+  })
+
+  it("reports sold_out when in-window but inventory is known-zero", () => {
+    const r = evaluateShipWindow(
+      { opensAt: null, closesAt: null, allowPreorder: false, inventoryKnownZero: true },
+      NOW
+    )
+    expect(r).toMatchObject({ orderable: false, reason: "sold_out" })
+  })
+
+  it("is available with no window constraints and unknown inventory", () => {
+    const r = evaluateShipWindow(
+      { opensAt: null, closesAt: null, allowPreorder: false, inventoryKnownZero: false },
+      NOW
+    )
+    expect(r.orderable).toBe(true)
+  })
+})

--- a/backend/src/modules/order-cycle/plant-ship-window.ts
+++ b/backend/src/modules/order-cycle/plant-ship-window.ts
@@ -32,6 +32,38 @@ export interface OrderableResult {
 
 type QueryLike = { graph: (args: Record<string, unknown>) => Promise<{ data: any[] }> }
 
+export interface ShipWindowInput {
+  opensAt: Date | null
+  closesAt: Date | null
+  allowPreorder: boolean
+  /** true only when inventory is known and all variants are at/below zero. */
+  inventoryKnownZero: boolean
+}
+
+/**
+ * Pure ship-window evaluation (no I/O). Extracted for testing. Precedence:
+ * not-open → closed → sold-out → available.
+ */
+export function evaluateShipWindow(input: ShipWindowInput, now: Date): OrderableResult {
+  const { opensAt, closesAt, allowPreorder, inventoryKnownZero } = input
+  if (opensAt && now < opensAt) {
+    return {
+      orderable: allowPreorder,
+      reason: "window_not_open",
+      opens_at: opensAt,
+      closes_at: closesAt,
+      preorder_available: allowPreorder,
+    }
+  }
+  if (closesAt && now > closesAt) {
+    return { orderable: false, reason: "window_closed", opens_at: opensAt, closes_at: closesAt }
+  }
+  if (inventoryKnownZero) {
+    return { orderable: false, reason: "sold_out", opens_at: opensAt, closes_at: closesAt }
+  }
+  return { orderable: true, reason: "available", opens_at: opensAt, closes_at: closesAt }
+}
+
 export class PlantShipWindowService {
   private readonly container: MedusaContainer
 
@@ -67,27 +99,13 @@ export class PlantShipWindowService {
     const allowPreorder =
       (product.metadata as Record<string, unknown> | null)?.allow_preorder === true
 
-    if (opensAt && now < opensAt) {
-      return {
-        orderable: allowPreorder,
-        reason: "window_not_open",
-        opens_at: opensAt,
-        closes_at: closesAt,
-        preorder_available: allowPreorder,
-      }
-    }
-    if (closesAt && now > closesAt) {
-      return { orderable: false, reason: "window_closed", opens_at: opensAt, closes_at: closesAt }
-    }
-
     // Best-effort inventory check (only when the field is populated).
     const variants = (product.variants ?? []) as Array<{ inventory_quantity?: number | null }>
     const known = variants.filter((v) => typeof v.inventory_quantity === "number")
-    if (known.length > 0 && known.every((v) => (v.inventory_quantity ?? 0) <= 0)) {
-      return { orderable: false, reason: "sold_out", opens_at: opensAt, closes_at: closesAt }
-    }
+    const inventoryKnownZero =
+      known.length > 0 && known.every((v) => (v.inventory_quantity ?? 0) <= 0)
 
-    return { orderable: true, reason: "available", opens_at: opensAt, closes_at: closesAt }
+    return evaluateShipWindow({ opensAt, closesAt, allowPreorder, inventoryKnownZero }, now)
   }
 
   /**

--- a/backend/src/modules/payout-breakdown/__tests__/grower-payout.unit.spec.ts
+++ b/backend/src/modules/payout-breakdown/__tests__/grower-payout.unit.spec.ts
@@ -1,0 +1,40 @@
+import { computeNodeSplit, GROWER_SPLIT_CONFIG, PLATFORM_FEE } from "../grower-payout"
+
+describe("grower-payout: computeNodeSplit", () => {
+  it("splits a $100 node sale at 5% platform fee / 60% grower", () => {
+    const r = computeNodeSplit(10000, 0.05, 0.6)
+    expect(r.grossDollars).toBe(100)
+    expect(r.platformFee).toBeCloseTo(5, 6)
+    expect(r.net).toBeCloseTo(95, 6)
+    expect(r.growerAmount).toBeCloseTo(57, 6)
+    expect(r.hubAmount).toBe(38) // 95 - 57, rounded to cents
+  })
+
+  it("gives the hub nothing when the grower keeps 100% (hub_sc)", () => {
+    const r = computeNodeSplit(10000, 0.05, 1.0)
+    expect(r.hubAmount).toBe(0)
+    expect(r.growerAmount).toBeCloseTo(95, 6)
+  })
+
+  it("rounds the hub amount to whole cents", () => {
+    const r = computeNodeSplit(3333, 0.05, 0.62)
+    // gross 33.33, fee 1.6665, net 31.6635, grower 19.63137, hub 12.03213 -> 12.03
+    expect(r.hubAmount).toBe(12.03)
+  })
+
+  it("handles a zero-value line", () => {
+    const r = computeNodeSplit(0, 0.05, 0.6)
+    expect(r.grossDollars).toBe(0)
+    expect(r.hubAmount).toBe(0)
+  })
+
+  it("keeps split config + platform fee constants in expected ranges", () => {
+    expect(GROWER_SPLIT_CONFIG.hub_sc).toBe(1.0)
+    expect(GROWER_SPLIT_CONFIG.node_nc_mtn).toBe(0.62)
+    for (const v of Object.values(GROWER_SPLIT_CONFIG)) {
+      expect(v).toBeGreaterThanOrEqual(0.6)
+      expect(v).toBeLessThanOrEqual(1.0)
+    }
+    expect(PLATFORM_FEE).toBe(0.05)
+  })
+})

--- a/backend/src/modules/payout-breakdown/grower-payout.ts
+++ b/backend/src/modules/payout-breakdown/grower-payout.ts
@@ -48,6 +48,31 @@ export const PLATFORM_FEE = 0.05
 /** Owner id of the system account that receives hub cuts. */
 const HUB_ACCOUNT_OWNER = "hub_sc"
 
+export interface NodeSplit {
+  grossDollars: number
+  platformFee: number
+  net: number
+  growerAmount: number
+  hubAmount: number
+}
+
+/**
+ * Pure node-split math (no I/O). gross (cents) → platform fee → net → grower /
+ * hub amounts in dollars, hub amount rounded to cents. Extracted for testing.
+ */
+export function computeNodeSplit(
+  grossCents: number,
+  platformFeeFraction: number,
+  growerSplit: number
+): NodeSplit {
+  const grossDollars = grossCents / 100
+  const platformFee = grossDollars * platformFeeFraction
+  const net = grossDollars - platformFee
+  const growerAmount = net * growerSplit
+  const hubAmount = Math.round((net - growerAmount) * 100) / 100
+  return { grossDollars, platformFee, net, growerAmount, hubAmount }
+}
+
 export type GrowerPayoutStatus = "transferred" | "pending" | "skipped"
 
 export interface GrowerPayoutEvent {
@@ -72,6 +97,12 @@ type HawalaService = {
   createTransfer: (data: Record<string, unknown>) => Promise<any>
   listLedgerEntries: (filters: Record<string, unknown>) => Promise<any[]>
   getAccountBalance: (id: string) => Promise<{ available_balance: number }>
+  requestPayout: (data: {
+    vendor_id: string
+    amount: number
+    payout_tier: "INSTANT" | "SAME_DAY" | "NEXT_DAY" | "WEEKLY"
+    bank_account_id?: string
+  }) => Promise<{ id: string; status?: string }>
 }
 
 type PayoutBreakdownService = {
@@ -150,11 +181,12 @@ export class GrowerPayoutService {
     }
 
     const feeFraction = await this.platformFeeFraction(item.seller_id)
-    const platformFee = grossDollars * feeFraction
-    const net = grossDollars - platformFee
     const split = GROWER_SPLIT_CONFIG[item.grower_node] ?? 0.6
-    const growerAmount = net * split
-    const hubAmount = Math.round((net - growerAmount) * 100) / 100
+    const { platformFee, net, growerAmount, hubAmount } = computeNodeSplit(
+      item.gross_cents,
+      feeFraction,
+      split
+    )
 
     base.platform_fee = platformFee
     base.net_after_fee = net
@@ -260,28 +292,76 @@ export class GrowerPayoutService {
   }
 
   /**
-   * Monthly settlement. Aggregates each grower's net USD earnings into a payout
-   * figure. The actual bank/ACH execution is the external SEAM — here we compute
-   * the per-seller settlement amounts and return them for an ACH provider to
-   * disburse (Moov/Stripe at launch). Callers should mark settled entries via the
-   * hawala SettlementBatch flow once the transfer clears.
+   * Monthly settlement. Aggregates each grower's net USD earnings for the period
+   * and hands each to the EXISTING hawala payout pipeline via `requestPayout`,
+   * which debits SELLER_EARNINGS → SETTLEMENT and creates a PayoutRequest. The
+   * actual Stripe ACH push is performed downstream by the existing
+   * StripeAchService pipeline (gated by Stripe credentials), so there is no new
+   * external provider here.
+   *
+   * Balance-guarded + per-seller try/catch: a seller whose available balance is
+   * below the computed net (e.g. funds not yet settled) is reported as deferred
+   * rather than throwing.
    */
   async processMonthlyPayouts(
     sellerIds: string[],
-    period: { from: Date; to: Date }
-  ): Promise<Array<{ seller_id: string; amount: number; currency: "USD" }>> {
-    const settlements: Array<{ seller_id: string; amount: number; currency: "USD" }> = []
+    period: { from: Date; to: Date },
+    payoutTier: "INSTANT" | "SAME_DAY" | "NEXT_DAY" | "WEEKLY" = "WEEKLY"
+  ): Promise<
+    Array<{
+      seller_id: string
+      amount: number
+      currency: "USD"
+      status: "requested" | "deferred"
+      payout_request_id?: string
+      reason?: string
+    }>
+  > {
+    const results: Array<{
+      seller_id: string
+      amount: number
+      currency: "USD"
+      status: "requested" | "deferred"
+      payout_request_id?: string
+      reason?: string
+    }> = []
+
     for (const sellerId of sellerIds) {
       const rows = await this.getGrowerPayoutHistory(sellerId, period.from, period.to)
-      const net = rows.reduce(
-        (sum, r) => sum + (r.direction === "credit" ? r.amount : -r.amount),
-        0
-      )
-      if (net > 0) settlements.push({ seller_id: sellerId, amount: net, currency: "USD" })
+      const net =
+        Math.round(
+          rows.reduce(
+            (sum, r) => sum + (r.direction === "credit" ? r.amount : -r.amount),
+            0
+          ) * 100
+        ) / 100
+      if (net <= 0) continue
+
+      try {
+        const payout = await this.hawala.requestPayout({
+          vendor_id: sellerId,
+          amount: net,
+          payout_tier: payoutTier,
+        })
+        results.push({
+          seller_id: sellerId,
+          amount: net,
+          currency: "USD",
+          status: "requested",
+          payout_request_id: payout.id,
+        })
+      } catch (err) {
+        // Insufficient balance / no account → defer rather than fail the run.
+        results.push({
+          seller_id: sellerId,
+          amount: net,
+          currency: "USD",
+          status: "deferred",
+          reason: err instanceof Error ? err.message : "payout_request_failed",
+        })
+      }
     }
-    // TODO: external — hand `settlements` to the ACH provider (Moov/Stripe) and,
-    // on success, record a hawala SettlementBatch + mark entries SETTLED.
-    return settlements
+    return results
   }
 
   /**

--- a/backend/src/modules/progression/__tests__/grower-karma.unit.spec.ts
+++ b/backend/src/modules/progression/__tests__/grower-karma.unit.spec.ts
@@ -1,0 +1,40 @@
+import {
+  growerTierForXp,
+  GROWER_TIERS,
+  GROWER_KARMA_DELTAS,
+} from "../grower-karma"
+
+describe("grower-karma: growerTierForXp", () => {
+  it("maps XP to the correct tier at boundaries", () => {
+    expect(growerTierForXp(0)).toBe("Seedling")
+    expect(growerTierForXp(49)).toBe("Seedling")
+    expect(growerTierForXp(50)).toBe("Sprout")
+    expect(growerTierForXp(199)).toBe("Sprout")
+    expect(growerTierForXp(200)).toBe("Root")
+    expect(growerTierForXp(499)).toBe("Root")
+    expect(growerTierForXp(500)).toBe("Canopy")
+    expect(growerTierForXp(1499)).toBe("Canopy")
+    expect(growerTierForXp(1500)).toBe("Ancestor")
+    expect(growerTierForXp(99999)).toBe("Ancestor")
+  })
+
+  it("never returns below Seedling for negative XP", () => {
+    expect(growerTierForXp(-10)).toBe("Seedling")
+  })
+
+  it("tier split percentages increase monotonically", () => {
+    const order = ["Seedling", "Sprout", "Root", "Canopy", "Ancestor"] as const
+    for (let i = 1; i < order.length; i++) {
+      expect(GROWER_TIERS[order[i]].split_pct).toBeGreaterThan(
+        GROWER_TIERS[order[i - 1]].split_pct
+      )
+    }
+  })
+
+  it("defines the expected KARMA deltas", () => {
+    expect(GROWER_KARMA_DELTAS.units_sold).toBe(1)
+    expect(GROWER_KARMA_DELTAS.rare_species_produced).toBe(10)
+    expect(GROWER_KARMA_DELTAS.five_star_review).toBe(15)
+    expect(GROWER_KARMA_DELTAS.seasonal_deadline_met).toBe(20)
+  })
+})

--- a/backend/src/modules/progression/grower-karma.ts
+++ b/backend/src/modules/progression/grower-karma.ts
@@ -43,7 +43,22 @@ export const GROWER_TIERS = {
 
 export type GrowerTierName = keyof typeof GROWER_TIERS
 
-const TIER_ORDER: GrowerTierName[] = ["Seedling", "Sprout", "Root", "Canopy", "Ancestor"]
+export const TIER_ORDER: GrowerTierName[] = [
+  "Seedling",
+  "Sprout",
+  "Root",
+  "Canopy",
+  "Ancestor",
+]
+
+/** Pure: map a PRODUCER-track XP total to its grower tier. Extracted for testing. */
+export function growerTierForXp(xp: number): GrowerTierName {
+  let tier: GrowerTierName = "Seedling"
+  for (const name of TIER_ORDER) {
+    if (xp >= GROWER_TIERS[name].min) tier = name
+  }
+  return tier
+}
 
 export interface EmitGrowerKarmaInput {
   seller_id: string
@@ -112,14 +127,6 @@ export class GrowerKarmaService {
     return true
   }
 
-  private static tierForXp(xp: number): GrowerTierName {
-    let tier: GrowerTierName = "Seedling"
-    for (const name of TIER_ORDER) {
-      if (xp >= GROWER_TIERS[name].min) tier = name
-    }
-    return tier
-  }
-
   /** Current grower tier + progress, derived from PRODUCER-track XP. */
   async getGrowerTier(sellerId: string): Promise<{
     current_karma: number
@@ -135,7 +142,7 @@ export class GrowerKarmaService {
       producerXp = summary.tracks.find((t) => t.role === Stance.PRODUCER)?.xp ?? 0
     }
 
-    const tier = GrowerKarmaService.tierForXp(producerXp)
+    const tier = growerTierForXp(producerXp)
     const idx = TIER_ORDER.indexOf(tier)
     const nextTier = idx < TIER_ORDER.length - 1 ? TIER_ORDER[idx + 1] : null
     const karmaToNext = nextTier ? GROWER_TIERS[nextTier].min - producerXp : null


### PR DESCRIPTION
## Summary

Follow-ups to the merged Plant Network work (#728). Wires the previously-stubbed seams to infrastructure the repo **already has** (so they're real, not blind scaffolding), adds provider-agnostic shipping labels, documents config, and adds unit tests.

- **Cert upload (S3) → MinIO**: `checkPhytoCertRequirement` now returns a presigned PUT URL via the existing MinIO File module (`Modules.FILE.getPresignedUploadUrl`); returns `null` gracefully when the active provider lacks presign (local dev).
- **ACH settlement → existing hawala pipeline**: `processMonthlyPayouts` hands each grower's net to the existing `hawalaService.requestPayout()` (debits `SELLER_EARNINGS` → `SETTLEMENT`, creates a `PayoutRequest`). The actual Stripe ACH push stays in the existing `StripeAchService`, so there's no new external provider — per-seller try/catch defers under-funded sellers instead of failing the run.
- **Shipping labels → provider-agnostic**: new `LabelProvider` interface + `NoopLabelProvider` (default), selected by `PLANT_LABEL_PROVIDER`, wired into `dispatchFulfillmentsToNodes`. EasyPost/Shippo/direct-USPS can drop in later with no change to fulfillment logic (there is no OSS drop-in for real postage, so this keeps it vendor-neutral).
- **Config**: documented `HUB_SELLER_ID` and `PLANT_LABEL_PROVIDER` in `.env.template`.
- **Tests**: extracted the core decision logic into pure functions (`computeNodeSplit`, `classifyPhytoRestrictions`, `evaluateShipWindow`, `growerTierForXp`, `summarizeSpeciesDemand`) and added 24 unit tests across 5 suites. Service behaviour is unchanged (each service calls the new pure fn).

Why: the merged PR left these as explicitly-marked seams pending external wiring; exploration showed most of that infra already exists in-repo, so they could be wired for real and verified here.

## Related Issues

Closes #

## Validation

- [x] Tests updated/added where appropriate
- [x] Local checks executed
- [ ] Migration or rollout steps documented (if applicable) — no schema changes in this PR
- [ ] For new vendor extension keys: completed `docs/VENDOR_EXTENSION_DEFINITION_OF_DONE.md` checklist — N/A
- [ ] If this PR addresses a manual test-plan item, the relevant `docs/testing/*.md` checklist item is referenced — N/A

Commands run:

```bash
npx tsc --noEmit            # 0 errors
npm run test:unit           # 5 new suites, 24 tests passing
npx eslint <changed files>  # clean
```

## Release Notes

- [ ] No release note needed
- [x] Release note required (describe below)

Release note: Plant Network grower payouts now route monthly settlement through the existing hawala payout pipeline; phytosanitary cert uploads use presigned MinIO URLs; grower-node shipping labels go through a pluggable `LabelProvider` (set `PLANT_LABEL_PROVIDER`, default no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuwQZgUFJFpVHJx48k2aa3)_