### PR TITLE
Add vendor-controlled embed surface toggles for FBM Connect

### DIFF
--- a/backend/src/api/store/vendors/[handle]/route.ts
+++ b/backend/src/api/store/vendors/[handle]/route.ts
@@ -3,6 +3,7 @@ const log = createLogger("api/store/vendors/handle");
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { BOOKING_MODULE } from "../../../../modules/booking";
 import type BookingService from "../../../../modules/booking/service";
+import { resolveEmbedFeatures } from "../../../../shared/website-config";
 
 /**
  * GET /store/vendors/:handle  —  FBM Store API (public, website-agnostic)
@@ -129,6 +130,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
           "social_links",
           "mxid",
           "blackout_user_id",
+          "embed_features",
         ],
         filters: { seller_id: seller.id },
       });
@@ -137,10 +139,18 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       log.warn(`seller_metadata lookup failed for ${seller.id}`, err);
     }
 
-    // Chat is offered when the vendor has a reachable Blackout/Matrix identity.
-    const chatEnabled = Boolean(meta?.mxid || meta?.blackout_user_id);
+    // Vendor-controlled embed toggles. Null/missing ⇒ all surfaces on, so
+    // existing embeds are unchanged. These gate the public response below in
+    // addition to the data-presence checks, so a turned-off surface never
+    // leaves the server even if a host page still has the markup.
+    const features = resolveEmbedFeatures(meta?.embed_features);
 
-    const vendor = wantVendor
+    // Chat is offered when the vendor has a reachable Blackout/Matrix identity
+    // AND the vendor has not turned the chat surface off.
+    const chatEnabled =
+      Boolean(meta?.mxid || meta?.blackout_user_id) && features.chat;
+
+    const vendor = wantVendor && features.vendor
       ? {
           id: seller.id,
           handle: seller.handle,
@@ -160,8 +170,14 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
       : undefined;
 
     // 3) Published products for this seller (with variant prices).
+    // Fetch when the caller asked for products AND at least one product-backed
+    // surface (flat grid, digital, or services) is enabled — digital/services
+    // are derived from the same query.
+    const fetchProducts =
+      wantProducts &&
+      (features.products || features.digital || features.services);
     let products: any[] = [];
-    if (wantProducts) {
+    if (fetchProducts) {
       try {
         const { data: rows } = await query.graph({
           entity: "product",
@@ -272,14 +288,22 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     // Grouped views for the specialized connect.js components. The flat
     // `products` array above stays the back-compat contract; these are additive.
     const productGroups = {
-      digital: products.filter((p) => p.type === "digital"),
-      services: products.filter((p) => p.type === "service"),
-      physical: products.filter((p) => p.type === "physical"),
+      digital: features.digital
+        ? products.filter((p) => p.type === "digital")
+        : [],
+      services: features.services
+        ? products.filter((p) => p.type === "service")
+        : [],
+      physical: features.products
+        ? products.filter((p) => p.type === "physical")
+        : [],
     };
 
-    // 4) Events (ticket products) for this seller — best effort.
+    // 4) Events (ticket products) for this seller — best effort. Skipped when
+    // the vendor has turned the events surface off.
+    const fetchEvents = wantEvents && features.events;
     let events: any[] = [];
-    if (wantEvents) {
+    if (fetchEvents) {
       try {
         const { data: ticketRows } = await query.graph({
           entity: "ticket_product",
@@ -346,20 +370,28 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     return res.json({
       vendor,
-      products: wantProducts ? products : undefined,
+      // The flat list backs the general product grid (`data-fbm="products"`).
+      // Emptied when the vendor turns the products surface off; digital and
+      // services still arrive via product_groups below.
+      products: wantProducts ? (features.products ? products : []) : undefined,
       // Additive grouped view; `events` stays its own top-level array for
       // back-compat. Mirrors it under product_groups.events for symmetry.
       product_groups: wantProducts
-        ? { ...productGroups, events: wantEvents ? events : [] }
+        ? { ...productGroups, events: fetchEvents ? events : [] }
         : undefined,
       events: wantEvents ? events : undefined,
       // Capability flags so an embed can decide which widgets to render without
-      // a second request. `booking_enabled` is finalized in the booking phase;
-      // it is true when any service product exists.
+      // a second request. Each is the vendor's toggle AND-ed with data
+      // availability, so a disabled surface is always false here.
       capabilities: {
+        vendor_enabled: features.vendor,
+        products_enabled: features.products,
+        digital_enabled: features.digital,
+        services_enabled: features.services,
+        events_enabled: features.events,
+        reviews_enabled: features.reviews,
         chat_enabled: chatEnabled,
-        booking_enabled: productGroups.services.length > 0,
-        reviews_enabled: true,
+        booking_enabled: productGroups.services.length > 0 && features.booking,
       },
       reviews_summary: {
         average: meta?.rating ?? null,

--- a/backend/src/api/vendor/website/launch/route.ts
+++ b/backend/src/api/vendor/website/launch/route.ts
@@ -23,6 +23,7 @@ type MetaRow = {
   site_status: string | null;
   site_url: string | null;
   site_repo: string | null;
+  embed_features: string[] | null;
 };
 
 /**
@@ -74,7 +75,7 @@ export async function POST(
 
   const { data: metaRows } = await query.graph({
     entity: "seller_metadata",
-    fields: ["id", "connect_domains", "site_status", "site_url", "site_repo"],
+    fields: ["id", "connect_domains", "site_status", "site_url", "site_repo", "embed_features"],
     filters: { seller_id: sellerId },
   });
 
@@ -109,7 +110,7 @@ export async function POST(
 
     const { data: refreshed } = await query.graph({
       entity: "seller_metadata",
-      fields: ["connect_domains", "site_status", "site_url", "site_repo"],
+      fields: ["connect_domains", "site_status", "site_url", "site_repo", "embed_features"],
       filters: { seller_id: sellerId },
     });
 

--- a/backend/src/api/vendor/website/route.ts
+++ b/backend/src/api/vendor/website/route.ts
@@ -16,7 +16,10 @@ import {
   normalizeDomains,
   probeSiteLive,
 } from "../../../shared/site-provisioning";
-import { serializeWebsite } from "../../../shared/website-config";
+import {
+  EMBED_FEATURE_KEYS,
+  serializeWebsite,
+} from "../../../shared/website-config";
 
 type SellerRow = { id: string; handle: string };
 type MetaRow = {
@@ -25,8 +28,22 @@ type MetaRow = {
   site_status: string | null;
   site_url: string | null;
   site_repo: string | null;
+  embed_features: string[] | null;
   updated_at?: string | Date | null;
 };
+
+/**
+ * Normalize an incoming embed_features value. `null`/undefined resets to the
+ * default (all surfaces on). An array is filtered to the known surface keys so
+ * unknown keys can never be persisted.
+ */
+function normalizeEmbedFeatures(
+  value: unknown,
+): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const allowed = new Set<string>(EMBED_FEATURE_KEYS);
+  return value.filter((k): k is string => typeof k === "string" && allowed.has(k));
+}
 
 async function loadContext(req: AuthenticatedMedusaRequest, sellerId: string) {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
@@ -46,6 +63,7 @@ async function loadContext(req: AuthenticatedMedusaRequest, sellerId: string) {
       "site_status",
       "site_url",
       "site_repo",
+      "embed_features",
       "updated_at",
     ],
     filters: { seller_id: sellerId },
@@ -116,8 +134,10 @@ export async function GET(
 /**
  * POST /vendor/website
  *
- * Save the Connect whitelist (bare hostnames). Body is validated upstream:
- *   { connect_domains: string[] | null }
+ * Save the Connect whitelist and/or the embed feature toggles. Each field is
+ * optional and applied only when present, so the domain editor and the
+ * "what to show" toggles can save independently:
+ *   { connect_domains?: string[] | null, embed_features?: string[] | null }
  */
 export async function POST(
   req: AuthenticatedMedusaRequest,
@@ -127,8 +147,10 @@ export async function POST(
   if (!sellerId) return;
 
   try {
-    const body = req.body as { connect_domains?: string[] | null };
-    const domains = normalizeDomains(body.connect_domains ?? []);
+    const body = req.body as {
+      connect_domains?: string[] | null;
+      embed_features?: string[] | null;
+    };
 
     const { seller, meta } = await loadContext(req, sellerId);
     if (!seller) {
@@ -137,14 +159,23 @@ export async function POST(
         .json({ message: "Seller not found", type: "not_found" });
     }
 
+    // Build a partial update from only the fields the caller actually sent.
+    const updates: Record<string, unknown> = {};
+    if ("connect_domains" in body) {
+      updates.connect_domains = normalizeDomains(body.connect_domains ?? []);
+    }
+    if ("embed_features" in body) {
+      updates.embed_features = normalizeEmbedFeatures(body.embed_features);
+    }
+
     const sellerExtension = req.scope.resolve("sellerExtension");
     if (meta) {
       await updateSellerMetadataRecord(sellerExtension as SellerExtensionService, [
-        { id: meta.id, connect_domains: domains },
+        { id: meta.id, ...updates },
       ]);
     } else {
       await createSellerMetadataRecord(sellerExtension as SellerExtensionService, [
-        { seller_id: sellerId, connect_domains: domains },
+        { seller_id: sellerId, ...updates },
       ]);
     }
 

--- a/backend/src/modules/seller-extension/migrations/Migration20260629AddEmbedFeatures.ts
+++ b/backend/src/modules/seller-extension/migrations/Migration20260629AddEmbedFeatures.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * Migration: Add `embed_features` to seller_metadata
+ *
+ * Backs the vendor-controlled toggles on the "My Website" tab that decide which
+ * surfaces the FBM Connect embed renders on a vendor's external site
+ * (vendor / products / digital / services / events / reviews / booking / chat).
+ *
+ *  - embed_features : jsonb — array of enabled surface keys. NULL (the default)
+ *                             means "all surfaces enabled", so existing embeds
+ *                             are unchanged until a vendor saves a selection.
+ */
+export class Migration20260629AddEmbedFeatures extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+      ADD COLUMN IF NOT EXISTS "embed_features" jsonb DEFAULT NULL;
+    `);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "seller_metadata"
+      DROP COLUMN IF EXISTS "embed_features";
+    `);
+  }
+}

--- a/backend/src/modules/seller-extension/models/seller-metadata.ts
+++ b/backend/src/modules/seller-extension/models/seller-metadata.ts
@@ -140,6 +140,11 @@ const SellerMetadata = model.define("seller_metadata", {
   // Vendor-selected dashboard extensions (feature keys)
   enabled_extensions: model.json().nullable(),
 
+  // Vendor-selected embed surfaces for the FBM Connect embed. Array of enabled
+  // keys (see EMBED_FEATURE_KEYS in shared/website-config). Null ⇒ all surfaces
+  // enabled (default-on), so existing embeds are unaffected.
+  embed_features: model.json().nullable(),
+
   // Creator-specific fields (used when vendor_type === CREATOR)
   creator_handle: model.text().nullable(),
   creator_bio: model.text().nullable(),

--- a/backend/src/shared/__tests__/website-config.unit.spec.ts
+++ b/backend/src/shared/__tests__/website-config.unit.spec.ts
@@ -1,0 +1,65 @@
+import {
+  EMBED_FEATURE_KEYS,
+  resolveEmbedFeatures,
+  serializeWebsite,
+} from "../website-config"
+
+describe("resolveEmbedFeatures", () => {
+  it("defaults to all surfaces on when null/undefined", () => {
+    const fromNull = resolveEmbedFeatures(null)
+    const fromUndefined = resolveEmbedFeatures(undefined)
+    for (const key of EMBED_FEATURE_KEYS) {
+      expect(fromNull[key]).toBe(true)
+      expect(fromUndefined[key]).toBe(true)
+    }
+  })
+
+  it("enables only the listed keys when a selection is stored", () => {
+    const out = resolveEmbedFeatures(["products", "reviews"])
+    expect(out.products).toBe(true)
+    expect(out.reviews).toBe(true)
+    expect(out.events).toBe(false)
+    expect(out.chat).toBe(false)
+    expect(out.vendor).toBe(false)
+  })
+
+  it("treats an empty array as everything off", () => {
+    const out = resolveEmbedFeatures([])
+    for (const key of EMBED_FEATURE_KEYS) {
+      expect(out[key]).toBe(false)
+    }
+  })
+
+  it("ignores unknown keys in the stored array", () => {
+    const out = resolveEmbedFeatures(["products", "not_a_real_surface"] as string[])
+    expect(out.products).toBe(true)
+    expect(Object.keys(out).sort()).toEqual([...EMBED_FEATURE_KEYS].sort())
+  })
+})
+
+describe("serializeWebsite embed_features", () => {
+  it("exposes a resolved on/off map (default all on)", () => {
+    const out = serializeWebsite("acme", {
+      connect_domains: null,
+      site_status: null,
+      site_url: null,
+      site_repo: null,
+      embed_features: null,
+    })
+    expect(out.embed_features.products).toBe(true)
+    expect(out.embed_features.chat).toBe(true)
+  })
+
+  it("reflects a custom selection", () => {
+    const out = serializeWebsite("acme", {
+      connect_domains: null,
+      site_status: null,
+      site_url: null,
+      site_repo: null,
+      embed_features: ["vendor", "products"],
+    })
+    expect(out.embed_features.vendor).toBe(true)
+    expect(out.embed_features.products).toBe(true)
+    expect(out.embed_features.events).toBe(false)
+  })
+})

--- a/backend/src/shared/website-config.ts
+++ b/backend/src/shared/website-config.ts
@@ -10,7 +10,48 @@ export type WebsiteMeta = {
   site_status: string | null;
   site_url: string | null;
   site_repo: string | null;
+  embed_features: string[] | null;
 };
+
+/**
+ * Embed surfaces a vendor can toggle on/off for their FBM Connect embed. These
+ * are the `data-fbm="<key>"` blocks connect.js renders and the sections the
+ * public Store API returns. This is the single source of truth shared by the
+ * Store API (gating) and the vendor "My Website" route (read/write).
+ */
+export const EMBED_FEATURE_KEYS = [
+  "vendor",
+  "products",
+  "digital",
+  "services",
+  "events",
+  "reviews",
+  "booking",
+  "chat",
+] as const;
+
+export type EmbedFeatureKey = (typeof EMBED_FEATURE_KEYS)[number];
+
+export type EmbedFeatures = Record<EmbedFeatureKey, boolean>;
+
+/**
+ * Resolve a stored `embed_features` value into an explicit on/off map.
+ *
+ * `null`/non-array (the default) means "all surfaces enabled" — so existing
+ * vendors who never touched the toggles keep their full embed. When a vendor
+ * saves a custom selection it is stored as the array of enabled keys; any key
+ * not in the array is off. An empty array therefore means "everything off".
+ */
+export function resolveEmbedFeatures(
+  embed_features: string[] | null | undefined,
+): EmbedFeatures {
+  const all = !Array.isArray(embed_features);
+  const enabled = new Set(all ? [] : (embed_features as string[]));
+  return EMBED_FEATURE_KEYS.reduce((acc, key) => {
+    acc[key] = all || enabled.has(key);
+    return acc;
+  }, {} as EmbedFeatures);
+}
 
 /** Public base URL the embedded SDK calls (the storefront-facing API host). */
 export function apiBase(): string {
@@ -45,6 +86,9 @@ export function serializeWebsite(handle: string, meta: WebsiteMeta | null) {
     site_status: meta?.site_status ?? "none",
     site_url: meta?.site_url ?? null,
     site_repo: meta?.site_repo ?? null,
+    // Resolved on/off map for every embed surface, so the portal renders the
+    // toggles without re-deriving the "null means all on" default.
+    embed_features: resolveEmbedFeatures(meta?.embed_features),
     launch_available: isLaunchConfigured(),
     api_base: apiBase(),
     storefront_url: storefrontBase(),

--- a/storefront/public/connect.js
+++ b/storefront/public/connect.js
@@ -933,6 +933,44 @@
   }
 
   // ---------------------------------------------------------------------------
+  // Capability gating — the vendor toggles which surfaces their embed shows
+  // from the FBM portal. The Store API returns a `capabilities` map; a surface
+  // is hidden only when its flag is explicitly false, so an older API that
+  // omits capabilities still renders everything (opt-out, never opt-in).
+  // ---------------------------------------------------------------------------
+  var CAP_FOR_KIND = {
+    vendor: "vendor_enabled",
+    products: "products_enabled",
+    digital: "digital_enabled",
+    services: "services_enabled",
+    events: "events_enabled",
+    reviews: "reviews_enabled",
+    booking: "booking_enabled",
+    chat: "chat_enabled",
+  };
+
+  function getCapabilities(handle) {
+    return getData(handle || config.handle, { include: "vendor,products,events" })
+      .then(function (d) {
+        return (d && d.capabilities) || {};
+      })
+      .catch(function () {
+        return {}; // never block rendering on a failed capabilities probe
+      });
+  }
+
+  function renderKind(kind, node, opts) {
+    if (kind === "products") renderProducts(node, opts);
+    else if (kind === "digital") renderDigital(node, opts);
+    else if (kind === "services") renderServices(node, opts);
+    else if (kind === "events") renderEvents(node, opts);
+    else if (kind === "reviews") renderReviews(node, opts);
+    else if (kind === "vendor") renderVendor(node, opts);
+    else if (kind === "booking") renderBooking(node, opts);
+    else if (kind === "chat") renderChat(node, opts);
+  }
+
+  // ---------------------------------------------------------------------------
   // Zero-JS auto-mount: scan for [data-fbm] elements and render them
   // ---------------------------------------------------------------------------
   function autoMount(root) {
@@ -949,14 +987,15 @@
         product: node.getAttribute("data-fbm-product") || undefined,
         label: node.getAttribute("data-fbm-label") || undefined,
       };
-      if (kind === "products") renderProducts(node, opts);
-      else if (kind === "digital") renderDigital(node, opts);
-      else if (kind === "services") renderServices(node, opts);
-      else if (kind === "events") renderEvents(node, opts);
-      else if (kind === "reviews") renderReviews(node, opts);
-      else if (kind === "vendor") renderVendor(node, opts);
-      else if (kind === "booking") renderBooking(node, opts);
-      else if (kind === "chat") renderChat(node, opts);
+      var capKey = CAP_FOR_KIND[kind];
+      getCapabilities(opts.handle).then(function (caps) {
+        // Vendor turned this surface off — render nothing.
+        if (capKey && caps[capKey] === false) {
+          node.innerHTML = "";
+          return;
+        }
+        renderKind(kind, node, opts);
+      });
     });
     wireBuyButtons(root);
   }

--- a/vendor-panel/src/hooks/api/website.tsx
+++ b/vendor-panel/src/hooks/api/website.tsx
@@ -15,9 +15,24 @@ export const websiteQueryKeys = queryKeysFactory(WEBSITE_QUERY_KEY)
 
 export type SiteStatus = "none" | "provisioning" | "live" | "failed"
 
+/** Embed surfaces the vendor can toggle on/off for their FBM Connect embed. */
+export type EmbedFeatureKey =
+  | "vendor"
+  | "products"
+  | "digital"
+  | "services"
+  | "events"
+  | "reviews"
+  | "booking"
+  | "chat"
+
+export type EmbedFeatures = Record<EmbedFeatureKey, boolean>
+
 export type FbmWebsite = {
   handle: string
   connect_domains: string[]
+  /** Resolved on/off map for every embed surface (default = all on). */
+  embed_features: EmbedFeatures
   site_status: SiteStatus
   site_url: string | null
   site_repo: string | null
@@ -68,6 +83,28 @@ export const useUpdateWebsiteDomains = (
       fetchQuery("/vendor/website", {
         method: "POST",
         body: { connect_domains },
+      }),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: websiteQueryKeys.details() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+/**
+ * POST /vendor/website — save which embed surfaces show on the external site.
+ * Pass the array of enabled surface keys, or `null` to reset to "all on".
+ */
+export const useUpdateWebsiteFeatures = (
+  options?: UseMutationOptions<FbmWebsiteResponse, FetchError, EmbedFeatureKey[] | null>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (embed_features: EmbedFeatureKey[] | null) =>
+      fetchQuery("/vendor/website", {
+        method: "POST",
+        body: { embed_features },
       }),
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({ queryKey: websiteQueryKeys.details() })

--- a/vendor-panel/src/routes/my-website/components/connect-panel.tsx
+++ b/vendor-panel/src/routes/my-website/components/connect-panel.tsx
@@ -9,7 +9,12 @@ import {
   toast,
 } from "@medusajs/ui"
 import { useEffect, useMemo, useState } from "react"
-import { FbmWebsite, useUpdateWebsiteDomains } from "../../../hooks/api/website"
+import {
+  EmbedFeatureKey,
+  FbmWebsite,
+  useUpdateWebsiteDomains,
+  useUpdateWebsiteFeatures,
+} from "../../../hooks/api/website"
 import { CodeBlock, Step } from "./shared"
 import { KeysSection } from "./keys-section"
 import { EmbedPreview } from "./embed-preview"
@@ -64,7 +69,7 @@ const SDK_METHODS: Array<{ call: string; desc: string }> = [
 ]
 
 /** Component catalog for the picker / preview. */
-const COMPONENTS: Array<{ kind: string; label: string; needsKey?: boolean; attrs?: string }> = [
+const COMPONENTS: Array<{ kind: EmbedFeatureKey; label: string; needsKey?: boolean; attrs?: string }> = [
   { kind: "vendor", label: "Profile header" },
   { kind: "products", label: "Product grid", attrs: ' data-fbm-limit="6"' },
   { kind: "digital", label: "Digital products" },
@@ -86,12 +91,43 @@ export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
     setDomains(website.connect_domains || [])
   }, [website.connect_domains])
 
-  const [picked, setPicked] = useState<string[]>(["vendor", "products"])
+  const { mutate: saveFeatures, isPending: isSavingFeatures } =
+    useUpdateWebsiteFeatures()
 
-  const togglePicked = (kind: string) => {
+  // Enabled surfaces persisted on the seller — the authoritative list of what
+  // the embed shows, in catalog order. Default (all on) yields every kind.
+  const enabledKeys = useMemo(
+    () => COMPONENTS.filter((c) => website.embed_features?.[c.kind]).map((c) => c.kind),
+    [website.embed_features]
+  )
+
+  const [picked, setPicked] = useState<EmbedFeatureKey[]>(enabledKeys)
+
+  // Re-sync local toggles whenever the persisted selection changes (e.g. after
+  // a save or a refetch).
+  useEffect(() => {
+    setPicked(enabledKeys)
+  }, [enabledKeys])
+
+  const togglePicked = (kind: EmbedFeatureKey) => {
     setPicked((cur) =>
       cur.includes(kind) ? cur.filter((k) => k !== kind) : [...cur, kind]
     )
+  }
+
+  const featuresDirty =
+    JSON.stringify([...picked].sort()) !==
+    JSON.stringify([...enabledKeys].sort())
+
+  const persistFeatures = () => {
+    // Preserve catalog order so the stored list is stable/readable.
+    const ordered = COMPONENTS.filter((c) => picked.includes(c.kind)).map(
+      (c) => c.kind
+    )
+    saveFeatures(ordered, {
+      onSuccess: () => toast.success("Embed visibility saved"),
+      onError: () => toast.error("Could not save embed visibility"),
+    })
   }
 
   // Build the component markup from the picker, preserving catalog order.
@@ -166,8 +202,10 @@ export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
 
       <Step n={3} title="Pick what to show — then preview it live">
         <Text className="text-ui-fg-subtle mb-2" size="small">
-          Choose the components you want, paste the markup where they should
-          appear, and watch the live preview update.
+          These toggles control what your embed is allowed to show on your
+          external site. Turn a surface off and it won't render anywhere — even
+          if its markup is still on the page. Save to apply, then paste the
+          markup below where each component should appear.
         </Text>
         <div className="mb-3 flex flex-wrap gap-2">
           {COMPONENTS.map((c) => {
@@ -186,6 +224,18 @@ export const ConnectPanel = ({ website }: { website: FbmWebsite }) => {
             )
           })}
         </div>
+        {featuresDirty && (
+          <div className="mb-3">
+            <Button
+              size="small"
+              onClick={persistFeatures}
+              isLoading={isSavingFeatures}
+              type="button"
+            >
+              Save visibility
+            </Button>
+          </div>
+        )}
         <CodeBlock code={componentSnippet} />
         <div className="mt-3">
           <EmbedPreview website={website} components={picked} />


### PR DESCRIPTION
## Summary

Added vendor-controlled toggles that allow sellers to choose which surfaces (vendor profile, products, digital, services, events, reviews, booking, chat) their FBM Connect embed renders on external sites. The toggles are:

- Stored in `seller_metadata.embed_features` as an array of enabled surface keys
- Resolved to an explicit on/off map throughout the codebase
- Enforced at the Store API level (gating what data is returned)
- Enforced at the client level in connect.js (preventing render even if markup exists)
- Managed via a new "Save visibility" UI in the vendor panel's "My Website" tab

**Key changes:**
- Added `embed_features` field to `seller_metadata` model with database migration
- Created `resolveEmbedFeatures()` utility to convert stored array to on/off map (null/undefined defaults to all enabled for backward compatibility)
- Updated Store API `/store/vendors/:handle` to gate data and capabilities based on vendor toggles
- Updated vendor API `/vendor/website` to accept and persist `embed_features` alongside `connect_domains`
- Enhanced connect.js to check capabilities before rendering each surface
- Added vendor panel UI to toggle surfaces and persist selections
- Added comprehensive unit tests for `resolveEmbedFeatures()` and `serializeWebsite()`

## Related Issues

Closes #

## Validation

- [x] Tests updated/added where appropriate — Added unit tests for `resolveEmbedFeatures()` and `serializeWebsite()` embed_features behavior
- [x] Local checks executed
- [x] Migration documented — `Migration20260629AddEmbedFeatures` adds nullable `embed_features` jsonb column to `seller_metadata`
- [x] Backward compatible — null/undefined defaults to all surfaces enabled, so existing vendors are unaffected until they save a custom selection

## Release Notes

- [x] Release note required

Release note:
Vendors can now control which surfaces their FBM Connect embed displays on external sites. A new "Save visibility" toggle in the "My Website" tab lets sellers turn off vendor profile, products, digital items, services, events, reviews, booking, and chat surfaces independently. Disabled surfaces won't render anywhere—even if the markup is still on the page.

https://claude.ai/code/session_014ef5Mazt42Axs5u2xJrZei